### PR TITLE
Inferschema

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -116,6 +116,11 @@ object Main extends StrictLogging {
           case _ =>
             printUsage()
         }
+
+      case "infer-schema" => {
+        //todo write parser
+
+      }
       case _ => printUsage()
     }
   }

--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -22,6 +22,7 @@ package com.ebiznext.comet.job
 
 import com.ebiznext.comet.config.{DatasetArea, Settings}
 import com.ebiznext.comet.job.index.IndexConfig
+import com.ebiznext.comet.job.infer.InferSchema
 import com.ebiznext.comet.workflow.IngestionWorkflow
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
@@ -59,6 +60,7 @@ object Main extends StrictLogging {
         |comet import
         |comet ingest datasetDomain datasetSchema datasetPath
         |comet index --domain domain --schema schema --timestamp {@timestamp|yyyy.MM.dd} --id type-id --mapping mapping --format parquet|json|json-array --dataset datasetPath --conf key=value,key=value,...
+        |comet infer-schema datasetPath savePath
         |      """.stripMargin
     )
   }
@@ -118,7 +120,7 @@ object Main extends StrictLogging {
         }
 
       case "infer-schema" => {
-        //todo write parser
+        InferSchema(arglist(1),arglist(2))
 
       }
       case _ => printUsage()

--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -60,7 +60,7 @@ object Main extends StrictLogging {
         |comet import
         |comet ingest datasetDomain datasetSchema datasetPath
         |comet index --domain domain --schema schema --timestamp {@timestamp|yyyy.MM.dd} --id type-id --mapping mapping --format parquet|json|json-array --dataset datasetPath --conf key=value,key=value,...
-        |comet infer-schema --domain domainName --input datasetpath --output outputPath --with-header withHeaderBoolean
+        |comet infer-schema --domain domainName --schema schemaName --input datasetpath --output outputPath --with-header withHeaderBoolean
         |      """.stripMargin
     )
   }
@@ -79,7 +79,7 @@ object Main extends StrictLogging {
     *             When called with a '-' sign, will look for all domain folder in the landing area except the ones in the command lines.
     *   - call "comet ingest domain schema hdfs://datasets/domain/pending/file.dsv"
     *             to ingest a file defined by its schema in the specified domain
-    *   -call "comet infer-schema --domain domainName --input datasetpath --output outputPath --with-header boolean
+    *   -call "comet infer-schema --domain domainName --schema schemaName --input datasetpath --output outputPath --with-header boolean
     */
   def main(args: Array[String]): Unit = {
     import Settings.{schemaHandler, storageHandler}

--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -22,7 +22,7 @@ package com.ebiznext.comet.job
 
 import com.ebiznext.comet.config.{DatasetArea, Settings}
 import com.ebiznext.comet.job.index.IndexConfig
-import com.ebiznext.comet.job.infer.{InferSchema, InferSchemaConfig}
+import com.ebiznext.comet.job.infer.InferSchemaConfig
 import com.ebiznext.comet.workflow.IngestionWorkflow
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
@@ -60,7 +60,7 @@ object Main extends StrictLogging {
         |comet import
         |comet ingest datasetDomain datasetSchema datasetPath
         |comet index --domain domain --schema schema --timestamp {@timestamp|yyyy.MM.dd} --id type-id --mapping mapping --format parquet|json|json-array --dataset datasetPath --conf key=value,key=value,...
-        |comet infer-schema --domain domainName --schema schemaName --input datasetpath --output outputPath --with-header withHeaderBoolean
+        |comet infer-schema --domain domainName --schema schemaName --input datasetpath --output outputPath --with-header headerBoolean
         |      """.stripMargin
     )
   }

--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -60,7 +60,7 @@ object Main extends StrictLogging {
         |comet import
         |comet ingest datasetDomain datasetSchema datasetPath
         |comet index --domain domain --schema schema --timestamp {@timestamp|yyyy.MM.dd} --id type-id --mapping mapping --format parquet|json|json-array --dataset datasetPath --conf key=value,key=value,...
-        |comet infer-schema datasetPath savePath
+        |comet infer-schema datasetPath savePath header (Optional)
         |      """.stripMargin
     )
   }
@@ -120,7 +120,14 @@ object Main extends StrictLogging {
         }
 
       case "infer-schema" => {
-        InferSchema(arglist(1),arglist(2))
+        if (arglist.length < 3)
+          new InferSchema(arglist(1), arglist(2))
+        else
+          arglist(3).toLowerCase() match {
+            case "true" | "false" =>
+              new InferSchema(arglist(1), arglist(2), Option(arglist(3).toBoolean))
+            case _ => printUsage()
+          }
 
       }
       case _ => printUsage()

--- a/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaConfig.scala
@@ -29,7 +29,7 @@ case class InferConfig(
                         header: Option[Boolean] = Some(false)
                       )
 
-object InferSchemaConfig {
+object InferSchemaConfig{
 
   /**
     *

--- a/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaConfig.scala
@@ -1,3 +1,22 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ *
+ */
 package com.ebiznext.comet.job.infer
 import scopt.OParser
 
@@ -11,6 +30,11 @@ case class InferConfig(
 
 object InferSchemaConfig {
 
+  /**
+    *
+    * @param args args list passed from command line
+    * @return Option of case class InferConfig.
+    */
   def parse(args: Seq[String]): Option[InferConfig] = {
     val builder = OParser.builder[InferConfig]
 

--- a/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaConfig.scala
@@ -1,0 +1,42 @@
+package com.ebiznext.comet.job.infer
+import scopt.OParser
+
+case class InferConfig(
+  domainName: String = "",
+  inputPath: String = "",
+  outputPath: String = "",
+  header: Option[Boolean] = Some(false)
+)
+
+object InferSchemaConfig {
+
+  def parse(args: Seq[String]): Option[InferConfig] = {
+    val builder = OParser.builder[InferConfig]
+
+    val parser: OParser[Unit, InferConfig] = {
+      import builder._
+      OParser.sequence(
+        programName("comet"),
+        head("comet", "1.x"),
+        opt[String]("domain")
+          .action((x, c) => c.copy(domainName = x))
+          .required()
+          .text("Domain Name"),
+        opt[String]("input")
+          .action((x, c) => c.copy(inputPath = x))
+          .required()
+          .text("Input Path"),
+        opt[String]("output")
+          .action((x, c) => c.copy(outputPath = x))
+          .required()
+          .text("Output Path"),
+        opt[Option[Boolean]]("with-header")
+          .action((x, c) => c.copy(header = x))
+          .optional()
+          .text("Does the file contain a header")
+      )
+    }
+    OParser.parse(parser, args, InferConfig())
+
+  }
+}

--- a/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaConfig.scala
@@ -3,6 +3,7 @@ import scopt.OParser
 
 case class InferConfig(
   domainName: String = "",
+  schemaName: String = "",
   inputPath: String = "",
   outputPath: String = "",
   header: Option[Boolean] = Some(false)
@@ -20,6 +21,10 @@ object InferSchemaConfig {
         head("comet", "1.x"),
         opt[String]("domain")
           .action((x, c) => c.copy(domainName = x))
+          .required()
+          .text("Domain Name"),
+        opt[String]("schema")
+          .action((x, c) => c.copy(schemaName = x))
           .required()
           .text("Domain Name"),
         opt[String]("input")

--- a/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaConfig.scala
@@ -18,15 +18,16 @@
  *
  */
 package com.ebiznext.comet.job.infer
+
 import scopt.OParser
 
 case class InferConfig(
-  domainName: String = "",
-  schemaName: String = "",
-  inputPath: String = "",
-  outputPath: String = "",
-  header: Option[Boolean] = Some(false)
-)
+                        domainName: String = "",
+                        schemaName: String = "",
+                        inputPath: String = "",
+                        outputPath: String = "",
+                        header: Option[Boolean] = Some(false)
+                      )
 
 object InferSchemaConfig {
 

--- a/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
@@ -79,11 +79,17 @@ object InferSchemaJob extends SparkJob {
     val partitionWithIndex = rddDatasetInit.mapPartitionsWithIndex { (index, iterator) => {
       val iteratorList = iterator.toList
       //The first line is stored into the 0th partition
-      if (index == 0)
+      //Check if data is stored on the same partition (if true return directly the first and the last line)
+      if (index == 0 & lastPartitionNo == 0) {
+        Iterator(iteratorList.take(1).head, iteratorList.reverse.take(1).last)
+      }
+      else if (index == 0 & lastPartitionNo != 0) {
         iteratorList.take(1).iterator
+      }
       //The last line is stored into the last partition
-      else if (index == lastPartitionNo)
+      else if (index == lastPartitionNo) {
         iteratorList.reverse.take(1).iterator
+      }
       else
         Iterator()
     }

--- a/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
@@ -42,7 +42,7 @@ class InferSchema(
                    dataPath: String,
                    savePath: String,
                    header: Option[Boolean] = Some(false)
-                 ) {
+                 ){
 
   InferSchemaJob.infer(domainName, schemaName, dataPath, savePath, header.getOrElse(false))
 
@@ -51,7 +51,7 @@ class InferSchema(
 /** *
   * Infers the schema of a given datapath, domain name, schema name.
   */
-object InferSchemaJob extends SparkJob {
+object InferSchemaJob extends SparkJob{
 
   /**
     * Read file without specifying the format
@@ -82,15 +82,13 @@ object InferSchemaJob extends SparkJob {
       //Check if data is stored on the same partition (if true return directly the first and the last line)
       if (index == 0 & lastPartitionNo == 0) {
         Iterator(iteratorList.take(1).head, iteratorList.reverse.take(1).last)
-      }
-      else if (index == 0 & lastPartitionNo != 0) {
+      } else if (index == 0 & lastPartitionNo != 0) {
         iteratorList.take(1).iterator
       }
       //The last line is stored into the last partition
       else if (index == lastPartitionNo) {
         iteratorList.reverse.take(1).iterator
-      }
-      else
+      } else
         Iterator()
     }
     }

--- a/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
@@ -52,12 +52,6 @@ object InferSchemaJob extends SparkJob {
       .textFile(path.toString)
   }
 
-  /** Get Mode
-    *
-    * @return the Mode, for now we will assume file
-    */
-  def getMode: String = "FILE"
-
   /** Get format file
     *
     * @param datasetInit : created dataset without specifying format
@@ -160,8 +154,6 @@ object InferSchemaJob extends SparkJob {
 
     val dataframeWithFormat = createDataFrameWithFormat(datasetWithoutFormat, path, header)
 
-    val mode = Option(getMode)
-
     val format = Option(getFormatFile(datasetWithoutFormat))
 
     val array = if (format.getOrElse("") == "ARRAY_JSON") true else false
@@ -175,9 +167,7 @@ object InferSchemaJob extends SparkJob {
     val attributes: List[Attribute] = inferSchema.createAttributes(dataframeWithFormat.schema)
 
     val metadata = inferSchema.createMetaData(
-      mode,
       format,
-      None, //multiline is not supported
       Option(array),
       Option(withHeader),
       Option(separator)
@@ -194,7 +184,7 @@ object InferSchemaJob extends SparkJob {
       inferSchema.createDomain(
         domainName,
         getDomainDirectoryName(path),
-        schemas = List(schema) // todo add support to iterate over all the files in a directory
+        schemas = List(schema)
       )
 
     inferSchema.generateYaml(domain, savePath)

--- a/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
@@ -2,13 +2,54 @@ package com.ebiznext.comet.job.infer
 
 import java.util.regex.Pattern
 
+import com.ebiznext.comet.job.infer.InferSchemaJob._
 import com.ebiznext.comet.schema.handlers.InferSchemaHandler
 import com.ebiznext.comet.schema.model.Attribute
 import com.ebiznext.comet.utils.SparkJob
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
-object InferSchemaJob extends SparkJob{
+
+case class InferSchema(dataPath : String,
+                       savePath: String) {
+
+  val path = new Path(dataPath)
+
+  val datasetWithoutFormat = readFile(path)
+
+  val dataframeWithFormat = createDataFrameWithFormat(datasetWithoutFormat, path)
+
+  val mode = getMode
+
+  val format = getFormatFile(datasetWithoutFormat,getExtensionFile(path))
+
+  val multiline = getMultiline
+
+  val array = if(format == "ARRAY_JSON") true else false
+
+  val withHeader = getWithHeader
+
+  val separator = getSeparator(datasetWithoutFormat)
+
+  val quote = getQuote
+
+  val escape = getEscape
+
+  val writeMode = getWriteMode
+
+  val inferSchema = new InferSchemaHandler(dataframeWithFormat)
+
+  val attributes: List[Attribute] = inferSchema.createAttributes(dataframeWithFormat.schema)
+  val metadata = inferSchema.createMetaData(mode,format,multiline,array,withHeader,separator,quote,escape,writeMode,None,false,None)
+
+  val schema = inferSchema.createSchema(getSchemaName(path),Pattern.compile(getSchemaPattern(path)),attributes,metadata)
+
+  val domain = inferSchema.createDomain(getDomainName(path),getDomainDirectoryName(path),None, List(schema))
+
+  inferSchema.generateYaml(domain, savePath)
+}
+
+object InferSchemaJob extends SparkJob {
 
   /** Read file without specifying the format
     *
@@ -20,8 +61,6 @@ object InferSchemaJob extends SparkJob{
       .textFile(path.toString)
   }
 
-
-  //TODO manage mode
   /** Get domain name
     *
     * @return the domain name
@@ -51,7 +90,7 @@ object InferSchemaJob extends SparkJob{
   def getFormatFile(datasetInit: Dataset[String], extension : String): String = {
     val firstLine = datasetInit.first()
 
-    firstLine.charAt(1).toString match {
+    firstLine.charAt(0).toString match {
       case "{"  => "JSON"
       case "[" => "ARRAY_JSON"
       case _  => if (extension.matches(".*sv$")) "DSV"
@@ -81,7 +120,7 @@ object InferSchemaJob extends SparkJob{
     * @return the domain name
     */
   def getDomainName(path: Path) : String = {
-    path.getName
+    path.getParent.getName
   }
 
   /** Get domain directory name
@@ -107,10 +146,10 @@ object InferSchemaJob extends SparkJob{
       fileName
   }
 
-  /** Get domain pattern
+  /** Get schema pattern
     *
     * @param path : file path
-    * @return the domain pattern
+    * @return the schema pattern
     */
   def getSchemaPattern(path: Path) : String = {
     path.getName
@@ -120,24 +159,30 @@ object InferSchemaJob extends SparkJob{
     *
     * @return the header option
     */
-  def getWithHeader : Boolean = {
-    false
-  }
+  def getWithHeader : Boolean = false
 
-  def getMultiline : Boolean = {
-    false
-  }
 
-  def getQuote: String = {
-    "\""
-  }
+  /** Get multiline option
+    *
+    * @return the multiline option
+    */
+  def getMultiline : Boolean = false
 
-  def getEscape: String = {
-    "\\"
-  }
+  /** Get quote option
+    *
+    * @return the quote option
+    */
+  def getQuote: String = "\""
+
+  /** Get escape option
+    *
+    * @return the escape option
+    */
+  def getEscape: String = "\\"
+
 
   def getWriteMode : String = {
-    "OVERWRITE"
+    "APPEND"
   }
 
   /**
@@ -176,37 +221,6 @@ object InferSchemaJob extends SparkJob{
     */
   override def run(): SparkSession = session
 
-  val path = new Path("/tmp/ty/toy.json")
-  val rf = readFile(path)
-  val cdf = createDataFrameWithFormat(rf, path)
 
-  val mode = getMode
-
-  val format = getFormatFile(rf,getExtensionFile(path))
-
-  val multiline = getMultiline
-
-  val array = if(format == "ARRAY_JSON") true else false
-
-  val withHeader = getWithHeader
-
-  val separator = getSeparator(rf)
-
-  val quote = getQuote
-
-  val escape = getEscape
-
-  val writeMode = getWriteMode
-
-  val inferSchema = new InferSchemaHandler(cdf)
-
-  val attributes: List[Attribute] = inferSchema.createAttributes(cdf.schema)
-  val metadata = inferSchema.createMetaData(mode,format,multiline,array,withHeader,separator,quote,escape,writeMode,None,false,None)
-
-  val schema = inferSchema.createSchema(getSchemaName(path),Pattern.compile(getSchemaPattern(path)),attributes,metadata)
-
-  val domain = inferSchema.createDomain(getDomainName(path),getDomainDirectoryName(path),None, List(schema))
-
-  inferSchema.generateYaml(domain, "/tmp/res.yml")
 
 }

--- a/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
@@ -29,12 +29,12 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
 class InferSchema(
-  domainName: String,
-  schemaName: String,
-  dataPath: String,
-  savePath: String,
-  header: Option[Boolean] = Some(false)
-) {
+                   domainName: String,
+                   schemaName: String,
+                   dataPath: String,
+                   savePath: String,
+                   header: Option[Boolean] = Some(false)
+                 ) {
 
   InferSchemaJob.infer(domainName, schemaName, dataPath, savePath, header.getOrElse(false))
 
@@ -70,7 +70,7 @@ object InferSchemaJob extends SparkJob {
     if (firstLine.startsWith("{") & firstLine.endsWith("}")) "JSON"
     else if (firstLine.startsWith("[") & lastLine.endsWith("]")) "ARRAY_JSON"
     else "DSV"
-    
+
   }
 
   /** Get separator file
@@ -112,14 +112,14 @@ object InferSchemaJob extends SparkJob {
   /**
     *
     * @param datasetInit : created dataset without specifying format
-    * @param path : file path
+    * @param path        : file path
     * @return
     */
   def createDataFrameWithFormat(
-    datasetInit: Dataset[String],
-    path: Path,
-    header: Boolean
-  ): DataFrame = {
+                                 datasetInit: Dataset[String],
+                                 path: Path,
+                                 header: Boolean
+                               ): DataFrame = {
     val formatFile = getFormatFile(datasetInit)
 
     formatFile match {
@@ -148,12 +148,12 @@ object InferSchemaJob extends SparkJob {
     * @return : Spark Session used for the job
     */
   def infer(
-    domainName: String,
-    schemaName: String,
-    dataPath: String,
-    savePath: String,
-    header: Boolean
-  ): Unit = {
+             domainName: String,
+             schemaName: String,
+             dataPath: String,
+             savePath: String,
+             header: Boolean
+           ): Unit = {
     val path = new Path(dataPath)
 
     val datasetWithoutFormat = readFile(path)

--- a/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
@@ -28,18 +28,29 @@ import com.ebiznext.comet.utils.SparkJob
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
+/***
+  *
+  * @param domainName : name of the domain
+  * @param schemaName : name of the schema
+  * @param dataPath   : path to the dataset to infer schema from. format is file:///path/to/read
+  * @param savePath   : path to save the yaml file. format is /path/to/save
+  * @param header     : option of boolean to check if header should be included.
+  */
 class InferSchema(
-                   domainName: String,
-                   schemaName: String,
-                   dataPath: String,
-                   savePath: String,
-                   header: Option[Boolean] = Some(false)
-                 ) {
+  domainName: String,
+  schemaName: String,
+  dataPath: String,
+  savePath: String,
+  header: Option[Boolean] = Some(false)
+) {
 
   InferSchemaJob.infer(domainName, schemaName, dataPath, savePath, header.getOrElse(false))
 
 }
 
+/***
+  * Infers the schema of a given datapath, domain name, schema name.
+  */
 object InferSchemaJob extends SparkJob {
 
   /** Read file without specifying the format
@@ -84,7 +95,6 @@ object InferSchemaJob extends SparkJob {
       .toString
   }
 
-
   /** Get domain directory name
     *
     * @param path : file path
@@ -110,10 +120,10 @@ object InferSchemaJob extends SparkJob {
     * @return
     */
   def createDataFrameWithFormat(
-                                 datasetInit: Dataset[String],
-                                 path: Path,
-                                 header: Boolean
-                               ): DataFrame = {
+    datasetInit: Dataset[String],
+    path: Path,
+    header: Boolean
+  ): DataFrame = {
     val formatFile = getFormatFile(datasetInit)
 
     formatFile match {
@@ -142,12 +152,12 @@ object InferSchemaJob extends SparkJob {
     * @return : Spark Session used for the job
     */
   def infer(
-             domainName: String,
-             schemaName: String,
-             dataPath: String,
-             savePath: String,
-             header: Boolean
-           ): Unit = {
+    domainName: String,
+    schemaName: String,
+    dataPath: String,
+    savePath: String,
+    header: Boolean
+  ): Unit = {
     val path = new Path(dataPath)
 
     val datasetWithoutFormat = readFile(path)

--- a/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
@@ -1,0 +1,156 @@
+package com.ebiznext.comet.job.infer
+
+import com.ebiznext.comet.schema.handlers.InferSchemaHandler
+import com.ebiznext.comet.utils.SparkJob
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
+
+object InferSchemaJob extends SparkJob{
+
+  /** Read file without specifying the format
+    *
+    * @param path : file path
+    * @return a dataset of string that contains data file
+    */
+  def readFile(path: Path) = {
+    session.read
+      .textFile(path.toString)
+  }
+
+  /** Get domain name
+    *
+    * @return the domain name
+    */
+  def getMode: String = "FILE"
+
+  /** Get extension file
+    *
+    * @param path : file path
+    * @return the file extension
+    */
+  def getExtensionFile(path: Path) ={
+    val fileName = path.getName
+
+    if(fileName.contains("."))
+      fileName.split("\\.").last
+    else
+      ""
+  }
+
+  /** Get format file
+    *
+    * @param datasetInit : created dataset without specifying format
+    * @param extension : extension file
+    * @return
+    */
+  def getFormatFile(datasetInit: Dataset[String], extension : String): String = {
+    val firstLine = datasetInit.first()
+
+    firstLine.charAt(1).toString match {
+      case "{"  => "JSON"
+      case "[" => "ARRAY_JSON"
+      case _  => if (extension.matches(".*sv$")) "DSV"
+            else throw new Exception("The format of this file is not supported")
+    }
+  }
+
+  /** Get separator file
+    *
+    * @param datasetInit : created dataset without specifying format
+    * @return the file separator
+    */
+  def getSeparator(datasetInit: Dataset[String]) = {
+    session.sparkContext
+      .parallelize(datasetInit.take(10))
+      .map(x => x.replaceAll("[A-Za-z0-9 \"'()?!éèîàÀÉÈç+]", ""))
+      .flatMap(_.toCharArray)
+      .map(w => (w, 1))
+      .reduceByKey(_ + _)
+      .first()._1
+      .toString
+  }
+
+  /** Get domain name
+    *
+    * @param path : file path
+    * @return the domain name
+    */
+  def getDomainName(path: Path) : String = {
+    path.getParent.getName
+  }
+
+  /** Get domain pattern
+    *
+    * @param path : file path
+    * @return the domain pattern
+    */
+  def getDomainPattern(path: Path) : String = {
+    path.getName
+  }
+
+  /** Get domain directory name
+    *
+    * @param path : file path
+    * @return the domain directory name
+    */
+  def getDomainDirectoryName(path: Path): String = {
+    path.toString.replace(path.getName, "")
+  }
+
+  /** Get header option
+    *
+    * @return the header option
+    */
+  def getWithHeader : Boolean = {
+    false
+  }
+
+  def getQuote: String = {
+    "\""
+  }
+
+  def getEscape: String = {
+    "\\"
+  }
+
+  /**
+    *
+    * @param datasetInit : created dataset without specifying format
+    * @param path : file path
+    * @return
+    */
+  def createDataFrameWithFormat(datasetInit: Dataset[String],path: Path): DataFrame = {
+    val formatFile = getFormatFile(datasetInit, getExtensionFile(path))
+
+    formatFile match {
+      case "JSON" | "ARRAY_JSON" => session.read
+        .format("json")
+        .option("inferSchema", false)
+        .load(path.toString)
+
+      case "DSV" => session.read
+        .format("com.databricks.spark.csv")
+        .option("header", getWithHeader)
+        .option("inferSchema", false)
+        .option("delimiter", getSeparator(datasetInit))
+        .option("quote", getQuote)
+        .option("escape", getEscape)
+        .option("parserLib", "UNIVOCITY")
+        .load(path.toString)
+    }
+  }
+
+  override def name: String = "InferSchema"
+
+  /**
+    * Just to force any spark job to implement its entry point using within the "run" method
+    *
+    * @return : Spark Session used for the job
+    */
+  override def run(): SparkSession = session
+
+  val rf = readFile(new Path("/tmp/ty/toy.json"))
+  val cdf = createDataFrameWithFormat(rf, new Path("/tmp/ty/toy.json" ))
+
+  new InferSchemaHandler(cdf)
+}

--- a/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
@@ -205,9 +205,9 @@ object InferSchemaJob extends SparkJob {
 
     val dataframeWithFormat = createDataFrameWithFormat(datasetWithoutFormat, path, header)
 
-    val mode = getMode
+    val mode = Option(getMode)
 
-    val format = getFormatFile(datasetWithoutFormat, getExtensionFile(path))
+    val format = Option(getFormatFile(datasetWithoutFormat, getExtensionFile(path)))
 
     val array = if (format == "ARRAY_JSON") true else false
 
@@ -228,21 +228,22 @@ object InferSchemaJob extends SparkJob {
     val metadata = inferSchema.createMetaData(
       mode,
       format,
-      multiline = false, //multiline is not supported
-      array,
-      withHeader,
-      separator,
-      quote,
-      escape,
-      writeMode,
-      index = false
+      None, //multiline is not supported
+      Option(array),
+      Option(withHeader),
+      Option(separator),
+      Option(quote),
+      Option(escape),
+      Option(writeMode),
+      None,
+      None
     )
 
     val schema = inferSchema.createSchema(
       getSchemaName(path),
       Pattern.compile(getSchemaPattern(path)),
       attributes,
-      metadata
+      Some(metadata)
     )
 
     val domain =

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsConfig.scala
@@ -7,7 +7,7 @@ import scopt.OParser
 case class MetricsConfig(
                           domain: String = "",
                           schema: String = ""
-                        ) {
+                        ){
 
   /** Function to build path of data to compute metrics on
     * using the attribute domain and schema and ingested files path.
@@ -20,7 +20,7 @@ case class MetricsConfig(
 
 }
 
-object MetricsConfig {
+object MetricsConfig{
 
   /** Function to parse command line arguments (domain and schema).
     *

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
@@ -79,7 +79,7 @@ class MetricsJob(
                   schema: Schema,
                   stage: String,
                   storageHandler: StorageHandler
-                ) extends SparkJob {
+                ) extends SparkJob{
 
   /** Function that retrieves class names for each variable (case discrete variable)
     *

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -21,8 +21,11 @@
 package com.ebiznext.comet.schema.handlers
 import java.io.File
 import java.util.regex.Pattern
+
 import com.ebiznext.comet.job.Main
 import com.ebiznext.comet.schema.model._
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FSDataOutputStream, FileSystem, Path}
 import org.apache.spark.sql.types.{ArrayType, StructType}
 
 object InferSchemaHandler {
@@ -148,7 +151,8 @@ object InferSchemaHandler {
     * @param savePath path to save files.
     */
   def generateYaml(domain: Domain, savePath: String): Unit = {
-    Main.mapper.writeValue(new File(savePath), domain)
+    val os = HdfsStorageHandler.getOutputStream(new Path(savePath))
+    Main.mapper.writeValue(os, domain)
   }
 
 }

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -23,10 +23,9 @@ import java.io.File
 import java.util.regex.Pattern
 import com.ebiznext.comet.job.Main
 import com.ebiznext.comet.schema.model._
-import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.{ArrayType, StructType}
 
-class InferSchemaHandler(dataframe: DataFrame) {
+object InferSchemaHandler {
 
   /***
     *   Traverses the schema and returns a list of attributes.

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -1,7 +1,6 @@
 package com.ebiznext.comet.schema.handlers
 import java.io.File
 import java.util.regex.Pattern
-
 import com.ebiznext.comet.schema.model._
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
@@ -9,37 +8,88 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.{ArrayType, StructType}
 
-class InferSchemaHandler(dataframe:DataFrame, header:Boolean) {
+class InferSchemaHandler(dataframe: DataFrame) {
 
-  private def createAttributes(schema: StructType):List[Attribute] ={
-    schema.map(row => row.dataType.typeName match {
-      case "struct" => Attribute(row.name, row.dataType.typeName, Some(false), !row.nullable, attributes= Some(createAttributes(row.dataType.asInstanceOf[StructType])))
-      case "array" =>
-        val elemType = row.dataType.asInstanceOf[ArrayType].elementType
-        if(elemType.typeName.equals("struct"))
-        // if the array contains elements of type struct.
-        // {people: [{name:Person1, age:22},{name:Person2, age:25}]}
-          Attribute(row.name, elemType.typeName, Some(true),!row.nullable,attributes= Some(createAttributes(elemType.asInstanceOf[StructType])))
-        else
-        // if it is a regular array. {ages: [21, 25]}
-          Attribute(row.name, elemType.typeName, Some(true),!row.nullable)
-      case _ => Attribute(row.name, row.dataType.typeName,Some(false) ,!row.nullable)
-    }).toList
+  private def createAttributes(schema: StructType): List[Attribute] = {
+    schema
+      .map(
+        row =>
+          row.dataType.typeName match {
+            case "struct" =>
+              Attribute(
+                row.name,
+                row.dataType.typeName,
+                Some(false),
+                !row.nullable,
+                attributes = Some(createAttributes(row.dataType.asInstanceOf[StructType]))
+              )
+            case "array" =>
+              val elemType = row.dataType.asInstanceOf[ArrayType].elementType
+              if (elemType.typeName.equals("struct"))
+                // if the array contains elements of type struct.
+                // {people: [{name:Person1, age:22},{name:Person2, age:25}]}
+                Attribute(
+                  row.name,
+                  elemType.typeName,
+                  Some(true),
+                  !row.nullable,
+                  attributes = Some(createAttributes(elemType.asInstanceOf[StructType]))
+                )
+              else
+                // if it is a regular array. {ages: [21, 25]}
+                Attribute(row.name, elemType.typeName, Some(true), !row.nullable)
+            case _ => Attribute(row.name, row.dataType.typeName, Some(false), !row.nullable)
+        }
+      )
+      .toList
   }
 
-
-  private def createMetaData():Metadata ={
-      Metadata(Some(Mode.FILE),Some(Format.JSON), Some(true),Some(false), Some(header) )
-    }
-
-
-  private def createSchema(p: Pattern ):Schema ={
-    Schema("Test",p, createAttributes(dataframe.schema), Some(createMetaData), None, None, None, None)
-
+  def createMetaData(
+    mode: String,
+    format: String,
+    multiline: Boolean,
+    array: Boolean,
+    withHeader: Boolean,
+    separator: String,
+    quote: String,
+    escape: String,
+    write: String,
+    partition: Option[Partition] = None,
+    index: Boolean,
+    mapping: Option[EsMapping] = None
+  ): Metadata = {
+    Metadata(
+      Some(Mode.fromString(mode)),
+      Some(Format.fromString(format)),
+      Some(multiline),
+      Some(array),
+      Some(withHeader),
+      Some(separator),
+      Some(quote),
+      Some(escape),
+      Some(WriteMode.fromString(write)),
+      partition,
+      Some(index),
+      mapping
+    )
   }
 
-  def generateYaml(savePath: String): Unit ={
-    val data: Schema = createSchema(Pattern) // todo this wont work for now.
+  private def createSchema(
+    name: String,
+    pattern: Pattern,
+    attributes: List[Attribute],
+    metadata: Metadata,
+    merge: Option[MergeOptions],
+    comment: Option[String],
+    presql: Option[List[String]],
+    postsql: Option[List[String]]
+  ): Schema = {
+
+    Schema(name, pattern, attributes, Some(metadata), merge, comment, None, None)
+  }
+
+  def generateYaml(schema: Schema, savePath:String): Unit = {
+    val data: Schema = schema
     val mapper: ObjectMapper = new ObjectMapper(new YAMLFactory)
       .registerModule(DefaultScalaModule)
 

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -75,7 +75,6 @@ object InferSchemaHandler {
   /***
     *   builds the Metadata case class. check case class metadata for attribute definition
     *
-    * @param mode
     * @param format
     * @param multiline
     * @param array
@@ -85,17 +84,15 @@ object InferSchemaHandler {
     */
 
   def createMetaData(
-    mode: Option[String] = None,
     format: Option[String] = None,
-    multiline: Option[Boolean] = None,
     array: Option[Boolean],
     withHeader: Option[Boolean],
     separator: Option[String]
   ): Metadata = {
     Metadata(
-      Some(Mode.fromString(mode.getOrElse("FILE"))),
+      Some(Mode.fromString("FILE")),
       Some(Format.fromString(format.getOrElse("DSV"))),
-      multiline,
+      multiline = None,
       array,
       withHeader,
       separator
@@ -112,7 +109,6 @@ object InferSchemaHandler {
     * @return
     */
 
-  // todo check with hayssam why schema case class doesnt have default params
   def createSchema(
     name: String,
     pattern: Pattern,

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -10,11 +10,12 @@ import org.apache.spark.sql.types.{ArrayType, StructType}
 
 class InferSchemaHandler(dataframe: DataFrame) {
 
-  private def createAttributes(schema: StructType): List[Attribute] = {
+   def createAttributes(schema: StructType): List[Attribute] = {
     schema
       .map(
         row =>
           row.dataType.typeName match {
+
             case "struct" =>
               Attribute(
                 row.name,
@@ -23,6 +24,7 @@ class InferSchemaHandler(dataframe: DataFrame) {
                 !row.nullable,
                 attributes = Some(createAttributes(row.dataType.asInstanceOf[StructType]))
               )
+
             case "array" =>
               val elemType = row.dataType.asInstanceOf[ArrayType].elementType
               if (elemType.typeName.equals("struct"))
@@ -38,6 +40,7 @@ class InferSchemaHandler(dataframe: DataFrame) {
               else
                 // if it is a regular array. {ages: [21, 25]}
                 Attribute(row.name, elemType.typeName, Some(true), !row.nullable)
+
             case _ => Attribute(row.name, row.dataType.typeName, Some(false), !row.nullable)
         }
       )
@@ -74,7 +77,7 @@ class InferSchemaHandler(dataframe: DataFrame) {
     )
   }
 
-  private def createSchema(
+   def createSchema(
     name: String,
     pattern: Pattern,
     attributes: List[Attribute],
@@ -85,11 +88,24 @@ class InferSchemaHandler(dataframe: DataFrame) {
     postsql: Option[List[String]]
   ): Schema = {
 
-    Schema(name, pattern, attributes, Some(metadata), merge, comment, None, None)
+    Schema(name, pattern, attributes, Some(metadata), merge, comment, presql, postsql)
   }
 
-  def generateYaml(schema: Schema, savePath:String): Unit = {
-    val data: Schema = schema
+  def createDomain(name: String,
+                   directory: String,
+                   metadata: Option[Metadata] = None,
+                   schemas: List[Schema] = Nil,
+                   comment: Option[String] = None,
+                   extensions: Option[List[String]] = None,
+                   ack: Option[String] = None): Domain = {
+
+    Domain(name: String, directory: String, metadata: Option[Metadata], schemas: List[Schema], comment: Option[String], extensions: Option[List[String]], ack: Option[String])
+  }
+
+
+
+  def generateYaml(domain: Domain, savePath:String): Unit = {
+    val data: Domain = domain
     val mapper: ObjectMapper = new ObjectMapper(new YAMLFactory)
       .registerModule(DefaultScalaModule)
 

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -19,19 +19,17 @@
  */
 
 package com.ebiznext.comet.schema.handlers
-import java.io.File
-import java.util.regex.Pattern
 
+import java.util.regex.Pattern
 import com.ebiznext.comet.job.Main
 import com.ebiznext.comet.schema.model._
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FSDataOutputStream, FileSystem, Path}
+import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.types.{ArrayType, StructType}
 
 object InferSchemaHandler {
 
-  /***
-    *   Traverses the schema and returns a list of attributes.
+  /** *
+    * Traverses the schema and returns a list of attributes.
     *
     * @param schema Schema so that we find all Attributes
     * @return List of Attributes
@@ -55,8 +53,8 @@ object InferSchemaHandler {
             case "array" =>
               val elemType = row.dataType.asInstanceOf[ArrayType].elementType
               if (elemType.typeName.equals("struct"))
-                // if the array contains elements of type struct.
-                // {people: [{name:Person1, age:22},{name:Person2, age:25}]}
+              // if the array contains elements of type struct.
+              // {people: [{name:Person1, age:22},{name:Person2, age:25}]}
                 Attribute(
                   row.name,
                   elemType.typeName,
@@ -65,18 +63,18 @@ object InferSchemaHandler {
                   attributes = Some(createAttributes(elemType.asInstanceOf[StructType]))
                 )
               else
-                // if it is a regular array. {ages: [21, 25]}
+              // if it is a regular array. {ages: [21, 25]}
                 Attribute(row.name, elemType.typeName, Some(true), !row.nullable)
 
             // if the datatype is a simple Attribute
             case _ => Attribute(row.name, row.dataType.typeName, Some(false), !row.nullable)
-        }
+          }
       )
       .toList
   }
 
-  /***
-    *   builds the Metadata case class. check case class metadata for attribute definition
+  /** *
+    * builds the Metadata case class. check case class metadata for attribute definition
     *
     * @param mode       : FILE mode by default
     * @param format     : DSV by default
@@ -88,11 +86,11 @@ object InferSchemaHandler {
     */
 
   def createMetaData(
-    format: Option[String] = None,
-    array: Option[Boolean],
-    withHeader: Option[Boolean],
-    separator: Option[String]
-  ): Metadata = {
+                      format: Option[String] = None,
+                      array: Option[Boolean],
+                      withHeader: Option[Boolean],
+                      separator: Option[String]
+                    ): Metadata = {
     Metadata(
       mode = Some(Mode.fromString("FILE")),
       Some(Format.fromString(format.getOrElse("DSV"))),
@@ -103,8 +101,8 @@ object InferSchemaHandler {
     )
   }
 
-  /***
-    *   builds the Schema case class
+  /** *
+    * builds the Schema case class
     *
     * @param name       : Schema name, must be unique in the domain. Will become the hive table name
     * @param pattern    : filename pattern to which this schema must be applied
@@ -114,40 +112,40 @@ object InferSchemaHandler {
     */
 
   def createSchema(
-    name: String,
-    pattern: Pattern,
-    attributes: List[Attribute],
-    metadata: Option[Metadata]
-  ): Schema = {
+                    name: String,
+                    pattern: Pattern,
+                    attributes: List[Attribute],
+                    metadata: Option[Metadata]
+                  ): Schema = {
 
     Schema(name, pattern, attributes, metadata, None, None, None, None)
   }
 
-  /***
+  /** *
     * Builds the Domain case class
     *
-    * @param name       : Domain name
-    * @param directory  : Folder on the local filesystem where incomping files are stored.
-    *                   This folder will be scanned regurlaly to move the dataset to the cluster
-    * @param metadata   : Default Schema meta data.
-    * @param schemas    : List of schema for each dataset in this domain
+    * @param name      : Domain name
+    * @param directory : Folder on the local filesystem where incomping files are stored.
+    *                  This folder will be scanned regurlaly to move the dataset to the cluster
+    * @param metadata  : Default Schema meta data.
+    * @param schemas   : List of schema for each dataset in this domain
     * @return
     */
 
   def createDomain(
-    name: String,
-    directory: String,
-    metadata: Option[Metadata] = None,
-    schemas: List[Schema] = Nil
-  ): Domain = {
+                    name: String,
+                    directory: String,
+                    metadata: Option[Metadata] = None,
+                    schemas: List[Schema] = Nil
+                  ): Domain = {
 
     Domain(name, directory, metadata, schemas)
   }
 
-  /***
+  /** *
     * Generates the YAML file using the domain object and a savepath
     *
-    * @param domain Domain case class
+    * @param domain   Domain case class
     * @param savePath path to save files.
     */
   def generateYaml(domain: Domain, savePath: String): Unit = {

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -29,6 +29,7 @@ object InferSchemaHandler {
 
   /***
     *   Traverses the schema and returns a list of attributes.
+    *
     * @param schema Schema so that we find all Attributes
     * @return List of Attributes
     */
@@ -73,34 +74,23 @@ object InferSchemaHandler {
 
   /***
     *   builds the Metadata case class. check case class metadata for attribute definition
+    *
     * @param mode
     * @param format
     * @param multiline
     * @param array
     * @param withHeader
     * @param separator
-    * @param quote
-    * @param escape
-    * @param write
-    * @param partition
-    * @param index
-    * @param mapping
     * @return
     */
-  // todo can we replace mode, format and writemode by values instead of options of strings
+
   def createMetaData(
     mode: Option[String] = None,
     format: Option[String] = None,
     multiline: Option[Boolean] = None,
     array: Option[Boolean],
     withHeader: Option[Boolean],
-    separator: Option[String],
-    quote: Option[String],
-    escape: Option[String],
-    write: Option[String] = None,
-    partition: Option[Partition] = None,
-    index: Option[Boolean] = None,
-    mapping: Option[EsMapping] = None
+    separator: Option[String]
   ): Metadata = {
     Metadata(
       Some(Mode.fromString(mode.getOrElse("FILE"))),
@@ -108,52 +98,38 @@ object InferSchemaHandler {
       multiline,
       array,
       withHeader,
-      separator,
-      quote,
-      escape,
-      Some(WriteMode.fromString(write.getOrElse("APPEND"))),
-      partition,
-      index,
-      mapping
+      separator
     )
   }
 
   /***
     *   builds the Schema case class
+    *
     * @param name
     * @param pattern
     * @param attributes
     * @param metadata
-    * @param merge
-    * @param comment
-    * @param presql
-    * @param postsql
     * @return
     */
 
+  // todo check with hayssam why schema case class doesnt have default params
   def createSchema(
     name: String,
     pattern: Pattern,
     attributes: List[Attribute],
-    metadata: Option[Metadata],
-    merge: Option[MergeOptions] = None,
-    comment: Option[String] = None,
-    presql: Option[List[String]] = None,
-    postsql: Option[List[String]] = None
+    metadata: Option[Metadata]
   ): Schema = {
 
-    Schema(name, pattern, attributes, metadata, merge, comment, presql, postsql)
+    Schema(name, pattern, attributes, metadata, None, None, None, None)
   }
 
   /***
     * Builds the Domain case class
+    *
     * @param name
     * @param directory
     * @param metadata
     * @param schemas
-    * @param comment
-    * @param extensions
-    * @param ack
     * @return
     */
 
@@ -161,17 +137,15 @@ object InferSchemaHandler {
     name: String,
     directory: String,
     metadata: Option[Metadata] = None,
-    schemas: List[Schema] = Nil,
-    comment: Option[String] = None,
-    extensions: Option[List[String]] = None,
-    ack: Option[String] = None
+    schemas: List[Schema] = Nil
   ): Domain = {
 
-    Domain(name, directory, metadata, schemas, comment, extensions, ack)
+    Domain(name, directory, metadata, schemas)
   }
 
   /***
     * Generates the YAML file using the domain object and a savepath
+    *
     * @param domain Domain case class
     * @param savePath path to save files.
     */

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -1,0 +1,49 @@
+package com.ebiznext.comet.schema.handlers
+import java.io.File
+import java.util.regex.Pattern
+
+import com.ebiznext.comet.schema.model._
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types.{ArrayType, StructType}
+
+class InferSchemaHandler(dataframe:DataFrame, header:Boolean) {
+
+  private def createAttributes(schema: StructType):List[Attribute] ={
+    schema.map(row => row.dataType.typeName match {
+      case "struct" => Attribute(row.name, row.dataType.typeName, Some(false), !row.nullable, attributes= Some(createAttributes(row.dataType.asInstanceOf[StructType])))
+      case "array" =>
+        val elemType = row.dataType.asInstanceOf[ArrayType].elementType
+        if(elemType.typeName.equals("struct"))
+        // if the array contains elements of type struct.
+        // {people: [{name:Person1, age:22},{name:Person2, age:25}]}
+          Attribute(row.name, elemType.typeName, Some(true),!row.nullable,attributes= Some(createAttributes(elemType.asInstanceOf[StructType])))
+        else
+        // if it is a regular array. {ages: [21, 25]}
+          Attribute(row.name, elemType.typeName, Some(true),!row.nullable)
+      case _ => Attribute(row.name, row.dataType.typeName,Some(false) ,!row.nullable)
+    }).toList
+  }
+
+
+  private def createMetaData():Metadata ={
+      Metadata(Some(Mode.FILE),Some(Format.JSON), Some(true),Some(false), Some(header) )
+    }
+
+
+  private def createSchema(p: Pattern ):Schema ={
+    Schema("Test",p, createAttributes(dataframe.schema), Some(createMetaData), None, None, None, None)
+
+  }
+
+  def generateYaml(savePath: String): Unit ={
+    val data: Schema = createSchema(Pattern) // todo this wont work for now.
+    val mapper: ObjectMapper = new ObjectMapper(new YAMLFactory)
+      .registerModule(DefaultScalaModule)
+
+    mapper.writeValue(new File(savePath), data)
+  }
+
+}

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -75,11 +75,12 @@ object InferSchemaHandler {
   /***
     *   builds the Metadata case class. check case class metadata for attribute definition
     *
-    * @param format
-    * @param multiline
-    * @param array
-    * @param withHeader
-    * @param separator
+    * @param mode       : FILE mode by default
+    * @param format     : DSV by default
+    * @param multiline  : are json objects on a single line or multiple line ? Single by default.  false means single. false also means faster
+    * @param array      : Is a json stored as a single object array ? false by default
+    * @param withHeader : does the dataset has a header ? true bu default
+    * @param separator  : the column separator,  ';' by default
     * @return
     */
 
@@ -90,7 +91,7 @@ object InferSchemaHandler {
     separator: Option[String]
   ): Metadata = {
     Metadata(
-      Some(Mode.fromString("FILE")),
+      mode = Some(Mode.fromString("FILE")),
       Some(Format.fromString(format.getOrElse("DSV"))),
       multiline = None,
       array,
@@ -102,10 +103,10 @@ object InferSchemaHandler {
   /***
     *   builds the Schema case class
     *
-    * @param name
-    * @param pattern
-    * @param attributes
-    * @param metadata
+    * @param name       : Schema name, must be unique in the domain. Will become the hive table name
+    * @param pattern    : filename pattern to which this schema must be applied
+    * @param attributes : datasets columns
+    * @param metadata   : Dataset metadata
     * @return
     */
 
@@ -122,10 +123,11 @@ object InferSchemaHandler {
   /***
     * Builds the Domain case class
     *
-    * @param name
-    * @param directory
-    * @param metadata
-    * @param schemas
+    * @param name       : Domain name
+    * @param directory  : Folder on the local filesystem where incomping files are stored.
+    *                   This folder will be scanned regurlaly to move the dataset to the cluster
+    * @param metadata   : Default Schema meta data.
+    * @param schemas    : List of schema for each dataset in this domain
     * @return
     */
 

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -88,7 +88,7 @@ class InferSchemaHandler(dataframe: DataFrame) {
     * @param mapping
     * @return
     */
-  // todo can we replace mode, format and writemode by values instead of options
+  // todo can we replace mode, format and writemode by values instead of options of strings
   def createMetaData(
     mode: Option[String] = None,
     format: Option[String] = None,
@@ -132,7 +132,6 @@ class InferSchemaHandler(dataframe: DataFrame) {
     * @return
     */
 
-  // todo can we use something like automapper?
   def createSchema(
     name: String,
     pattern: Pattern,

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -82,10 +82,10 @@ class InferSchemaHandler(dataframe: DataFrame) {
     pattern: Pattern,
     attributes: List[Attribute],
     metadata: Metadata,
-    merge: Option[MergeOptions],
-    comment: Option[String],
-    presql: Option[List[String]],
-    postsql: Option[List[String]]
+    merge: Option[MergeOptions] = None,
+    comment: Option[String] = None,
+    presql: Option[List[String]] = None,
+    postsql: Option[List[String]] = None
   ): Schema = {
 
     Schema(name, pattern, attributes, Some(metadata), merge, comment, presql, postsql)

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -26,7 +26,7 @@ import com.ebiznext.comet.schema.model._
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.types.{ArrayType, StructType}
 
-object InferSchemaHandler {
+object InferSchemaHandler{
 
   /** *
     * Traverses the schema and returns a list of attributes.

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
@@ -67,6 +67,12 @@ trait StorageHandler {
   */
 class HdfsStorageHandler extends StorageHandler {
 
+  /**
+    * Gets the outputstream given a path
+    *
+    * @param path : path
+    * @return FSDataOutputStream
+    */
   def getOutputStream(path: Path): FSDataOutputStream = {
     val conf = new Configuration()
     val fs = FileSystem.get(conf)
@@ -96,10 +102,7 @@ class HdfsStorageHandler extends StorageHandler {
     * @param path : Absolute file path
     */
   def write(data: String, path: Path): Unit = {
-    val conf = new Configuration()
-    val fs = FileSystem.get(conf)
-    fs.delete(path, false)
-    val os: FSDataOutputStream = fs.create(path)
+    val os: FSDataOutputStream = getOutputStream(path)
     os.writeBytes(data)
     os.close()
   }

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
@@ -58,12 +58,22 @@ trait StorageHandler {
 
   def spaceConsumed(path: Path): Long
 
+  def getOutputStream(path: Path): FSDataOutputStream
+
 }
 
 /**
   * HDFS Filesystem Handler
   */
 class HdfsStorageHandler extends StorageHandler {
+
+  def getOutputStream(path: Path): FSDataOutputStream = {
+    val conf = new Configuration()
+    val fs = FileSystem.get(conf)
+    fs.delete(path, false)
+    val outputStream: FSDataOutputStream = fs.create(path)
+    outputStream
+  }
 
   /**
     * Read a UTF-8 text file into a string used to load yml configuration files

--- a/src/main/scala/com/ebiznext/comet/schema/model/Format.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Format.scala
@@ -43,7 +43,7 @@ object Format {
     value.toUpperCase match {
       case "DSV"         => Format.DSV
       case "SIMPLE_JSON" => Format.SIMPLE_JSON
-      case "JSON"        => Format.JSON
+      case "JSON" | "ARRAY_JSON"       => Format.JSON
     }
   }
 

--- a/src/main/scala/com/ebiznext/comet/schema/model/Format.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Format.scala
@@ -33,11 +33,11 @@ import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer}
   */
 @JsonSerialize(using = classOf[ToStringSerializer])
 @JsonDeserialize(using = classOf[FormatDeserializer])
-sealed case class Format(value: String) {
+sealed case class Format(value: String){
   override def toString: String = value
 }
 
-object Format {
+object Format{
 
   def fromString(value: String): Format = {
     value.toUpperCase match {
@@ -56,7 +56,7 @@ object Format {
   val formats: Set[Format] = Set(DSV, SIMPLE_JSON, JSON)
 }
 
-class FormatDeserializer extends JsonDeserializer[Format] {
+class FormatDeserializer extends JsonDeserializer[Format]{
   override def deserialize(jp: JsonParser, ctx: DeserializationContext): Format = {
     val value = jp.readValueAs[String](classOf[String])
     Format.fromString(value)

--- a/src/main/scala/com/ebiznext/comet/schema/model/Format.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Format.scala
@@ -41,9 +41,9 @@ object Format {
 
   def fromString(value: String): Format = {
     value.toUpperCase match {
-      case "DSV"         => Format.DSV
+      case "DSV" => Format.DSV
       case "SIMPLE_JSON" => Format.SIMPLE_JSON
-      case "JSON" | "ARRAY_JSON"       => Format.JSON
+      case "JSON" | "ARRAY_JSON" => Format.JSON
     }
   }
 

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -23,6 +23,7 @@ package com.ebiznext.comet.workflow
 import better.files._
 import com.ebiznext.comet.config.{DatasetArea, Settings}
 import com.ebiznext.comet.job.index.{IndexConfig, IndexJob}
+import com.ebiznext.comet.job.infer.{InferConfig, InferSchema}
 import com.ebiznext.comet.job.ingest.{DsvIngestionJob, JsonIngestionJob, SimpleJsonIngestionJob}
 import com.ebiznext.comet.job.transform.AutoJob
 import com.ebiznext.comet.schema.handlers.{LaunchHandler, SchemaHandler, StorageHandler}
@@ -329,5 +330,9 @@ class IngestionWorkflow(
 
   def index(config: IndexConfig) = {
     new IndexJob(config, Settings.storageHandler).run()
+  }
+
+  def infer(config: InferConfig) = {
+    new InferSchema(config.inputPath, config.outputPath, config.header)
   }
 }

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -333,6 +333,12 @@ class IngestionWorkflow(
   }
 
   def infer(config: InferConfig) = {
-    new InferSchema(config.inputPath, config.outputPath, config.header)
+    new InferSchema(
+      config.domainName,
+      config.schemaName,
+      config.inputPath,
+      config.outputPath,
+      config.header
+    )
   }
 }

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -341,6 +341,7 @@ class IngestionWorkflow(
       config.outputPath,
       config.header
     )
+  }
 
   /**
     * Runs the metrics job

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandlerSpec.scala
@@ -1,0 +1,103 @@
+package com.ebiznext.comet.schema.handlers
+import com.ebiznext.comet.schema.model.Attribute
+import org.apache.spark.sql.SparkSession
+import org.scalatest.{FlatSpec, Matchers}
+
+class InferSchemaHandlerSpec extends FlatSpec with Matchers{
+
+
+  val spark: SparkSession = SparkSession.builder()
+    .master("local[1]")
+    .appName("InferSchemaHandlerTest")
+    .getOrCreate()
+
+  import spark.implicits._
+
+
+
+  "CreateAttributes" should "create the correct list of attributes for a complex Json" in {
+
+
+    val ComplexjsonStr = """{ "metadata": { "key": 84896, "value": 54 }}"""
+
+    val df = spark.read
+      .option("inferSchema", value = true)
+      .json(Seq(ComplexjsonStr).toDS.rdd)
+
+  val complexAttr2 = Attribute("key", "long", Some(false), false)
+  val complexAttr3 = Attribute("value", "long", Some(false), false)
+
+  val complexAttr1: List[Attribute] = List(
+    Attribute(
+      "metadata",
+      "struct",
+      Some(false),
+      false,
+      attributes = Some(List(complexAttr2, complexAttr3))
+    )
+  )
+
+  val complexAttr: List[Attribute] = InferSchemaHandler.createAttributes(df.schema)
+
+    complexAttr shouldBe complexAttr1
+  }
+
+  "CreateAttributes" should "create the correct list of attributes for a simple Json" in {
+    val SimpleJsonStr = """{ "key": "Fares", "value": 3 }}"""
+
+    val df1 = spark.read
+    .option("inferSchema", value = true)
+    .json(Seq(SimpleJsonStr).toDS.rdd)
+
+  val simpleAttr: List[Attribute] = InferSchemaHandler.createAttributes(df1.schema)
+
+  val simpleAttr1: List[Attribute] = List(
+    Attribute("key", "string", Some(false), false),
+    Attribute("value", "long", Some(false), false)
+  )
+    simpleAttr shouldBe simpleAttr1
+  }
+
+
+
+  "CreateAttributes" should "create the correct list of attributes for a dsv with header" in {
+    val df1 = spark.read
+      .format("com.databricks.spark.csv")
+      .option("inferSchema", value = true)
+      .option("header", true)
+      .option("delimiter", ";")
+      .option("parserLib", "UNIVOCITY")
+      .load("src/test/resources/sample/SCHEMA-VALID.dsv")
+
+    val dsv: List[Attribute] = InferSchemaHandler.createAttributes(df1.schema)
+
+    val dsv1: List[Attribute] = List(
+      Attribute("firstname", "string", Some(false), false),
+      Attribute("lastname", "string", Some(false), false),
+      Attribute("age", "string", Some(false), false)
+    )
+    dsv shouldBe dsv1
+
+  }
+
+  "CreateAttributes" should "create the correct list of attributes for a dsv without header" in {
+    val df1 = spark.read
+      .format("com.databricks.spark.csv")
+      .option("inferSchema", value = true)
+      .option("header", false)
+      .option("delimiter", ";")
+      .option("parserLib", "UNIVOCITY")
+      .load("src/test/resources/sample/SCHEMA-VALID-NOHEADER.dsv")
+
+    val dsv: List[Attribute] = InferSchemaHandler.createAttributes(df1.schema)
+
+    val dsv1: List[Attribute] = List(
+      Attribute("_c0", "string", Some(false), false),
+      Attribute("_c1", "string", Some(false), false),
+      Attribute("_c2", "integer", Some(false), false)
+    )
+    dsv shouldBe dsv1
+
+  }
+
+}

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaJobSpec.scala
@@ -1,0 +1,43 @@
+package com.ebiznext.comet.schema.handlers
+
+import com.ebiznext.comet.TestHelper
+import com.ebiznext.comet.job.infer.InferSchemaJob
+import org.apache.spark.sql.Dataset
+
+class InferSchemaJobSpec extends TestHelper {
+
+  val dataset_csv: Dataset[String] = sparkSession.read
+    .textFile("src/test/resources/sample/SCHEMA-VALID-NOHEADER.dsv")
+
+  val dataset_jsonArray: Dataset[String] = sparkSession.read
+    .textFile("src/test/resources/sample/simple-json-locations/locations.json")
+
+  val dataset_psv: Dataset[String] = sparkSession.read
+    .textFile("src/test/resources/quickstart/incoming/sales/customers-2018-01-01.psv")
+
+  "GetSeparatorSemiColon" should "succeed" in {
+
+    InferSchemaJob.getSeparator(dataset_csv) shouldBe ";"
+
+  }
+
+  "GetSeparatorPipe" should "succeed" in {
+
+    InferSchemaJob.getSeparator(dataset_psv) shouldBe "|"
+
+  }
+
+  "GetFormat" should "succeed" in {
+
+    InferSchemaJob.getFormatFile(dataset_csv) shouldBe "DSV"
+
+  }
+
+  "GetFormatArrayJson" should "succeed" in {
+
+    InferSchemaJob.getFormatFile(dataset_jsonArray) shouldBe "ARRAY_JSON"
+
+  }
+
+
+}

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaJobSpec.scala
@@ -9,11 +9,17 @@ class InferSchemaJobSpec extends TestHelper {
   val dataset_csv: Dataset[String] = sparkSession.read
     .textFile("src/test/resources/sample/SCHEMA-VALID-NOHEADER.dsv")
 
-  val dataset_jsonArray: Dataset[String] = sparkSession.read
-    .textFile("src/test/resources/sample/simple-json-locations/locations.json")
-
   val dataset_psv: Dataset[String] = sparkSession.read
     .textFile("src/test/resources/quickstart/incoming/sales/customers-2018-01-01.psv")
+
+  val dataset_json: Dataset[String] = sparkSession.read
+    .textFile("src/test/resources/sample/json/complex.json")
+
+  val dataset_jsonArray: Dataset[String] = sparkSession.read
+    .textFile("src/test/resources/quickstart/incoming/hr/sellers-2018-01-01.json")
+
+  val dataset_jsonArrayMultiline: Dataset[String] = sparkSession.read
+    .textFile("src/test/resources/sample/simple-json-locations/locations.json")
 
   "GetSeparatorSemiColon" should "succeed" in {
 
@@ -27,9 +33,16 @@ class InferSchemaJobSpec extends TestHelper {
 
   }
 
-  "GetFormat" should "succeed" in {
+  "GetFormatCSV" should "succeed" in {
 
     InferSchemaJob.getFormatFile(dataset_csv) shouldBe "DSV"
+
+  }
+
+
+  "GetFormatJson" should "succeed" in {
+
+    InferSchemaJob.getFormatFile(dataset_json) shouldBe "JSON"
 
   }
 
@@ -38,5 +51,12 @@ class InferSchemaJobSpec extends TestHelper {
     InferSchemaJob.getFormatFile(dataset_jsonArray) shouldBe "ARRAY_JSON"
 
   }
+
+  "GetFormatArrayJsonMultiline" should "succeed" in {
+
+    InferSchemaJob.getFormatFile(dataset_jsonArrayMultiline) shouldBe "ARRAY_JSON"
+
+  }
+
 
 }

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaJobSpec.scala
@@ -39,5 +39,4 @@ class InferSchemaJobSpec extends TestHelper {
 
   }
 
-
 }


### PR DESCRIPTION
## Summary
Infers the schema of a dataframe
**Contributor @Rayan958**

**Related Issue: #83**

**PR Type: Feature**

**Status: WIP**

**Breaking change? No**


## Description
### Solution
Added an infer schema possibility. given a dataset and a fs savepath, we will read the file, determine seperator, type... generate a dataframe and use that to create a yaml file with all the Attributes, Schemas and Domain listed.


### Deploy Notes
example of usage, 
spark-submit target/scala-2.11/comet-assembly-0.1.jar infer-schema file:///path/to/file.extension /path/to/results.yml header
header is a Boolean, to be used in the case of DSV

### Remaining Todos
This should be done before merging this PR:
* [x] - add unit tests

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



