### PR TITLE
improve Metrics performance (Optimise computation time)

### DIFF
--- a/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
+++ b/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
@@ -66,11 +66,12 @@ class SparkEnv(name: String) extends StrictLogging {
   /**
     * Creates a Spark Session with the spark.* keys defined the applciation conf file.
     */
-  lazy val session: SparkSession = {
+  lazy val session: SparkSession = SparkSession.builder.config(config).getOrCreate()
+  /* {
     if (Settings.comet.hive)
       SparkSession.builder.config(config).enableHiveSupport().getOrCreate()
     else
       SparkSession.builder.config(config).getOrCreate()
   }
-
+ */
 }

--- a/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
+++ b/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
@@ -66,8 +66,7 @@ class SparkEnv(name: String) extends StrictLogging {
   /**
     * Creates a Spark Session with the spark.* keys defined the applciation conf file.
     */
-  lazy val session: SparkSession = SparkSession.builder.config(config).getOrCreate()
-  {
+  lazy val session: SparkSession = {
     if (Settings.comet.hive)
       SparkSession.builder.config(config).enableHiveSupport().getOrCreate()
     else

--- a/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
+++ b/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
@@ -67,11 +67,11 @@ class SparkEnv(name: String) extends StrictLogging {
     * Creates a Spark Session with the spark.* keys defined the applciation conf file.
     */
   lazy val session: SparkSession = SparkSession.builder.config(config).getOrCreate()
-  /* {
+  {
     if (Settings.comet.hive)
       SparkSession.builder.config(config).enableHiveSupport().getOrCreate()
     else
       SparkSession.builder.config(config).getOrCreate()
   }
- */
+
 }

--- a/src/main/scala/com/ebiznext/comet/job/metrics/Metrics.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/Metrics.scala
@@ -13,31 +13,31 @@ object Metrics extends StrictLogging {
     */
   case class ContinuousMetric(name: String, function: Column => Column)
 
-  object Min extends ContinuousMetric("Min", min)
+  object Min extends ContinuousMetric("min", min)
 
-  object Max extends ContinuousMetric("Max", max)
+  object Max extends ContinuousMetric("max", max)
 
-  object Count extends ContinuousMetric("Count", count)
+  object Count extends ContinuousMetric("count", count)
 
-  object Sum extends ContinuousMetric("Sum", sum)
+  object Sum extends ContinuousMetric("sum", sum)
 
-  object Skewness extends ContinuousMetric("Skewness", skewness)
+  object Skewness extends ContinuousMetric("skewness", skewness)
 
-  object Kurtosis extends ContinuousMetric("Kurtosis", kurtosis)
+  object Kurtosis extends ContinuousMetric("kurtosis", kurtosis)
 
-  object Percentile75 extends ContinuousMetric("Percentile75", percentile75)
+  object Percentile75 extends ContinuousMetric("percentile75", percentile75)
 
-  object Percentile25 extends ContinuousMetric("Percentile25", percentile25)
+  object Percentile25 extends ContinuousMetric("percentile25", percentile25)
 
-  object Median extends ContinuousMetric("Median", customMedian)
+  object Median extends ContinuousMetric("median", customMedian)
 
-  object Mean extends ContinuousMetric("Mean", customMean)
+  object Mean extends ContinuousMetric("mean", customMean)
 
-  object Variance extends ContinuousMetric("Var", customVariance)
+  object Variance extends ContinuousMetric("variance", customVariance)
 
-  object Stddev extends ContinuousMetric("Stddev", customStddev)
+  object Stddev extends ContinuousMetric("standardDev", customStddev)
 
-  object CountMissValues extends ContinuousMetric("CountMissValues", customCountMissValues)
+  object CountMissValues extends ContinuousMetric("missingValues", customCountMissValues)
 
   /** List of all available metrics
     *
@@ -79,7 +79,7 @@ object Metrics extends StrictLogging {
     */
 
   def customMean(e: Column): Column = {
-    customMetric(e: Column, "Mean", mean)
+    customMetric(e: Column, "mean", mean)
   }
 
   /** Customize variance of the column e
@@ -89,7 +89,7 @@ object Metrics extends StrictLogging {
     */
 
   def customVariance(e: Column): Column = {
-    customMetric(e: Column, "Var", variance)
+    customMetric(e: Column, "variance", variance)
   }
 
   /** Customize Stddev of the column e
@@ -99,7 +99,7 @@ object Metrics extends StrictLogging {
     */
 
   def customStddev(e: Column): Column = {
-    customMetric(e: Column, "Stddev", stddev)
+    customMetric(e: Column, "standardDev", stddev)
   }
 
   /** Customize function metric in the case continuous variabes used for : percentile 25, median and percentile75
@@ -130,7 +130,7 @@ object Metrics extends StrictLogging {
     */
 
   def percentile25(e: Column): Column = {
-    customMetricUDF(e: Column, "Percentile25", callUDF, "percentile_approx", 0.25)
+    customMetricUDF(e: Column, "percentile25", callUDF, "percentile_approx", 0.25)
   }
 
   /** Customize Median of the column e
@@ -140,7 +140,7 @@ object Metrics extends StrictLogging {
     */
 
   def customMedian(e: Column): Column = {
-    customMetricUDF(e: Column, "Median", callUDF, "percentile_approx", 0.50)
+    customMetricUDF(e: Column, "median", callUDF, "percentile_approx", 0.50)
   }
 
   /** Customize percentile of order 0.75 of the column e
@@ -150,7 +150,7 @@ object Metrics extends StrictLogging {
     */
 
   def percentile75(e: Column): Column = {
-    customMetricUDF(e: Column, "Percentile75", callUDF, "percentile_approx", 0.75)
+    customMetricUDF(e: Column, "percentile75", callUDF, "percentile_approx", 0.75)
   }
 
   /** Customize missing values
@@ -160,7 +160,7 @@ object Metrics extends StrictLogging {
     */
   def customCountMissValues(e: Column): Column = {
     val nameCol = e.toString()
-    val aliasCountMissValues: String = "CountMissValues" + "(" + nameCol + ")"
+    val aliasCountMissValues: String = "missingValues" + "(" + nameCol + ")"
     val unionMissingValues = sum(
       when(
         e.isNull
@@ -190,7 +190,7 @@ object Metrics extends StrictLogging {
       selectedListColumns.columns.map(c => bround(col(c), 3).alias(c)): _*
     )
     //Add column Variables that contains the nameCol
-    val addVariablesColumn: DataFrame = broundColumns.withColumn("Variables", lit(nameCol))
+    val addVariablesColumn: DataFrame = broundColumns.withColumn("variableName", lit(nameCol))
     //Remove nameCol to keep only the metric name foreach metric.
     val removeNameColumnMetric = addVariablesColumn.columns.toList
       .map(str => str.replaceAll("\\(" + nameCol + "\\)", ""))
@@ -241,7 +241,7 @@ object Metrics extends StrictLogging {
     operations: List[ContinuousMetric]
   ): DataFrame = {
     val attributeChecked = extractMetricsAttributes(dataset, continuousAttributes)
-    val colRenamed: List[String] = "Variables" :: operations.map(_.name)
+    val colRenamed: List[String] = "variableName" :: operations.map(_.name)
     val metrics: List[Column] =
       attributeChecked.flatMap(name => operations.map(metric => metric.function(col(name))))
     val metricFrame: DataFrame = dataset.agg(metrics.head, metrics.tail: _*)
@@ -273,7 +273,7 @@ object Metrics extends StrictLogging {
     */
 
   val discreteMetrics: List[DiscreteMetric] =
-    List(Category,CountDistinct, CountDiscrete, Frequencies, CountMissValuesDiscrete)
+    List(Category, CountDistinct, CountDiscrete, Frequencies, CountMissValuesDiscrete)
 
   /** Function to compute the Dataframe metric by variable
     *

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
@@ -277,20 +277,10 @@ class MetricsJob(
     val continuousDataset: DataFrame =
       Metrics.computeContinuousMetric(dataUse, continAttrs, continuousOps)
 
-    logger.info("The discret metrics: \n\n ")
-
-    discreteDataset.show()
-
-    logger.info("The Continuous metrics metrics: \n\n ")
-
-    continuousDataset.show()
-
-    logger.info("First's part done: \n\n ")
 
     val allMetricsDf: DataFrame =
       unionDisContMetric(discreteDataset, continuousDataset, domain, schema, timestamp, stage)
 
-    allMetricsDf.show()
 
     save(allMetricsDf, savePath)
     session

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
@@ -57,7 +57,7 @@ case class MetricRow(
   frequencies: Option[Map[String, Double]],
   missingValuesDiscrete: Option[Long],
   timestamp: Long,
-  stage: Stage
+  stage: String
 )
 
 /** To record statistics with other information during ingestion.
@@ -249,7 +249,7 @@ class MetricsJob(
       .withColumn("domain", lit(domain.name))
       .withColumn("schema", lit(schema.name))
       .withColumn("ingestionTime", lit(ingestionTime))
-      .withColumn("stageState", lit(stageState))
+      .withColumn("stageState", lit(stageState.toString))
       .select(sortSelectCol.head, sortSelectCol.tail: _*)
 
   }

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
@@ -1,7 +1,7 @@
 package com.ebiznext.comet.job.metrics
 
 import com.ebiznext.comet.config.{DatasetArea, Settings}
-import com.ebiznext.comet.job.metrics.Metrics.{ContinuousMetric, DiscreteMetric}
+import com.ebiznext.comet.job.metrics.Metrics.{logger, ContinuousMetric, DiscreteMetric}
 import com.ebiznext.comet.schema.handlers.StorageHandler
 import com.ebiznext.comet.schema.model.{Domain, Schema, Stage}
 import com.ebiznext.comet.utils.SparkJob
@@ -235,6 +235,9 @@ class MetricsJob(
 
     val neededColList: List[Column] = listtotal.map(x => col(x))
 
+    logger.info(
+      "The liste of Columne: " + neededColList
+    )
     val coupleDataMetrics =
       List((discreteDataset, listDiscAttrName), (continuousDataset, listContAttrName))
 

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
@@ -1,7 +1,7 @@
 package com.ebiznext.comet.job.metrics
 
 import com.ebiznext.comet.config.{DatasetArea, Settings}
-import com.ebiznext.comet.job.metrics.Metrics.{logger, ContinuousMetric, DiscreteMetric}
+import com.ebiznext.comet.job.metrics.Metrics.{ContinuousMetric, DiscreteMetric}
 import com.ebiznext.comet.schema.handlers.StorageHandler
 import com.ebiznext.comet.schema.model.{Domain, Schema, Stage}
 import com.ebiznext.comet.utils.SparkJob
@@ -9,56 +9,6 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql._
 import org.apache.spark.sql.execution.streaming.FileStreamSource.Timestamp
 import org.apache.spark.sql.functions.{col, lit}
-
-/**
-  *
-  * @param domain                : Domain name
-  * @param schema                : Schema
-  * @param variableName          : Variable name from the attributes
-  * @param min                   : Min metric
-  * @param max                   : Max metric
-  * @param mean                  : Mean metric
-  * @param count                 : Count metric
-  * @param missingValues         : Missing Values metric
-  * @param variance              : Variance metric
-  * @param standardDev           : Standard deviation metric
-  * @param sum                   : Sum metric
-  * @param skewness              : Skewness metric
-  * @param kurtosis              : Kurtosis metric
-  * @param percentile25          : Percentile25 metric
-  * @param median                : Median metric
-  * @param percentile75          : Percentile75 metric
-  * @param category              : Category metric
-  * @param countDistinct         : Count Distinct metric
-  * @param countByCategory       : Count By Category metric
-  * @param frequencies           : Frequency metric
-  * @param missingValuesDiscrete : Missing Values Discrete metric
-  */
-case class MetricRow(
-  domain: String,
-  schema: String,
-  variableName: String,
-  min: Option[Double],
-  max: Option[Double],
-  mean: Option[Double],
-  count: Option[Long],
-  missingValues: Option[Long],
-  variance: Option[Double],
-  standardDev: Option[Double],
-  sum: Option[Double],
-  skewness: Option[Double],
-  kurtosis: Option[Double],
-  percentile25: Option[Double],
-  median: Option[Double],
-  percentile75: Option[Double],
-  category: Option[List[String]],
-  countDistinct: Option[Long],
-  countByCategory: Option[Map[String, Long]],
-  frequencies: Option[Map[String, Double]],
-  missingValuesDiscrete: Option[Long],
-  timestamp: Long,
-  stage: String
-)
 
 /** To record statistics with other information during ingestion.
   *
@@ -277,10 +227,8 @@ class MetricsJob(
     val continuousDataset: DataFrame =
       Metrics.computeContinuousMetric(dataUse, continAttrs, continuousOps)
 
-
     val allMetricsDf: DataFrame =
       unionDisContMetric(discreteDataset, continuousDataset, domain, schema, timestamp, stage)
-
 
     save(allMetricsDf, savePath)
     session

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
@@ -246,8 +246,8 @@ class MetricsJob(
         tupleDataMetric => generateFullMetric(tupleDataMetric._1, tupleDataMetric._2, neededColList)
       )
       .reduce(_ union _)
-      .withColumn("domain", lit(domain))
-      .withColumn("schema", lit(schema))
+      .withColumn("domain", lit(domain.name))
+      .withColumn("schema", lit(schema.name))
       .withColumn("ingestionTime", lit(ingestionTime))
       .withColumn("stageState", lit(stageState))
       .select(sortSelectCol.head, sortSelectCol.tail: _*)
@@ -276,6 +276,16 @@ class MetricsJob(
     val discreteDataset: DataFrame = Metrics.computeDiscretMetric(dataUse, discAttrs, discreteOps)
     val continuousDataset: DataFrame =
       Metrics.computeContinuousMetric(dataUse, continAttrs, continuousOps)
+
+    logger.info("The discret metrics: \n\n ")
+
+    discreteDataset.show()
+
+    logger.info("The Continuous metrics metrics: \n\n ")
+
+    continuousDataset.show()
+
+    logger.info("First's part done: \n\n ")
 
     val allMetricsDf: DataFrame =
       unionDisContMetric(discreteDataset, continuousDataset, domain, schema, timestamp, stage)

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
@@ -8,8 +8,8 @@ import com.ebiznext.comet.utils.SparkJob
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql._
 import org.apache.spark.sql.execution.streaming.FileStreamSource.Timestamp
-import org.apache.spark.sql.functions.col
-import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions.{col, lit}
+
 
 /**
   *
@@ -79,38 +79,20 @@ class MetricsJob(
   storageHandler: StorageHandler
 ) extends SparkJob {
 
-  /** Function that retrieves class names for each variable (case discrete variable)
+
+  override def name: String = "Compute metrics job"
+
+  /** Function to build the metrics save path
     *
-    * @param dataInit     : Dataframe that contains all the computed metrics
-    * @param nameVariable : name of the variable
-    * @return : list of all class associates to the variable
+    * @param path : path where metrics are stored
+    * @return : path where the metrics for the specified schema are stored
     */
-
-  def getListCategory(dataInit: DataFrame, nameVariable: String): List[String] = {
-    val dataReduceCategory: DataFrame = dataInit.filter(col("Variables").isin(nameVariable))
-    dataReduceCategory.select("Category").collect.map(_.getString(0)).toList
-
-  }
-
-  /**
-    * Gets the categorical metric as type T
-    *
-    * @param dataInit     :   Initial dataset
-    * @param nameVariable :   Name of the variable
-    * @param nameCategory :   Name of the category
-    * @param metric       :   Name of the metric to compute
-    * @tparam T :   Return type of the function
-    * @return :   T, Long for CountDiscrete and Double for Frequencies
-    */
-  def getCategoryMetric[T: Manifest](
-    dataInit: DataFrame,
-    nameVariable: String,
-    nameCategory: String,
-    metric: String
-  ): T = {
-    val dataReduceCategory: DataFrame = dataInit.filter(col("Variables").isin(nameVariable))
-    val dataCategory: DataFrame = dataReduceCategory.filter(col("Category").isin(nameCategory))
-    dataCategory.select(col(metric)).first().getAs[T](0)
+  def getMetricsPath(path: String): Path = {
+    new Path(
+      path
+        .replace("{domain}", domain.name)
+        .replace("{schema}", schema.name)
+    )
   }
 
   /**
@@ -148,205 +130,55 @@ class MetricsJob(
     }
   }
 
-  /**
-    * Function to get metric
+  /** Function that retrieves full metrics dataframe with both set discrete and continuous metrics
     *
-    * @param metric  : metric we're looking for
-    * @param colName : Column name
-    * @tparam T : Type of the metric value
-    * @return : Option of T either Double or Long depending on the metric.
+    * @param dataMetric : dataframe obtain from computeDiscretMetric( ) or computeContinuiousMetric( )
+    * @param listAttibutes : list of all variables
+    * @param colName  : list of column
+    * @return Dataframe : that contain the full metrics  with all variables and all metrics
     */
-  def getMetric[T: Manifest](metric: DataFrame, colName: String): Option[T] = {
-    metric.select("_metricType_").first().getString(0) match {
-      case "Continuous" => Some(metric.select(colName).first().getAs[T](0))
-      case _            => None
-    }
+
+  def generateFullMetric(dataMetric : DataFrame, listAttibutes: List[String], colName: List[Column]): DataFrame= {
+    listAttibutes.foldLeft(dataMetric){(data, nameCol) =>  data.withColumn(nameCol, lit(null) ) }.select(colName:_*)
+
   }
 
-  /** Function that get String type metric
+  /** Function Function that unifies discrete and continuous metrics dataframe, then write save the result to parquet
     *
-    * @param metric  : the dataset
-    * @param colName : the column name
-    * @return : the metric in Option type of List of String
-    */
-  def getMetricListStringType(metric: DataFrame, colName: String): Option[List[String]] = {
-    metric.select("_metricType_").first().getString(0) match {
-      case "Discrete" => Some(metric.select("Category").collect.map(_.getString(0)).toList)
-      case _          => None
-    }
-  }
-
-  /** Function that get countByCategory and frequencies metrics
-    *
-    * @param dfStatistics : the dataframe
-    * @param colName      : the column name
-    * @return : the metric in Option type of Map[String,A]
-    */
-  def getMetricCount[A](
-    dfStatistics: DataFrame,
-    colName: String,
-    threshold: Int,
-    metric: String,
-    f: (DataFrame, String, String, String) => A
-  ): Option[Map[String, A]] = {
-    dfStatistics.select("_metricType_").first().getString(0) match {
-      case "Discrete" if getListCategory(dfStatistics, colName).length - threshold < 0 =>
-        Some(
-          Map(
-            getListCategory(dfStatistics, colName)
-              .map(x => x -> f(dfStatistics, colName, x, metric)): _*
-          )
-        )
-      case _ => None
-    }
-  }
-
-  /** Function that get missingValuesDiscrete variable metric
-    *
-    * @param dfStatistics : the dataframe
-    * @param colName      : the column name
-    * @param threshold    : the threshold
-    * @return : the metric in Option type of Long
-    */
-  def getMetricCountMissValuesDiscrete(
-    dfStatistics: DataFrame,
-    colName: String,
-    threshold: Int
-  ): Option[Long] = {
-    dfStatistics.select("_metricType_").first().getString(0) match {
-      case "Discrete" if getListCategory(dfStatistics, colName).length - threshold < 0 =>
-        Some(
-          dfStatistics
-            .filter(col("Variables").isin(colName))
-            .select("CountMissValuesDiscrete")
-            .first()
-            .getLong(0)
-        )
-      case _ => None
-    }
-  }
-
-  /** Function that get countDistinct variable metric
-    *
-    * @param metric  : the dataframe
-    * @param colName : the column name
-    * @return : the metric in Option type of Int
-    */
-  def getMetricCountDistinct(metric: DataFrame, colName: String): Option[Long] = {
-    metric.select("_metricType_").first().getString(0) match {
-      case "Discrete" => Some(getListCategory(metric, colName).length)
-      case _          => None
-    }
-  }
-
-  /** Function that unify metric dataframes schemas on MetricRow case class, then write save the result to parquet
-    *
-    * @param listDfStats   : List of dataframes that contains metrics of each type (continuous and discrete)
-    * @param domain        : name of the domain
-    * @param schema        : schema of the initial data
+    * @param discreteDataset : dataframe that contains all the discrete metrics
+    * @param continuousDataset : dataframe that contains all the continuous metrics
+    * @param domain    : name of the domain
+    * @param schema    : schema of the initial data
     * @param ingestionTime : time which correspond to the ingestion
-    * @param stageState    : stage (unit / global)
-    * @param threshold     : The limit value for the number of sub-class to consider
+    * @param stageState   : stage (unit / global)
+    * @return
     */
-  def extractMetrics(
-    listDfStats: List[DataFrame],
-    domain: Domain,
-    schema: Schema,
-    ingestionTime: Timestamp,
-    stageState: Stage,
-    threshold: Int
-  ): DataFrame = {
 
-    listDfStats
-      .map { dfStatistics =>
-        val listVariable: List[String] = dfStatistics
-          .select("Variables")
-          .collect
-          .map(_.getString(0))
-          .toList
-          .distinct
-        val listRowByVariable = listVariable.map { c =>
-          val metric = dfStatistics.filter(col("Variables").isin(c))
-          MetricRow(
-            domain.name,
-            schema.name,
-            c,
-            getMetric[Double](metric, "Min"),
-            getMetric[Double](metric, "Max"),
-            getMetric[Double](metric, "Mean"),
-            getMetric[Long](metric, "Count"),
-            getMetric[Long](metric, "CountMissValues"),
-            getMetric[Double](metric, "Var"),
-            getMetric[Double](metric, "Stddev"),
-            getMetric[Double](metric, "Sum"),
-            getMetric[Double](metric, "Skewness"),
-            getMetric[Double](metric, "Kurtosis"),
-            getMetric[Double](metric, "Percentile25"),
-            getMetric[Double](metric, "Median"),
-            getMetric[Double](metric, "Percentile75"),
-            getMetricListStringType(metric, "Category"),
-            getMetricCountDistinct(dfStatistics, c),
-            getMetricCount[Long](
-              dfStatistics,
-              c,
-              threshold,
-              "CountDiscrete",
-              getCategoryMetric[Long]
-            ),
-            getMetricCount[Double](
-              dfStatistics,
-              c,
-              threshold,
-              "Frequencies",
-              getCategoryMetric[Double]
-            ),
-            getMetricCountMissValuesDiscrete(dfStatistics, c, threshold),
-            ingestionTime,
-            stageState
-          )
-        }
+  def unionDisContMetric( discreteDataset : DataFrame,
+                          continuousDataset : DataFrame,
+                          domain: Domain,
+                          schema: Schema,
+                          ingestionTime: Timestamp,
+                          stageState: Stage) : DataFrame= {
 
-        session.createDataFrame(listRowByVariable)
+    val listDiscAttrName: List[String] = List("min", "max", "mean", "count", "variance", "standardDev", "sum", "skewness", "kurtosis", "percentile25", "median", "percentile75", "missingValues")
+    val listContAttrName: List[String] = List("category", "countDistinct","countByCategory", "frequencies", "missingValuesDiscrete")
+    val listtotal: List[String] = List("variableName","min", "max", "mean", "count", "variance", "standardDev", "sum", "skewness", "kurtosis", "percentile25", "median", "percentile75", "missingValues","category", "countDistinct","countByCategory", "frequencies", "missingValuesDiscrete")
+    val sortSelectCol : List[String] = List("domain","schema","variableName","min","max", "mean", "count", "missingValues", "standardDev", "variance", "sum", "skewness", "kurtosis", "percentile25", "median", "percentile75", "category", "countDistinct", "countByCategory", "frequencies", "missingValuesDiscrete", "ingestionTime","stageState")
 
-      }
-      .reduce(_.union(_))
+    val neededColList: List[Column] = listtotal.map(x=> col(x) )
+
+
+    val coupleDataMetrics = List((discreteDataset,listDiscAttrName),(continuousDataset,listContAttrName))
+
+    coupleDataMetrics.map(tupleDataMetric => generateFullMetric(tupleDataMetric._1, tupleDataMetric._2, neededColList)).reduce(_ union _)
+      .withColumn("domain", lit(domain))
+      .withColumn("schema", lit(schema))
+      .withColumn("ingestionTime", lit(ingestionTime))
+      .withColumn("stageState", lit(stageState)).select(sortSelectCol.head, sortSelectCol.tail: _*)
+
   }
 
-  override def name: String = "Compute metrics job"
-
-  /** Function to build the metrics save path
-    *
-    * @param path : path where metrics are stored
-    * @return : path where the metrics for the specified schema are stored
-    */
-  def getMetricsPath(path: String): Path = {
-    new Path(
-      path
-        .replace("{domain}", domain.name)
-        .replace("{schema}", schema.name)
-    )
-  }
-
-  /** Function that enforce type on certain discrete metrics column to avoid types casts problems
-    * The types we enforce are the same as those in the case class MetricRow attributes.
-    *
-    * @param statsDf the dataframe we want to type
-    * @return typed dataframe
-    */
-  def discreteMetricTyping(statsDf: DataFrame): DataFrame = {
-    statsDf
-      .withColumn("Min", statsDf.col("Min").cast(DoubleType))
-      .withColumn("Max", statsDf.col("Max").cast(DoubleType))
-      .withColumn("Mean", statsDf.col("Mean").cast(DoubleType))
-      .withColumn("Var", statsDf.col("Var").cast(DoubleType))
-      .withColumn("Stddev", statsDf.col("Stddev").cast(DoubleType))
-      .withColumn("Sum", statsDf.col("Sum").cast(DoubleType))
-      .withColumn("Skewness", statsDf.col("Skewness").cast(DoubleType))
-      .withColumn("Kurtosis", statsDf.col("Kurtosis").cast(DoubleType))
-      .withColumn("Percentile25", statsDf.col("Percentile25").cast(DoubleType))
-      .withColumn("Median", statsDf.col("Median").cast(DoubleType))
-      .withColumn("Percentile75", statsDf.col("Percentile75").cast(DoubleType))
-  }
 
   /**
     * Just to force any spark job to implement its entry point using within the "run" method
@@ -367,19 +199,15 @@ class MetricsJob(
     val continuousOps: List[ContinuousMetric] = Metrics.continuousMetrics
     val savePath: Path = getMetricsPath(Settings.comet.metrics.path)
 
-    val discreteDataset =
-      Metrics.computeDiscretMetric(dataUse, discAttrs, discreteOps)
-    val continuousDataset =
-      discreteMetricTyping(Metrics.computeContinuousMetric(dataUse, continAttrs, continuousOps))
+    val discreteDataset = Metrics.computeDiscretMetric(dataUse, discAttrs, discreteOps)
+    val continuousDataset = Metrics.computeContinuousMetric(dataUse, continAttrs, continuousOps)
 
-    val allMetricsDf = extractMetrics(
-      List(discreteDataset, continuousDataset),
+
+    val allMetricsDf = unionDisContMetric(discreteDataset, continuousDataset,
       domain,
       schema,
       timestamp,
-      stage,
-      Settings.comet.metrics.discreteMaxCardinality
-    )
+      stage)
 
     save(allMetricsDf, savePath)
     session

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/StatDescJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/StatDescJobSpec.scala
@@ -1,12 +1,36 @@
 package com.ebiznext.comet.schema.handlers
 
-import com.ebiznext.comet.TestHelper
 import com.ebiznext.comet.job.metrics.Metrics
+import org.apache.log4j.{Level, Logger}
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions._
+import org.scalatest.FlatSpec
+
 import scala.reflect.runtime.universe._
 
-class StatDescJobSpec extends TestHelper {
+class StatDescJobSpec extends FlatSpec {
 
+  /**
+    * Custom Log Levels
+    */
+  Logger.getLogger("org").setLevel(Level.OFF)
+  Logger.getLogger("akka").setLevel(Level.OFF)
+  Logger.getLogger("org.apache.spark").setLevel(Level.OFF)
+
+  /**
+    * Spark configuration
+    */
+
+  val conf = new SparkConf() // set the configuration
+    .setAppName("Statistic Summary")
+    .setMaster("local[*]")
+
+  val spark = SparkSession // init sparksession
+    .builder
+    .config(conf)
+    .appName("readxlsx")
+    .getOrCreate()
 
   /** Function to get the Type
     *
@@ -36,7 +60,7 @@ class StatDescJobSpec extends TestHelper {
     *  Read the data .csv
     */
 
-  val dataInitialUsed = sparkSession.read
+  val dataInitialUsed = spark.read
     .format("csv")
     .option("header", "true") //reading the headers
     .option("mode", "DROPMALFORMED")

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/StatDescJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/StatDescJobSpec.scala
@@ -1,36 +1,12 @@
 package com.ebiznext.comet.schema.handlers
 
+import com.ebiznext.comet.TestHelper
 import com.ebiznext.comet.job.metrics.Metrics
-import org.apache.log4j.{Level, Logger}
-import org.apache.spark.SparkConf
-import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions._
-import org.scalatest.FlatSpec
-
 import scala.reflect.runtime.universe._
 
-class StatDescJobSpec extends FlatSpec {
+class StatDescJobSpec extends TestHelper {
 
-  /**
-    * Custom Log Levels
-    */
-  Logger.getLogger("org").setLevel(Level.OFF)
-  Logger.getLogger("akka").setLevel(Level.OFF)
-  Logger.getLogger("org.apache.spark").setLevel(Level.OFF)
-
-  /**
-    * Spark configuration
-    */
-
-  val conf = new SparkConf() // set the configuration
-    .setAppName("Statistic Summary")
-    .setMaster("local[*]")
-
-  val spark = SparkSession // init sparksession
-  .builder
-    .config(conf)
-    .appName("readxlsx")
-    .getOrCreate()
 
   /** Function to get the Type
     *
@@ -60,7 +36,7 @@ class StatDescJobSpec extends FlatSpec {
     *  Read the data .csv
     */
 
-  val dataInitialUsed = spark.read
+  val dataInitialUsed = sparkSession.read
     .format("csv")
     .option("header", "true") //reading the headers
     .option("mode", "DROPMALFORMED")


### PR DESCRIPTION
## Summary
Improve efficiency of the computation time of the discrete metrics.

**Related Issue: #36 **

**PR Type: Improvement**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
- use aggregation function in all discrete metrics function
- reduce the number of steps before saving  the results

### How has this been tested?
tested on Tafeng, Iris, Titanic , Yelp datasets

### Remaining Todos
* [ ] - add the threshold ( the number max of category of a dicrete variable)

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



