### PR TITLE
fix race condition in the test SparkContext lifetime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
 language: scala
+jdk:
+  #- oraclejdk8
+  #- oraclejdk9
+  - openjdk8
+  - openjdk10
+  # Note: as of 2020-02-11, JDK11 doesn't work (ASM6 can't support bytecode version 55)
+  
 scala:
   - 2.11.12
+#  - 2.12.10
+# Note: as of 2020-02-11, this doesn't work under scala 2.12.10 — Jackson 2.9.5 incompatibility


### PR DESCRIPTION
## Summary
In certain scenarios (e.g. few-core machines, `sbt test` invocation on the command line with non-parallel exectution, etc;), Scalatest was unable to start and execute all test suites before the TestHelper#afterAll method starts getting called. 

As a result, certain Suites (TestHelper instances) were handed a closed SparkContext, which is illegal. 

This PR provides a lifetime-tracking machinery that serves to share the SparkContext across all simultaneously running TestHelper instances (saving memory), but also rebuilding a new SparkContext instance in case the previous had to be closed.

This PR changes no existing interface