### PR TITLE
read format from job configuration file

### DIFF
--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -382,7 +382,7 @@ class IngestionWorkflow(
       val action = new AutoJob(
         job.name,
         job.getArea(),
-        Some("parquet"),
+        job.format,
         job.coalesce.getOrElse(false),
         job.udf,
         job.views,


### PR DESCRIPTION
## Summary
Read the output format of an AutoJob from the job configuration file

**PR Type: Bug Fix **

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
Use the AutoJobDesc.format property to set the forma of an AutoJob instead of hard coded 
`Some("parquet")`

### How has this been tested?
Local testing , no regression on Unit Tests


