### PR TITLE
Add metrics computing functionality

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -22,6 +22,7 @@ package com.ebiznext.comet.job
 
 import com.ebiznext.comet.config.{DatasetArea, Settings}
 import com.ebiznext.comet.job.index.IndexConfig
+import com.ebiznext.comet.job.metrics.MetricsConfig
 import com.ebiznext.comet.workflow.IngestionWorkflow
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
@@ -59,6 +60,7 @@ object Main extends StrictLogging {
         |comet import
         |comet ingest datasetDomain datasetSchema datasetPath
         |comet index --domain domain --schema schema --timestamp {@timestamp|yyyy.MM.dd} --id type-id --mapping mapping --format parquet|json|json-array --dataset datasetPath --conf key=value,key=value,...
+        |comet metrics --domain domain --schema schema
         |      """.stripMargin
     )
   }
@@ -77,6 +79,8 @@ object Main extends StrictLogging {
     *             When called with a '-' sign, will look for all domain folder in the landing area except the ones in the command lines.
     *   - call "comet ingest domain schema hdfs://datasets/domain/pending/file.dsv"
     *             to ingest a file defined by its schema in the specified domain
+    *   - call "comet metrics --domain domain-name --schema schema-name "
+    *             to compute all metrics on specific schema in a specific domain
     */
   def main(args: Array[String]): Unit = {
     import Settings.{schemaHandler, storageHandler}
@@ -116,6 +120,15 @@ object Main extends StrictLogging {
           case _ =>
             printUsage()
         }
+
+      case "metrics" =>
+        MetricsConfig.parse(args.drop(1)) match {
+          case Some(config) =>
+            workflow.metric(config)
+          case _ =>
+            printUsage()
+        }
+
       case _ => printUsage()
     }
   }

--- a/src/main/scala/com/ebiznext/comet/job/metrics/Metrics.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/Metrics.scala
@@ -233,7 +233,9 @@ object Metrics extends StrictLogging {
       attributeChecked
         .map(x => regroupContinuousMetricsByVariable(x, metricFrame))
         .reduce(_.union(_))
-    matrixMetric.select(colRenamed.head, colRenamed.tail: _*)
+    matrixMetric
+      .select(colRenamed.head, colRenamed.tail: _*)
+      .withColumn("Variable_Type", lit("Continuous"))
 
   }
 
@@ -360,7 +362,9 @@ object Metrics extends StrictLogging {
       attributeChecked
         .map(x => regroupDiscreteMetricsByVariable(dataInit, x, operations))
         .reduce(_.union(_))
-    matrixMetric.select(colRenamed.head, colRenamed.tail: _*)
+    matrixMetric
+      .select(colRenamed.head, colRenamed.tail: _*)
+      .withColumn("Variable_Type", lit("Discrete"))
   }
 
 }

--- a/src/main/scala/com/ebiznext/comet/job/metrics/Metrics.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/Metrics.scala
@@ -235,7 +235,7 @@ object Metrics extends StrictLogging {
         .reduce(_.union(_))
     matrixMetric
       .select(colRenamed.head, colRenamed.tail: _*)
-      .withColumn("Variable_Type", lit("Continuous"))
+      .withColumn("_metricType_", lit("Continuous"))
 
   }
 
@@ -364,7 +364,7 @@ object Metrics extends StrictLogging {
         .reduce(_.union(_))
     matrixMetric
       .select(colRenamed.head, colRenamed.tail: _*)
-      .withColumn("Variable_Type", lit("Discrete"))
+      .withColumn("_metricType_", lit("Discrete"))
   }
 
 }

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsConfig.scala
@@ -1,0 +1,49 @@
+package com.ebiznext.comet.job.metrics
+
+import com.ebiznext.comet.config.Settings
+import org.apache.hadoop.fs.Path
+import scopt.OParser
+
+case class MetricsConfig(
+                          domain: String = "",
+                          schema: String = ""
+                        ) {
+
+  /** Function to build path of data to compute metrics on
+    * using the attribute domain and schema and ingested files path.
+    *
+    * @return : the path of data to compute metrics on
+    */
+  def getDataset(): Path = {
+    new Path(s"${Settings.comet.datasets}/${Settings.comet.area.accepted}/$domain/$schema")
+  }
+
+}
+
+object MetricsConfig {
+
+  /** Function to parse command line arguments (domain and schema).
+    *
+    * @param args : Command line parameters
+    * @return : an Option of MetricConfing with the parsed domain and schema names.
+    */
+  def parse(args: Seq[String]): Option[MetricsConfig] = {
+    val builder = OParser.builder[MetricsConfig]
+    val parser: OParser[Unit, MetricsConfig] = {
+      import builder._
+      OParser.sequence(
+        programName("comet"),
+        head("comet", "1.x"),
+        opt[String]("domain")
+          .action((x, c) => c.copy(domain = x))
+          .required()
+          .text("Domain Name"),
+        opt[String]("schema")
+          .action((x, c) => c.copy(schema = x))
+          .required()
+          .text("Schema Name")
+      )
+    }
+    OParser.parse(parser, args, MetricsConfig())
+  }
+}

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
@@ -250,9 +250,9 @@ class MetricsJob(
                       stageState: String,
                       path: Path,
                       threshold: Int
-                    ): Unit = {
+                    ): DataFrame = {
 
-    val dataToSave = listDfStats
+    listDfStats
       .map { dfStatistics =>
         val listVariable: List[String] = dfStatistics
           .select("Variables")
@@ -305,8 +305,6 @@ class MetricsJob(
 
       }
       .reduce(_.union(_))
-
-    save(dataToSave, path)
   }
 
   override def name: String = "Compute metrics job"
@@ -366,7 +364,7 @@ class MetricsJob(
     val continuousDataset =
       discreteMetricTyping(Metrics.computeContinuiousMetric(dataUse, continAttr, continuousOps))
 
-    extractMetrics(
+    val allMetricsDf = extractMetrics(
       List(discreteDataset, continuousDataset),
       domain,
       schema,
@@ -376,6 +374,7 @@ class MetricsJob(
       Settings.comet.metrics.discreteMaxCardinality
     )
 
+    save(allMetricsDf, savePath)
     session
   }
 }

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
@@ -150,7 +150,7 @@ class MetricsJob(
     * @return : Option of T either Double or Long depending on the metric.
     */
   def getMetric[T: Manifest](metric: DataFrame, colName: String): Option[T] = {
-    metric.select("Variable_Type").first().getString(0) match {
+    metric.select("_metricType_").first().getString(0) match {
       case "Continuous" => Some(metric.select(colName).first().getAs[T](0))
       case _            => None
     }
@@ -163,7 +163,7 @@ class MetricsJob(
     * @return : the metric in Option type of List of String
     */
   def getMetricListStringType(metric: DataFrame, colName: String): Option[List[String]] = {
-    metric.select("Variable_Type").first().getString(0) match {
+    metric.select("_metricType_").first().getString(0) match {
       case "Discrete" => Some(metric.select("Category").collect.map(_.getString(0)).toList)
       case _          => None
     }
@@ -182,7 +182,7 @@ class MetricsJob(
                          metric: String,
                          f: (DataFrame, String, String, String) => A
                        ): Option[Map[String, A]] = {
-    dfStatistics.select("Variable_Type").first().getString(0) match {
+    dfStatistics.select("_metricType_").first().getString(0) match {
       case "Discrete" if getListCategory(dfStatistics, colName).length - threshold < 0 =>
         Some(
           Map(
@@ -206,7 +206,7 @@ class MetricsJob(
                                         colName: String,
                                         threshold: Int
                                       ): Option[Long] = {
-    dfStatistics.select("Variable_Type").first().getString(0) match {
+    dfStatistics.select("_metricType_").first().getString(0) match {
       case "Discrete" if getListCategory(dfStatistics, colName).length - threshold < 0 =>
         Some(
           dfStatistics
@@ -226,7 +226,7 @@ class MetricsJob(
     * @return : the metric in Option type of Int
     */
   def getMetricCountDistinct(metric: DataFrame, colName: String): Option[Long] = {
-    metric.select("Variable_Type").first().getString(0) match {
+    metric.select("_metricType_").first().getString(0) match {
       case "Discrete" => Some(getListCategory(metric, colName).length)
       case _          => None
     }

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
@@ -241,7 +241,7 @@ class MetricsJob(
     * @param threshold     : The limit value for the number of sub-class to consider
     * @return : the stored dataframe version of the parquet file
     */
-  def createDataframeToSave(
+  def formatDataframeToSave(
                              dfStatistics: DataFrame,
                              domain: Domain,
                              schema: Schema,
@@ -280,7 +280,13 @@ class MetricsJob(
         getMetricListStringType(metric, "Category"),
         getMetricCountDistinct(dfStatistics, c),
         getMetricCount[Long](dfStatistics, c, threshold, "CountDiscrete", getCategoryMetric[Long]),
-        getMetricCount[Double](dfStatistics,c,threshold,"Frequencies",getCategoryMetric[Double]),
+        getMetricCount[Double](
+          dfStatistics,
+          c,
+          threshold,
+          "Frequencies",
+          getCategoryMetric[Double]
+        ),
         getMetricCountMissValuesDiscrete(dfStatistics, c, threshold),
         ingestionTime,
         stageState
@@ -330,7 +336,7 @@ class MetricsJob(
     storageHandler.mkdirs(savePath)
 
     val disDataframe = this
-      .createDataframeToSave(
+      .formatDataframeToSave(
         discreteDataset,
         domain,
         schema,
@@ -341,7 +347,7 @@ class MetricsJob(
       )
 
     val conDataframe = this
-      .createDataframeToSave(
+      .formatDataframeToSave(
         continuousDataset,
         domain,
         schema,

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
@@ -10,75 +10,75 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.execution.streaming.FileStreamSource.Timestamp
 import org.apache.spark.sql.functions.col
 
+/**
+  *
+  * @param domain                : Domain name
+  * @param schema                : Schema
+  * @param variableName          : Variable name from the attributes
+  * @param min                   : Min metric
+  * @param max                   : Max metric
+  * @param mean                  : Mean metric
+  * @param count                 : Count metric
+  * @param missingValues         : Missing Values metric
+  * @param variance              : Variance metric
+  * @param standardDev           : Standard deviation metric
+  * @param sum                   : Sum metric
+  * @param skewness              : Skewness metric
+  * @param kurtosis              : Kurtosis metric
+  * @param percentile25          : Percentile25 metric
+  * @param median                : Median metric
+  * @param percentile75          : Percentile75 metric
+  * @param category              : Category metric
+  * @param countDistinct         : Count Distinct metric
+  * @param countByCategory       : Count By Category metric
+  * @param frequencies           : Frequency metric
+  * @param missingValuesDiscrete : Missing Values Discrete metric
+  */
+case class MetricRow(
+                      domain: String,
+                      schema: String,
+                      variableName: String,
+                      min: Option[Double],
+                      max: Option[Double],
+                      mean: Option[Double],
+                      count: Option[Long],
+                      missingValues: Option[Long],
+                      variance: Option[Double],
+                      standardDev: Option[Double],
+                      sum: Option[Double],
+                      skewness: Option[Double],
+                      kurtosis: Option[Double],
+                      percentile25: Option[Double],
+                      median: Option[Double],
+                      percentile75: Option[Double],
+                      category: Option[List[String]],
+                      countDistinct: Option[Int],
+                      countByCategory: Option[Map[String, Long]],
+                      frequencies: Option[Map[String, Double]],
+                      missingValuesDiscrete: Option[Long],
+                      timestamp: Long,
+                      stage: String
+                    )
+
 /** To record statistics with other information during ingestion.
   *
   */
 
 /**
   *
-  * @param datasetPath      : Path to the dataset
-  * @param domain           : Domain name
-  * @param schema           : Schema
-  * @param stage            : stage
-  * @param storageHandler   : Storage Handler
+  * @param datasetPath    : Path to the dataset
+  * @param domain         : Domain name
+  * @param schema         : Schema
+  * @param stage          : stage
+  * @param storageHandler : Storage Handler
   */
 class MetricsJob(
-  datasetPath: Path,
-  domain: Domain,
-  schema: Schema,
-  stage: String,
-  storageHandler: StorageHandler
-) extends SparkJob {
-
-  /**
-    *
-    * @param domain                : Domain name
-    * @param schema                : Schema
-    * @param variableName          : Variable name from the attributes
-    * @param min                   : Min metric
-    * @param max                   : Max metric
-    * @param mean                  : Mean metric
-    * @param count                 : Count metric
-    * @param missingValues         : Missing Values metric
-    * @param variance              : Variance metric
-    * @param standardDev           : Standard deviation metric
-    * @param sum                   : Sum metric
-    * @param skewness              : Skewness metric
-    * @param kurtosis              : Kurtosis metric
-    * @param percentile25          : Percentile25 metric
-    * @param median                : Median metric
-    * @param percentile75          : Percentile75 metric
-    * @param category              : Category metric
-    * @param countDistinct         : Count Distinct metric
-    * @param countByCategory       : Count By Category metric
-    * @param frequencies           : Frequency metric
-    * @param missingValuesDiscrete : Missing Values Discrete metric
-    */
-  case class MetricRow(
-    domain: String,
-    schema: String,
-    variableName: String,
-    min: Option[Long],
-    max: Option[Long],
-    mean: Option[Long],
-    count: Option[Long],
-    missingValues: Option[Long],
-    variance: Option[Double],
-    standardDev: Option[Double],
-    sum: Option[Double],
-    skewness: Option[Double],
-    kurtosis: Option[Double],
-    percentile25: Option[Double],
-    median: Option[Double],
-    percentile75: Option[Double],
-    category: Option[List[String]],
-    countDistinct: Option[Int],
-    countByCategory: Option[Map[String, Long]],
-    frequencies: Option[Map[String, Double]],
-    missingValuesDiscrete: Option[Long],
-    timestamp: Long,
-    stage: String
-  )
+                  datasetPath: Path,
+                  domain: Domain,
+                  schema: Schema,
+                  stage: String,
+                  storageHandler: StorageHandler
+                ) extends SparkJob {
 
   /** Function that retrieves class names for each variable (case discrete variable)
     *
@@ -100,49 +100,52 @@ class MetricsJob(
     * @param nameVariable :   Name of the variable
     * @param nameCategory :   Name of the category
     * @param metric       :   Name of the metric to compute
-    * @tparam T           :   Return type of the function
-    * @return             :   T, Long for CountDiscrete and Double for Frequencies
+    * @tparam T :   Return type of the function
+    * @return :   T, Long for CountDiscrete and Double for Frequencies
     */
   def getCategoryMetric[T: Manifest](
-    dataInit: DataFrame,
-    nameVariable: String,
-    nameCategory: String,
-    metric: String
-  ): T = {
+                                      dataInit: DataFrame,
+                                      nameVariable: String,
+                                      nameCategory: String,
+                                      metric: String
+                                    ): T = {
     val dataReduceCategory: DataFrame = dataInit.filter(col("Variables").isin(nameVariable))
     val dataCategory: DataFrame = dataReduceCategory.filter(col("Category").isin(nameCategory))
     dataCategory.select(col(metric)).first().getAs[T](0)
   }
 
   /**
-    * Saves a dataset. if the path exists already, save to an intermediary directory because
-    * spark cant read and write to the same directory
+    * Saves a dataset. if the path is empty (the first time we call metrics on the schema) then we can write
+    * if there's already parquet files stored in it, then create a temporary directory to compute on, and flush
+    * the path to move updated metrics in it
     *
     * @param dataToSave :   dataset to be saved
     * @param path       :   Path to save the file at
     */
   def saveDataset(dataToSave: DataFrame, path: Path): Unit = {
-    if (storageHandler.exist(path)) {
+    if (!storageHandler.list(path).isEmpty) {
       val pathIntermediate = new Path(path, ".stat")
-
       val dataByVariableStored: DataFrame = session.read.parquet(path.toString).union(dataToSave)
       dataByVariableStored.coalesce(1).write.mode("append").parquet(pathIntermediate.toString)
-      storageHandler.delete(path)
-      storageHandler.move(pathIntermediate, path)
+      storageHandler.list(path, ".parquet").map(storageHandler.delete(_))
+      storageHandler.list(pathIntermediate, ".parquet").map(storageHandler.move(_, path))
+      storageHandler.delete(pathIntermediate)
       logger.whenDebugEnabled {
         session.read.parquet(path.toString).show(1000, truncate = false)
       }
-    } else
+    } else {
       dataToSave.coalesce(1).write.mode("append").parquet(path.toString)
+
+    }
   }
 
   /**
     * Function to get metric
     *
-    * @param metric   : metric we're looking for
-    * @param colName  : Column name
-    * @tparam T       : Type of the metric value
-    * @return         : Option of T either Double or Long depending on the metric.
+    * @param metric  : metric we're looking for
+    * @param colName : Column name
+    * @tparam T : Type of the metric value
+    * @return : Option of T either Double or Long depending on the metric.
     */
   def getMetric[T: Manifest](metric: Dataset[Row], colName: String): Option[T] = {
     metric.count() match {
@@ -153,9 +156,9 @@ class MetricsJob(
 
   /** Function that get String type metric
     *
-    * @param metric   : the dataset
-    * @param colName  : the column name
-    * @return         : the metric in Option type of List of String
+    * @param metric  : the dataset
+    * @param colName : the column name
+    * @return : the metric in Option type of List of String
     */
   def getMetricListStringType(metric: Dataset[Row], colName: String): Option[List[String]] = {
     metric.count() match {
@@ -168,15 +171,15 @@ class MetricsJob(
     *
     * @param dfStatistics : the dataframe
     * @param colName      : the column name
-    * @return             : the metric in Option type of Map[String,A]
+    * @return : the metric in Option type of Map[String,A]
     */
   def getMetricCount[A](
-    dfStatistics: DataFrame,
-    colName: String,
-    threshold: Int,
-    metric: String,
-    f: (DataFrame, String, String, String) => A
-  ): Option[Map[String, A]] = {
+                         dfStatistics: DataFrame,
+                         colName: String,
+                         threshold: Int,
+                         metric: String,
+                         f: (DataFrame, String, String, String) => A
+                       ): Option[Map[String, A]] = {
     dfStatistics.filter(col("Variables").isin(colName)).count() match {
       case _ if getListCategory(dfStatistics, colName).length - threshold < 0 =>
         Some(
@@ -197,10 +200,10 @@ class MetricsJob(
     * @return : the metric in Option type of Long
     */
   def getMetricCountMissValuesDiscrete(
-    dfStatistics: DataFrame,
-    colName: String,
-    threshold: Int
-  ): Option[Long] = {
+                                        dfStatistics: DataFrame,
+                                        colName: String,
+                                        threshold: Int
+                                      ): Option[Long] = {
     dfStatistics.filter(col("Variables").isin(colName)).count() match {
       case _ if getListCategory(dfStatistics, colName).length - threshold < 0 =>
         Some(
@@ -218,7 +221,7 @@ class MetricsJob(
     *
     * @param dfStatistics : the dataframe
     * @param colName      : the column name
-    * @return             : the metric in Option type of Int
+    * @return : the metric in Option type of Int
     */
   def getMetricCountDistinct(dfStatistics: DataFrame, colName: String): Option[Int] = {
     dfStatistics.filter(col("Variables").isin(colName)).count() match {
@@ -229,24 +232,24 @@ class MetricsJob(
 
   /** Function to save the dfStatistics to parquet format.
     *
-    * @param dfStatistics      : Dataframe that contains all the computed metrics
-    * @param domain            : name of the domain
-    * @param schema            : schema of the initial data
-    * @param ingestionTime     : time which correspond to the ingestion
-    * @param stageState        : stage (unit / global)
-    * @param path              : path where to save the file
-    * @param threshold         : The limit value for the number of sub-class to consider
-    * @return                  : the stored dataframe version of the parquet file
+    * @param dfStatistics  : Dataframe that contains all the computed metrics
+    * @param domain        : name of the domain
+    * @param schema        : schema of the initial data
+    * @param ingestionTime : time which correspond to the ingestion
+    * @param stageState    : stage (unit / global)
+    * @param path          : path where to save the file
+    * @param threshold     : The limit value for the number of sub-class to consider
+    * @return : the stored dataframe version of the parquet file
     */
   def saveDataStatToParquet(
-    dfStatistics: DataFrame,
-    domain: Domain,
-    schema: Schema,
-    ingestionTime: Timestamp,
-    stageState: String,
-    path: Path,
-    threshold: Int
-  ): Unit = {
+                             dfStatistics: DataFrame,
+                             domain: Domain,
+                             schema: Schema,
+                             ingestionTime: Timestamp,
+                             stageState: String,
+                             path: Path,
+                             threshold: Int
+                           ): Unit = {
 
     val listVariable: List[String] = dfStatistics
       .select("Variables")
@@ -256,13 +259,14 @@ class MetricsJob(
       .distinct
     val listRowByVariable = listVariable.map { c =>
       val metric = dfStatistics.filter(col("Variables").isin(c))
+
       MetricRow(
         domain.name,
         schema.name,
         c,
-        getMetric[Long](metric, "Min"),
-        getMetric[Long](metric, "Max"),
-        getMetric[Long](metric, "Mean"),
+        getMetric[Double](metric, "Min"),
+        getMetric[Double](metric, "Max"),
+        getMetric[Double](metric, "Mean"),
         getMetric[Long](metric, "Count"),
         getMetric[Long](metric, "CountMissValues"),
         getMetric[Double](metric, "Var"),
@@ -275,25 +279,27 @@ class MetricsJob(
         getMetric[Double](metric, "Percentile75"),
         getMetricListStringType(metric, "Category"),
         getMetricCountDistinct(dfStatistics, c),
-        getMetricCount[Long](dfStatistics, c, threshold, "CountDiscrete", getCategoryMetric),
-        getMetricCount[Double](dfStatistics, c, threshold, "Frequencies", getCategoryMetric),
+        getMetricCount[Long](dfStatistics, c, threshold, "CountDiscrete", getCategoryMetric[Long]),
+        getMetricCount[Double](dfStatistics, c, threshold, "Frequencies", getCategoryMetric[Double]),
         getMetricCountMissValuesDiscrete(dfStatistics, c, threshold),
         ingestionTime,
         stageState
       )
     }
 
-    import session.implicits._
-
-    val dataByVariable = listRowByVariable.toDF
-
+    val dataByVariable = session.createDataFrame(listRowByVariable)
     saveDataset(dataByVariable, path)
 
   }
 
-  override def name: String = "Json Stat Job"
+  override def name: String = "Compute metrics job"
 
-  def metricsPath(path: String): Path = {
+  /** Function to build the metrics save path
+    *
+    * @param path          : path where metrics are stored
+    * @return              : path where the metrics for the specified schema are stored
+    */
+  def getMetricsPath(path: String): Path = {
     new Path(
       path
         .replace("{domain}", domain.name)
@@ -307,24 +313,22 @@ class MetricsJob(
     *
     * @return : Spark Session used for the job
     */
-  // TODO Implement stageState
   override def run(): SparkSession = {
     val dataUse: DataFrame = session.read.parquet(datasetPath.toString)
     val attributes: List[String] = schema.discreteAttrs().map(_.name)
     val discreteOps: List[DiscreteMetric] = Metrics.discreteMetrics
     val continuousOps: List[ContinuousMetric] = Metrics.continuousMetrics
-    val stageState: String = ???
-    val metricsPath: Path = new Path(Settings.comet.metrics.path)
+    val stageState: String = stage
+    val savePath: Path = getMetricsPath(Settings.comet.metrics.path)
 
     val discreteDataset =
       Metrics.computeDiscretMetric(dataUse, attributes, discreteOps)
     val continuousDataset =
       Metrics.computeContinuiousMetric(dataUse, schema.continuousAttrs().map(_.name), continuousOps)
 
-    val savePath = new Path(metricsPath, new Path(domain.name, schema.name))
     storageHandler.mkdirs(savePath)
     this.saveDataStatToParquet(
-      discreteDataset.union(continuousDataset),
+      discreteDataset.join(continuousDataset, "Variables"),
       domain,
       schema,
       storageHandler.lastModified(datasetPath),

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/StatDescJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/StatDescJobSpec.scala
@@ -87,7 +87,7 @@ class StatDescJobSpec extends FlatSpec {
     */
   val dimensionTable = (partialContinuousMetric.size + 1) * (listContnuousAttributes.size + 1)
 
-  val dimensionDataframe = (result1.columns.size) * (result1
+  val dimensionDataframe = (result1.columns.size-1) * (result1
     .select(col("Variables"))
     .collect()
     .map(_.getString(0))


### PR DESCRIPTION
## Summary
Add a metric command to compute statistics on ingested data.

**Related Issue: #36**

**PR Type: Bug Fix | Feature**

**Status: WIP**

**Breaking change? No**


## Description
### Solution
Added "metric" command to compute statistics on ingested data. With a command line specified domain and schema, the program will generate statistics for each column in the associated dataframe, and stores the results as parquet files on HDFS.
 
### Other changes
Describe any other additional work done:
- Change some MetricRow parameters types to solve types casts bugs
- Changes on saveDatasets method
- Use createDataframe instead of toDf to solve a NullPointerException bug
- Join continuous and discrete metrics dataframes instead of union.

### Deploy Notes
#### example of usage:
spark-submit comet-assembly-0.1.jar metrics --domain hr --schema sellers
"sellers" is a schema in the domain "hr"

### Remaining Todos
This should be done before merging this PR:
* [ ] - Manage dataframes "StructType" columns 

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



