### PR TITLE
BQLoad Fix: use job default fs instead of cluster system bucket

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
@@ -129,7 +129,7 @@ class BigQueryLoadJob(
     logger.info(s"BigQuery Config $cliConfig")
 
     val projectId = conf.get("fs.gs.project.id")
-    val bucket = conf.get("fs.gs.system.bucket")
+    val bucket = conf.get("fs.defaultFS")
 
     val bigqueryHelper = RemoteBigQueryHelper.create
     val bigquery = bigqueryHelper.getOptions.getService
@@ -187,7 +187,7 @@ class BigQueryLoadJob(
     val table = getOrCreateTable()
 
     Try {
-      val inputDataset = s"gs://$bucket${cliConfig.sourceFile}/*.parquet"
+      val inputDataset = s"$bucket${cliConfig.sourceFile}/*.parquet"
       logger.info(s"source ds: $inputDataset")
       logger.info(s"TableId: ${table.getTableId}")
 
@@ -202,8 +202,8 @@ class BigQueryLoadJob(
       job.waitFor()
 
       val stdTableDefinition =
-        bigquery.getTable(table.getTableId).getDefinition().asInstanceOf[StandardTableDefinition]
-      logger.info(s"Inserted ${stdTableDefinition.getNumRows} into BQ")
+        bigquery.getTable(table.getTableId).getDefinition.asInstanceOf[StandardTableDefinition]
+      logger.info(s"Inserted ${stdTableDefinition.getNumRows} rows into BQ")
 
       session
     }


### PR DESCRIPTION
## Summary
Fix issue : when hadoop fs.defaultFS and fs.gs.system.bucket have different values, no data is inserted into BigQuery

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
Fetch data from fs.defaultFS config value instead of that of fs.gs.system.bucket

### How has this been tested?
Ingest and BQ Load with a dataproc cluster with adhoc config

### Other changes

### Deploy Notes


### Remaining Todos

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



