### PR TITLE
[CDP-95] Fix test dataset race

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ src/test/resources/application.conf
 # Unix traditional
 *~
 ~*
+
+#Mac
+.DS_Store

--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,11 @@ organizationName := "Ebiznext"
 
 scalaVersion := scala211
 
+scalacOptions ++= Seq(
+  "-deprecation",
+  "-feature"
+)
+
 organizationHomepage := Some(url("http://www.ebiznext.com"))
 
 libraryDependencies := {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,11 +1,13 @@
+root = "/tmp"
+root = ${?COMET_ROOT}
 
-datasets = "/tmp/datasets"
+datasets = "${root}/datasets"
 datasets = ${?COMET_DATASETS}
 
-metadata = "/tmp/metadata"
+metadata = "${root}/metadata"
 metadata = ${?COMET_METADATA}
 
-tmpdir = "/tmp/comet_tmp"
+tmpdir = "${root}/comet_tmp"
 tmpdir = ${?COMET_TMPDIR}
 
 archive = true
@@ -41,7 +43,7 @@ chewer-prefix = "comet.chewer"
 chewer-prefix = ${?COMET_CHEWER_PREFIX}
 
 lock {
-  path = "/tmp/locks"
+  path = "${root}/locks"
   path = ${?COMET_LOCK_PATH}
 
   ingestion-timeout = -1
@@ -58,8 +60,8 @@ audit {
   active = true
   active = ${?COMET_AUDIT_ACTIVE}
 
-  #  path = "/tmp/metrics/{domain}/{schema}"
-  path = "/tmp/audit"
+  #  path = "${root}/metrics/{domain}/{schema}"
+  path = "${root}/audit"
   path = ${?COMET_AUDIT_PATH}
 
   audit-timeout = -1
@@ -80,8 +82,8 @@ metrics {
   active = false
   active = ${?COMET_METRICS_ACTIVE}
 
-  #  path = "/tmp/metrics/{domain}/{schema}"
-  path = "/tmp/metrics/{domain}"
+  #  path = "${root}/metrics/{domain}/{schema}"
+  path = "${root}/metrics/{domain}"
   path = ${?COMET_METRICS_PATH}
 
   discrete-max-cardinality = 10

--- a/src/main/scala/com/ebiznext/comet/config/DatasetArea.scala
+++ b/src/main/scala/com/ebiznext/comet/config/DatasetArea.scala
@@ -43,7 +43,7 @@ import org.apache.hadoop.fs.Path
   */
 object DatasetArea {
 
-  def path(domain: String, area: String)(implicit /* TODO: make me explicit */ settings: Settings) =
+  def path(domain: String, area: String)(implicit settings: Settings) =
     new Path(s"${settings.comet.datasets}/$area/$domain")
 
   def path(domainPath: Path, schema: String) = new Path(domainPath, schema)
@@ -54,7 +54,7 @@ object DatasetArea {
     * @param domain : Domain Name
     * @return Absolute path to the pending folder of domain
     */
-  def pending(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
+  def pending(domain: String)(implicit settings: Settings): Path =
     path(domain, settings.comet.area.pending)
 
   /**
@@ -64,7 +64,7 @@ object DatasetArea {
     * @param domain : Domain name
     * @return Absolute path to the pending unresolved folder of domain
     */
-  def unresolved(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
+  def unresolved(domain: String)(implicit settings: Settings): Path =
     path(domain, settings.comet.area.unresolved)
 
   /**
@@ -73,7 +73,7 @@ object DatasetArea {
     * @param domain : Domain name
     * @return Absolute path to the archive folder of domain
     */
-  def archive(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
+  def archive(domain: String)(implicit settings: Settings): Path =
     path(domain, settings.comet.area.archive)
 
   /**
@@ -82,7 +82,7 @@ object DatasetArea {
     * @param domain : Domain name
     * @return Absolute path to the ingesting folder of domain
     */
-  def ingesting(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
+  def ingesting(domain: String)(implicit settings: Settings): Path =
     path(domain, settings.comet.area.ingesting)
 
   /**
@@ -91,7 +91,7 @@ object DatasetArea {
     * @param domain : Domain name
     * @return Absolute path to the ingesting folder of domain
     */
-  def accepted(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
+  def accepted(domain: String)(implicit settings: Settings): Path =
     path(domain, settings.comet.area.accepted)
 
   /**
@@ -100,7 +100,7 @@ object DatasetArea {
     * @param domain : Domain name
     * @return Absolute path to the rejected folder of domain
     */
-  def rejected(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
+  def rejected(domain: String)(implicit settings: Settings): Path =
     path(domain, settings.comet.area.rejected)
 
   /**
@@ -109,22 +109,22 @@ object DatasetArea {
     * @param domain : Domain name
     * @return Absolute path to the business folder of domain
     */
-  def business(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
+  def business(domain: String)(implicit settings: Settings): Path =
     path(domain, settings.comet.area.business)
 
-  def metadata(implicit /* TODO: make me explicit */ settings: Settings): Path =
+  def metadata(implicit settings: Settings): Path =
     new Path(s"${settings.comet.metadata}")
 
-  def types(implicit /* TODO: make me explicit */ settings: Settings): Path =
+  def types(implicit settings: Settings): Path =
     new Path(metadata, "types")
 
-  def mapping(implicit /* TODO: make me explicit */ settings: Settings): Path =
+  def mapping(implicit settings: Settings): Path =
     new Path(metadata, "mapping")
 
-  def domains(implicit /* TODO: make me explicit */ settings: Settings): Path =
+  def domains(implicit settings: Settings): Path =
     new Path(metadata, "domains")
 
-  def jobs(implicit /* TODO: make me explicit */ settings: Settings): Path =
+  def jobs(implicit settings: Settings): Path =
     new Path(metadata, "jobs")
 
   /**
@@ -133,12 +133,12 @@ object DatasetArea {
     */
   def init(
     storage: StorageHandler
-  )(implicit /* TODO: make me explicit */ settings: Settings): Unit = {
+  )(implicit settings: Settings): Unit = {
     List(metadata, types, domains).foreach(storage.mkdirs)
   }
 
   def initDomains(storage: StorageHandler, domains: Iterable[String])(
-    implicit /* TODO: make me explicit */ settings: Settings
+    implicit settings: Settings
   ): Unit = {
     init(storage)
     domains.foreach { domain =>

--- a/src/main/scala/com/ebiznext/comet/config/DatasetArea.scala
+++ b/src/main/scala/com/ebiznext/comet/config/DatasetArea.scala
@@ -44,7 +44,7 @@ import org.apache.hadoop.fs.Path
 object DatasetArea {
 
   def path(domain: String, area: String)(implicit /* TODO: make me explicit */ settings: Settings) =
-    new Path(s"${Settings.comet.datasets}/$area/$domain")
+    new Path(s"${settings.comet.datasets}/$area/$domain")
 
   def path(domainPath: Path, schema: String) = new Path(domainPath, schema)
 
@@ -55,7 +55,7 @@ object DatasetArea {
     * @return Absolute path to the pending folder of domain
     */
   def pending(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
-    path(domain, Settings.comet.area.pending)
+    path(domain, settings.comet.area.pending)
 
   /**
     * datasets with a file name that could not match any schema file name pattern in the specified domain
@@ -65,7 +65,7 @@ object DatasetArea {
     * @return Absolute path to the pending unresolved folder of domain
     */
   def unresolved(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
-    path(domain, Settings.comet.area.unresolved)
+    path(domain, settings.comet.area.unresolved)
 
   /**
     * Once ingested datasets are archived in this folder.
@@ -74,7 +74,7 @@ object DatasetArea {
     * @return Absolute path to the archive folder of domain
     */
   def archive(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
-    path(domain, Settings.comet.area.archive)
+    path(domain, settings.comet.area.archive)
 
   /**
     * Datasets of the specified domain currently being ingested are located in this folder
@@ -83,7 +83,7 @@ object DatasetArea {
     * @return Absolute path to the ingesting folder of domain
     */
   def ingesting(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
-    path(domain, Settings.comet.area.ingesting)
+    path(domain, settings.comet.area.ingesting)
 
   /**
     * Valid records for datasets the specified domain are stored in this folder.
@@ -92,7 +92,7 @@ object DatasetArea {
     * @return Absolute path to the ingesting folder of domain
     */
   def accepted(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
-    path(domain, Settings.comet.area.accepted)
+    path(domain, settings.comet.area.accepted)
 
   /**
     * Invalid records and the reason why they have been rejected for the datasets of the specified domain are stored in this folder.
@@ -101,7 +101,7 @@ object DatasetArea {
     * @return Absolute path to the rejected folder of domain
     */
   def rejected(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
-    path(domain, Settings.comet.area.rejected)
+    path(domain, settings.comet.area.rejected)
 
   /**
     * Default target folder for autojobs applied to datasets in this domain
@@ -110,10 +110,10 @@ object DatasetArea {
     * @return Absolute path to the business folder of domain
     */
   def business(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
-    path(domain, Settings.comet.area.business)
+    path(domain, settings.comet.area.business)
 
   def metadata(implicit /* TODO: make me explicit */ settings: Settings): Path =
-    new Path(s"${Settings.comet.metadata}")
+    new Path(s"${settings.comet.metadata}")
 
   def types(implicit /* TODO: make me explicit */ settings: Settings): Path =
     new Path(metadata, "types")
@@ -162,16 +162,16 @@ object StorageArea {
 
   def fromString(value: String)(implicit settings: Settings): StorageArea = {
 
-    val rejected = Settings.comet.area.rejected.toLowerCase(Locale.ROOT)
-    val accepted = Settings.comet.area.accepted.toLowerCase(Locale.ROOT)
-    val business = Settings.comet.area.business.toLowerCase(Locale.ROOT)
+    val rejected = settings.comet.area.rejected.toLowerCase(Locale.ROOT)
+    val accepted = settings.comet.area.accepted.toLowerCase(Locale.ROOT)
+    val business = settings.comet.area.business.toLowerCase(Locale.ROOT)
 
     val lcValue = value.toLowerCase(Locale.ROOT)
 
     lcValue match {
-      case _ if lcValue == Settings.comet.area.rejectedFinal => StorageArea.rejected
-      case _ if lcValue == Settings.comet.area.acceptedFinal => StorageArea.accepted
-      case _ if lcValue == Settings.comet.area.businessFinal => StorageArea.business
+      case _ if lcValue == settings.comet.area.rejectedFinal => StorageArea.rejected
+      case _ if lcValue == settings.comet.area.acceptedFinal => StorageArea.accepted
+      case _ if lcValue == settings.comet.area.businessFinal => StorageArea.business
       case custom                                            => StorageArea.Custom(custom)
     }
   }

--- a/src/main/scala/com/ebiznext/comet/config/DatasetArea.scala
+++ b/src/main/scala/com/ebiznext/comet/config/DatasetArea.scala
@@ -20,11 +20,18 @@
 
 package com.ebiznext.comet.config
 
+import java.util.Locale
+
 import com.ebiznext.comet.schema.handlers.StorageHandler
-import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.{JsonGenerator, JsonParser}
 import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
-import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer}
+import com.fasterxml.jackson.databind.{
+  DeserializationContext,
+  JsonDeserializer,
+  JsonSerializer,
+  SerializerProvider
+}
 import org.apache.hadoop.fs.Path
 
 /**
@@ -36,7 +43,7 @@ import org.apache.hadoop.fs.Path
   */
 object DatasetArea {
 
-  def path(domain: String, area: String) =
+  def path(domain: String, area: String)(implicit /* TODO: make me explicit */ settings: Settings) =
     new Path(s"${Settings.comet.datasets}/$area/$domain")
 
   def path(domainPath: Path, schema: String) = new Path(domainPath, schema)
@@ -47,7 +54,8 @@ object DatasetArea {
     * @param domain : Domain Name
     * @return Absolute path to the pending folder of domain
     */
-  def pending(domain: String): Path = path(domain, Settings.comet.area.pending)
+  def pending(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
+    path(domain, Settings.comet.area.pending)
 
   /**
     * datasets with a file name that could not match any schema file name pattern in the specified domain
@@ -56,7 +64,7 @@ object DatasetArea {
     * @param domain : Domain name
     * @return Absolute path to the pending unresolved folder of domain
     */
-  def unresolved(domain: String): Path =
+  def unresolved(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
     path(domain, Settings.comet.area.unresolved)
 
   /**
@@ -65,7 +73,8 @@ object DatasetArea {
     * @param domain : Domain name
     * @return Absolute path to the archive folder of domain
     */
-  def archive(domain: String): Path = path(domain, Settings.comet.area.archive)
+  def archive(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
+    path(domain, Settings.comet.area.archive)
 
   /**
     * Datasets of the specified domain currently being ingested are located in this folder
@@ -73,7 +82,7 @@ object DatasetArea {
     * @param domain : Domain name
     * @return Absolute path to the ingesting folder of domain
     */
-  def ingesting(domain: String): Path =
+  def ingesting(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
     path(domain, Settings.comet.area.ingesting)
 
   /**
@@ -82,7 +91,7 @@ object DatasetArea {
     * @param domain : Domain name
     * @return Absolute path to the ingesting folder of domain
     */
-  def accepted(domain: String): Path =
+  def accepted(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
     path(domain, Settings.comet.area.accepted)
 
   /**
@@ -91,7 +100,7 @@ object DatasetArea {
     * @param domain : Domain name
     * @return Absolute path to the rejected folder of domain
     */
-  def rejected(domain: String): Path =
+  def rejected(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
     path(domain, Settings.comet.area.rejected)
 
   /**
@@ -100,24 +109,37 @@ object DatasetArea {
     * @param domain : Domain name
     * @return Absolute path to the business folder of domain
     */
-  def business(domain: String): Path =
+  def business(domain: String)(implicit /* TODO: make me explicit */ settings: Settings): Path =
     path(domain, Settings.comet.area.business)
 
-  val metadata: Path = new Path(s"${Settings.comet.metadata}")
-  val types: Path = new Path(metadata, "types")
-  val mapping: Path = new Path(metadata, "mapping")
-  val domains: Path = new Path(metadata, "domains")
-  val jobs: Path = new Path(metadata, "jobs")
+  def metadata(implicit /* TODO: make me explicit */ settings: Settings): Path =
+    new Path(s"${Settings.comet.metadata}")
+
+  def types(implicit /* TODO: make me explicit */ settings: Settings): Path =
+    new Path(metadata, "types")
+
+  def mapping(implicit /* TODO: make me explicit */ settings: Settings): Path =
+    new Path(metadata, "mapping")
+
+  def domains(implicit /* TODO: make me explicit */ settings: Settings): Path =
+    new Path(metadata, "domains")
+
+  def jobs(implicit /* TODO: make me explicit */ settings: Settings): Path =
+    new Path(metadata, "jobs")
 
   /**
     *
     * @param storage
     */
-  def init(storage: StorageHandler): Unit = {
+  def init(
+    storage: StorageHandler
+  )(implicit /* TODO: make me explicit */ settings: Settings): Unit = {
     List(metadata, types, domains).foreach(storage.mkdirs)
   }
 
-  def initDomains(storage: StorageHandler, domains: Iterable[String]): Unit = {
+  def initDomains(storage: StorageHandler, domains: Iterable[String])(
+    implicit /* TODO: make me explicit */ settings: Settings
+  ): Unit = {
     init(storage)
     domains.foreach { domain =>
       List(pending _, unresolved _, archive _, accepted _, rejected _, business _)
@@ -138,34 +160,70 @@ object DatasetArea {
   */
 object StorageArea {
 
-  def fromString(value: String): StorageArea = {
-    value.toLowerCase() match {
-      case Settings.comet.area.rejected => StorageArea.rejected
-      case Settings.comet.area.accepted => StorageArea.accepted
-      case Settings.comet.area.business => StorageArea.business
-      case custom                       => StorageArea(custom)
+  def fromString(value: String)(implicit settings: Settings): StorageArea = {
+
+    val rejected = Settings.comet.area.rejected.toLowerCase(Locale.ROOT)
+    val accepted = Settings.comet.area.accepted.toLowerCase(Locale.ROOT)
+    val business = Settings.comet.area.business.toLowerCase(Locale.ROOT)
+
+    val lcValue = value.toLowerCase(Locale.ROOT)
+
+    lcValue match {
+      case _ if lcValue == Settings.comet.area.rejectedFinal => StorageArea.rejected
+      case _ if lcValue == Settings.comet.area.acceptedFinal => StorageArea.accepted
+      case _ if lcValue == Settings.comet.area.businessFinal => StorageArea.business
+      case custom                                            => StorageArea.Custom(custom)
     }
   }
 
-  object rejected extends StorageArea(Settings.comet.area.rejected)
+  case object rejected extends StorageArea {
+    def value: String = "rejected"
+  }
+  case object accepted extends StorageArea {
+    def value: String = "accepted"
+  }
+  case object business extends StorageArea {
+    def value: String = "business"
+  }
 
-  object accepted extends StorageArea(Settings.comet.area.accepted)
-
-  object business extends StorageArea(Settings.comet.area.business)
+  final case class Custom(value: String) extends StorageArea
 
   def area(domain: String, area: StorageArea): String = s"${domain}_${area.value}"
 
 }
 
-class StorageAreaDeserializer extends JsonDeserializer[StorageArea] {
+final class StorageAreaSerializer extends JsonSerializer[StorageArea] {
+  override def serialize(
+    value: StorageArea,
+    gen: JsonGenerator,
+    serializers: SerializerProvider
+  ): Unit = {
+    val settings = serializers.getAttribute(classOf[Settings]).asInstanceOf[Settings]
+    require(settings != null, "the SerializationContext lacks a Settings instance")
+
+    val strValue = value match {
+      case StorageArea.accepted            => settings.comet.area.accepted
+      case StorageArea.rejected            => settings.comet.area.rejected
+      case StorageArea.business            => settings.comet.area.business
+      case StorageArea.Custom(customValue) => customValue
+    }
+
+    gen.writeString(strValue)
+  }
+}
+final class StorageAreaDeserializer extends JsonDeserializer[StorageArea] {
   override def deserialize(jp: JsonParser, ctx: DeserializationContext): StorageArea = {
+    val settings = ctx.getAttribute(classOf[Settings]).asInstanceOf[Settings]
+    require(settings != null, "the DeserializationContext lacks a Settings instance")
+
     val value = jp.readValueAs[String](classOf[String])
-    StorageArea.fromString(value)
+    StorageArea.fromString(value)(settings)
   }
 }
 
-@JsonSerialize(using = classOf[ToStringSerializer])
+@JsonSerialize(using = classOf[StorageAreaSerializer])
 @JsonDeserialize(using = classOf[StorageAreaDeserializer])
-sealed case class StorageArea(value: String) {
+sealed abstract class StorageArea {
+  def value: String
   override def toString: String = value
 }

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -181,12 +181,6 @@ object Settings extends StrictLogging {
     fileSystem: Option[String]
   ) extends Serializable {
 
-    @transient
-    lazy val launcherService: LaunchHandler = launcher match {
-      case "simple"  => new SimpleLauncher()
-      case "airflow" => new AirflowLauncher()
-    }
-
     @throws(classOf[ObjectStreamException])
     protected def writeReplace: AnyRef = {
       Comet.JsonWrapped(this)
@@ -240,6 +234,12 @@ object Settings extends StrictLogging {
   }
 }
 
+/**
+  * This class holds the current Comet settings and an assembly of reference instances for core, shared services
+  *
+  * SMELL: this may be the start of a Dependency Injection root (but at 2-3 objects, is DI justified? probably not
+  * quite yet) — cchepelov
+  */
 final case class Settings(comet: Settings.Comet) extends Serializable {
   def logger: Logger = Settings.loggerForCompanionInstances
 
@@ -256,5 +256,12 @@ final case class Settings(comet: Settings.Comet) extends Serializable {
       : Settings = this /* TODO: remove this once HdfsStorageHandler explicitly takes Settings or Settings.Comet in */
     new SchemaHandler(storageHandler)
   }
+
+  @transient
+  lazy val launcherService: LaunchHandler = comet.launcher match {
+    case "simple"  => new SimpleLauncher()
+    case "airflow" => new AirflowLauncher()
+  }
+
   def jobId: String = Settings.jobId
 }

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -214,10 +214,10 @@ object Settings extends StrictLogging {
   @deprecated("please use and pass on a Settings instance instead", "2020-02-25")
   def comet(implicit settings: Settings): Comet = settings.comet
 
-  @deprecated("please use and pass on a Settings instance instead", "2020-02-25")
+  @deprecated("please use and pass on a Settings instance instead", "2020-02-25") // ready to remove
   def storageHandler(implicit settings: Settings): HdfsStorageHandler = settings.storageHandler
 
-  @deprecated("please use and pass on a Settings instance instead", "2020-02-25")
+  @deprecated("please use and pass on a Settings instance instead", "2020-02-25") // ready to remove
   def schemaHandler(implicit settings: Settings): SchemaHandler = settings.schemaHandler
 
   def apply(

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -118,7 +118,10 @@ object Settings extends StrictLogging {
     ingestionTimeout: Long,
     @JsonSerialize(using = classOf[FiniteDurationSerializer])
     @JsonDeserialize(using = classOf[FiniteDurationDeserializer])
-    pollTime: FiniteDuration = FiniteDuration(5000L, TimeUnit.MILLISECONDS)
+    pollTime: FiniteDuration = FiniteDuration(5000L, TimeUnit.MILLISECONDS),
+    @JsonSerialize(using = classOf[FiniteDurationSerializer])
+    @JsonDeserialize(using = classOf[FiniteDurationDeserializer])
+    refreshTime: FiniteDuration = FiniteDuration(5000L, TimeUnit.MILLISECONDS)
   )
 
   final class FiniteDurationSerializer extends JsonSerializer[FiniteDuration] {

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -211,7 +211,7 @@ object Settings extends StrictLogging {
     }
   }
 
-  @deprecated("please use and pass on a Settings instance instead", "2020-02-25")
+  @deprecated("please use and pass on a Settings instance instead", "2020-02-25") // ready to remove
   def comet(implicit settings: Settings): Comet = settings.comet
 
   @deprecated("please use and pass on a Settings instance instead", "2020-02-25") // ready to remove

--- a/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
+++ b/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
@@ -34,8 +34,7 @@ import org.apache.spark.sql.SparkSession
   *
   * @param name : Cusom spark application name prefix. The current datetime is appended this the Spark Job name
   */
-class SparkEnv(name: String)(implicit /* TODO: make this explicit */ settings: Settings)
-    extends StrictLogging {
+class SparkEnv(name: String)(implicit settings: Settings) extends StrictLogging {
 
   /**
     * Load spark.* properties rom the application conf file

--- a/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
+++ b/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
@@ -72,7 +72,7 @@ class SparkEnv(name: String)(implicit /* TODO: make this explicit */ settings: S
     */
   lazy val session: SparkSession = {
     val session =
-      if (Settings.comet.hive)
+      if (settings.comet.hive)
         SparkSession.builder.config(config).enableHiveSupport().getOrCreate()
       else
         SparkSession.builder.config(config).getOrCreate()

--- a/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
+++ b/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
@@ -48,11 +48,12 @@ class SparkEnv(name: String) extends StrictLogging {
 
     thisConf.setAppName(appName)
 
-    import scala.collection.JavaConversions._
+    import scala.collection.JavaConverters._
     ConfigFactory
       .load()
       .getConfig("spark")
       .entrySet()
+      .asScala
       .map(x => (x.getKey, x.getValue.unwrapped().toString))
       .foreach {
         case (key, value) =>

--- a/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
+++ b/src/main/scala/com/ebiznext/comet/config/SparkEnv.scala
@@ -34,7 +34,8 @@ import org.apache.spark.sql.SparkSession
   *
   * @param name : Cusom spark application name prefix. The current datetime is appended this the Spark Job name
   */
-class SparkEnv(name: String) extends StrictLogging {
+class SparkEnv(name: String)(implicit /* TODO: make this explicit */ settings: Settings)
+    extends StrictLogging {
 
   /**
     * Load spark.* properties rom the application conf file

--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -90,13 +90,13 @@ object Main extends StrictLogging {
     */
   def main(args: Array[String]): Unit = {
     implicit val settings: Settings = Settings(ConfigFactory.load())
-    import Settings.{schemaHandler, storageHandler}
+    import settings.{schemaHandler, storageHandler, launcherService}
     DatasetArea.init(storageHandler)
 
     DatasetArea.initDomains(storageHandler, schemaHandler.domains.map(_.name))
 
     val workflow =
-      new IngestionWorkflow(storageHandler, schemaHandler, Settings.comet.launcherService)
+      new IngestionWorkflow(storageHandler, schemaHandler, launcherService)
 
     if (args.length == 0) printUsage()
 

--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -34,6 +34,7 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.hadoop.fs.Path
+import org.slf4j.MDC
 
 import scala.util.{Failure, Success, Try}
 
@@ -90,6 +91,8 @@ object Main extends StrictLogging {
     */
   def main(args: Array[String]): Unit = {
     implicit val settings: Settings = Settings(ConfigFactory.load())
+    settings.publishMDCData()
+
     import settings.{launcherService, schemaHandler, storageHandler}
     DatasetArea.init(storageHandler)
 

--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -31,6 +31,7 @@ import com.ebiznext.comet.workflow.IngestionWorkflow
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.hadoop.fs.Path
 
@@ -88,6 +89,7 @@ object Main extends StrictLogging {
     *             to compute all metrics on specific schema in a specific domain
     */
   def main(args: Array[String]): Unit = {
+    implicit val settings: Settings = Settings(ConfigFactory.load())
     import Settings.{schemaHandler, storageHandler}
     DatasetArea.init(storageHandler)
 

--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -90,7 +90,7 @@ object Main extends StrictLogging {
     */
   def main(args: Array[String]): Unit = {
     implicit val settings: Settings = Settings(ConfigFactory.load())
-    import settings.{schemaHandler, storageHandler, launcherService}
+    import settings.{launcherService, schemaHandler, storageHandler}
     DatasetArea.init(storageHandler)
 
     DatasetArea.initDomains(storageHandler, schemaHandler.domains.map(_.name))
@@ -120,9 +120,9 @@ object Main extends StrictLogging {
         val domain = arglist(1)
         val schema = arglist(2)
         val paths = arglist(3)
-        val lockPath = new Path(Settings.comet.lock.path, s"${domain}_${schema}.lock")
+        val lockPath = new Path(settings.comet.lock.path, s"${domain}_${schema}.lock")
         val locker = new FileLock(lockPath, storageHandler)
-        val waitTimeMillis = Settings.comet.lock.ingestionTimeout
+        val waitTimeMillis = settings.comet.lock.ingestionTimeout
         val ingestResult =
           if (locker.tryLock(waitTimeMillis)) {
             Try {

--- a/src/main/scala/com/ebiznext/comet/job/atlas/AtlasJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/atlas/AtlasJob.scala
@@ -33,10 +33,10 @@ class AtlasJob(
 
   def run(): Unit = {
     logger.info(s"")
-    val uris = cliConfig.uris.map(_.toArray).getOrElse(Array(Settings.comet.atlas.uri))
+    val uris = cliConfig.uris.map(_.toArray).getOrElse(Array(settings.comet.atlas.uri))
     val userPassword = (cliConfig.user, cliConfig.password) match {
       case (Some(user), Some(pwd)) => Array(user, pwd)
-      case _                       => Array(Settings.comet.atlas.user, Settings.comet.atlas.password)
+      case _                       => Array(settings.comet.atlas.user, settings.comet.atlas.password)
     }
     new AtlasModel(uris, userPassword).run(cliConfig, storageHandler)
   }

--- a/src/main/scala/com/ebiznext/comet/job/atlas/AtlasJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/atlas/AtlasJob.scala
@@ -28,7 +28,7 @@ import com.typesafe.scalalogging.StrictLogging
 class AtlasJob(
   cliConfig: AtlasConfig,
   storageHandler: StorageHandler
-)(implicit /* TODO: make me explicit */ settings: Settings)
+)(implicit settings: Settings)
     extends StrictLogging {
 
   def run(): Unit = {

--- a/src/main/scala/com/ebiznext/comet/job/atlas/AtlasJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/atlas/AtlasJob.scala
@@ -28,7 +28,8 @@ import com.typesafe.scalalogging.StrictLogging
 class AtlasJob(
   cliConfig: AtlasConfig,
   storageHandler: StorageHandler
-) extends StrictLogging {
+)(implicit /* TODO: make me explicit */ settings: Settings)
+    extends StrictLogging {
 
   def run(): Unit = {
     logger.info(s"")

--- a/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
@@ -13,7 +13,8 @@ import scala.util.{Failure, Success, Try}
 class BigQueryLoadJob(
   cliConfig: BigQueryLoadConfig,
   maybeSchema: scala.Option[BQSchema] = None
-) extends SparkJob {
+)(implicit /* TODO: make me explicit */ val settings: Settings)
+    extends SparkJob {
 
   override def name: String = s"bqload-${cliConfig.outputTable}"
 

--- a/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
@@ -13,7 +13,7 @@ import scala.util.{Failure, Success, Try}
 class BigQueryLoadJob(
   cliConfig: BigQueryLoadConfig,
   maybeSchema: scala.Option[BQSchema] = None
-)(implicit /* TODO: make me explicit */ val settings: Settings)
+)(implicit val settings: Settings)
     extends SparkJob {
 
   override def name: String = s"bqload-${cliConfig.outputTable}"

--- a/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
@@ -175,7 +175,7 @@ class BigQueryLoadJob(
     */
   override def run(): Try[SparkSession] = {
     val res =
-      if (Settings.comet.audit.active && Settings.comet.audit.index == "BQ")
+      if (settings.comet.audit.active && settings.comet.audit.index == "BQ")
         runBQSparkConnector()
       else
         Success(session)

--- a/src/main/scala/com/ebiznext/comet/job/index/IndexConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/IndexConfig.scala
@@ -37,7 +37,7 @@ case class IndexConfig(
   conf: Map[String, String] = Map()
 ) {
 
-  def getDataset(): Path = {
+  def getDataset()(implicit /* TODO: make me explicit */ settings: Settings): Path = {
     dataset.getOrElse {
       new Path(s"${Settings.comet.datasets}/${Settings.comet.area.accepted}/$domain/$schema")
     }

--- a/src/main/scala/com/ebiznext/comet/job/index/IndexConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/IndexConfig.scala
@@ -37,7 +37,7 @@ case class IndexConfig(
   conf: Map[String, String] = Map()
 ) {
 
-  def getDataset()(implicit /* TODO: make me explicit */ settings: Settings): Path = {
+  def getDataset()(implicit settings: Settings): Path = {
     dataset.getOrElse {
       new Path(s"${settings.comet.datasets}/${settings.comet.area.accepted}/$domain/$schema")
     }

--- a/src/main/scala/com/ebiznext/comet/job/index/IndexConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/IndexConfig.scala
@@ -39,7 +39,7 @@ case class IndexConfig(
 
   def getDataset()(implicit /* TODO: make me explicit */ settings: Settings): Path = {
     dataset.getOrElse {
-      new Path(s"${Settings.comet.datasets}/${Settings.comet.area.accepted}/$domain/$schema")
+      new Path(s"${settings.comet.datasets}/${settings.comet.area.accepted}/$domain/$schema")
     }
   }
 

--- a/src/main/scala/com/ebiznext/comet/job/index/IndexJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/IndexJob.scala
@@ -33,7 +33,8 @@ import scala.util.{Failure, Success, Try}
 class IndexJob(
   cliConfig: IndexConfig,
   storageHandler: StorageHandler
-) extends SparkJob {
+)(implicit /* TODO: make me explicit */ val settings: Settings)
+    extends SparkJob {
 
   val esresource = Some(("es.resource.write", s"${cliConfig.getResource()}"))
   val esId = cliConfig.id.map("es.mapping.id" -> _)

--- a/src/main/scala/com/ebiznext/comet/job/index/IndexJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/IndexJob.scala
@@ -57,9 +57,8 @@ class IndexJob(
           .json(path.toString)
 
       case "json-array" =>
-        val jsonRDD =
-          session.sparkContext.wholeTextFiles(path.toString).map(x => x._2)
-        session.read.json(jsonRDD)
+        val jsonDS = session.read.textFile(path.toString)
+        session.read.json(jsonDS)
 
       case "parquet" =>
         session.read.parquet(path.toString)

--- a/src/main/scala/com/ebiznext/comet/job/index/IndexJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/IndexJob.scala
@@ -76,7 +76,7 @@ class IndexJob(
 
     val content = cliConfig.mapping.map(storageHandler.read).getOrElse {
       val dynamicTemplate = for {
-        domain <- Settings.schemaHandler.getDomain(cliConfig.domain)
+        domain <- settings.schemaHandler.getDomain(cliConfig.domain)
         schema <- domain.schemas.find(_.name == cliConfig.schema)
       } yield schema.mapping(domain.mapping(schema), domain.name)
 

--- a/src/main/scala/com/ebiznext/comet/job/index/IndexJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/IndexJob.scala
@@ -89,7 +89,7 @@ class IndexJob(
 
     logger.info(s"Registering template ${cliConfig.domain}_${cliConfig.schema} -> $content")
     import scala.collection.JavaConverters._
-    val esOptions = Settings.comet.elasticsearch.options.asScala.toMap
+    val esOptions = settings.comet.elasticsearch.options.asScala.toMap
     val host: String = esOptions.getOrElse("es.nodes", "localhost")
     val port = esOptions.getOrElse("es.port", "9200").toInt
     val ssl = esOptions.getOrElse("es.net.ssl", "false").toBoolean

--- a/src/main/scala/com/ebiznext/comet/job/index/IndexJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/IndexJob.scala
@@ -33,7 +33,7 @@ import scala.util.{Failure, Success, Try}
 class IndexJob(
   cliConfig: IndexConfig,
   storageHandler: StorageHandler
-)(implicit /* TODO: make me explicit */ val settings: Settings)
+)(implicit val settings: Settings)
     extends SparkJob {
 
   val esresource = Some(("es.resource.write", s"${cliConfig.getResource()}"))

--- a/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/infer/InferSchemaJob.scala
@@ -22,6 +22,7 @@ package com.ebiznext.comet.job.infer
 
 import java.util.regex.Pattern
 
+import com.ebiznext.comet.config.{Settings, SparkEnv}
 import com.ebiznext.comet.schema.handlers.InferSchemaHandler
 import com.ebiznext.comet.schema.model.{Attribute, Domain}
 import com.ebiznext.comet.utils.SparkJob
@@ -44,16 +45,21 @@ class InferSchema(
   dataPath: String,
   savePath: String,
   header: Option[Boolean] = Some(false)
-) {
+)(implicit settings: Settings) {
 
-  InferSchemaJob.infer(domainName, schemaName, dataPath, savePath, header.getOrElse(false))
+  (new InferSchemaJob).infer(domainName, schemaName, dataPath, savePath, header.getOrElse(false))
 
 }
 
 /** *
   * Infers the schema of a given datapath, domain name, schema name.
   */
-object InferSchemaJob extends SparkJob {
+class InferSchemaJob(implicit settings: Settings) {
+
+  def name: String = "InferSchema"
+
+  private val sparkEnv: SparkEnv = new SparkEnv(name)
+  private val session: SparkSession = sparkEnv.session
 
   /**
     * Read file without specifying the format
@@ -175,8 +181,6 @@ object InferSchemaJob extends SparkJob {
     }
   }
 
-  override def name: String = "InferSchema"
-
   /**
     * Just to force any spark job to implement its entry point using within the "run" method
     *
@@ -230,11 +234,4 @@ object InferSchemaJob extends SparkJob {
 
     inferSchema.generateYaml(domain, savePath)
   }
-
-  /**
-    * Just to force any spark job to implement its entry point using within the "run" method
-    *
-    * @return : Spark Session used for the job
-    */
-  override def run(): Try[SparkSession] = Success(session)
 }

--- a/src/main/scala/com/ebiznext/comet/job/ingest/AuditLog.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/AuditLog.scala
@@ -92,7 +92,7 @@ object SparkAuditLogWriter {
   }
 
   def append(session: SparkSession, log: AuditLog)(
-    implicit /* TODO: make me explicit */ settings: Settings
+    implicit settings: Settings
   ) = {
     val lockPath = new Path(settings.comet.audit.path, s"audit.lock")
     val locker = new FileLock(lockPath, settings.storageHandler)

--- a/src/main/scala/com/ebiznext/comet/job/ingest/AuditLog.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/AuditLog.scala
@@ -91,7 +91,9 @@ object SparkAuditLogWriter {
     BQSchema.of(fields: _*)
   }
 
-  def append(session: SparkSession, log: AuditLog) = {
+  def append(session: SparkSession, log: AuditLog)(
+    implicit /* TODO: make me explicit */ settings: Settings
+  ) = {
     val lockPath = new Path(Settings.comet.audit.path, s"audit.lock")
     val locker = new FileLock(lockPath, Settings.storageHandler)
     import session.implicits._

--- a/src/main/scala/com/ebiznext/comet/job/ingest/AuditLog.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/AuditLog.scala
@@ -95,7 +95,7 @@ object SparkAuditLogWriter {
     implicit /* TODO: make me explicit */ settings: Settings
   ) = {
     val lockPath = new Path(Settings.comet.audit.path, s"audit.lock")
-    val locker = new FileLock(lockPath, Settings.storageHandler)
+    val locker = new FileLock(lockPath, settings.storageHandler)
     import session.implicits._
     if (Settings.comet.audit.active && locker.tryLock()) {
       val res = Try {

--- a/src/main/scala/com/ebiznext/comet/job/ingest/DsvIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/DsvIngestionJob.scala
@@ -23,6 +23,7 @@ package com.ebiznext.comet.job.ingest
 import java.sql.Timestamp
 import java.time.Instant
 
+import com.ebiznext.comet.config.Settings
 import com.ebiznext.comet.schema.handlers.StorageHandler
 import com.ebiznext.comet.schema.model.Rejection.{ColInfo, ColResult, RowInfo, RowResult}
 import com.ebiznext.comet.schema.model._
@@ -49,7 +50,8 @@ class DsvIngestionJob(
   val types: List[Type],
   val path: List[Path],
   val storageHandler: StorageHandler
-) extends IngestionJob {
+)(implicit val settings: Settings)
+    extends IngestionJob {
 
   /**
     *
@@ -227,7 +229,7 @@ object DsvIngestionUtil {
     attributes: List[Attribute],
     types: List[Type],
     sparkType: StructType
-  ): (RDD[String], RDD[Row]) = {
+  )(implicit settings: Settings): (RDD[String], RDD[Row]) = {
     val now = Timestamp.from(Instant.now)
     val checkedRDD: RDD[RowResult] = dataset.rdd.mapPartitions { partition =>
       partition.map { row: Row =>

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.{StringType, StructField, StructType, TimestampType}
 
 import scala.util.{Failure, Success, Try}
+import scala.language.existentials
 
 /**
   *

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -427,7 +427,7 @@ object IngestionUtil {
     domainName: String,
     schemaName: String,
     now: Timestamp
-  ): (DataFrame, Path) = {
+  )(implicit /* TODO: make me explicit */ settings: Settings): (DataFrame, Path) = {
     import session.implicits._
     val rejectedPath = new Path(DatasetArea.rejected(domainName), schemaName)
     val rejectedPathName = rejectedPath.toString
@@ -466,6 +466,8 @@ object IngestionUtil {
     colRawValue: String,
     colAttribute: Attribute,
     tpe: Type
+  )(
+    implicit /* TODO: make me explicit. Avoid rebuilding the PrivacyLevel(settings) at each invocation? */ settings: Settings
   ): ColResult = {
     def ltrim(s: String) = s.replaceAll("^\\s+", "")
     def rtrim(s: String) = s.replaceAll("\\s+$", "")

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -359,7 +359,7 @@ trait IngestionJob extends SparkJob {
               )
               val end = Timestamp.from(Instant.now())
               val log = AuditLog(
-                Settings.jobId,
+                s"${settings.comet.jobId}",
                 inputFiles,
                 domain.name,
                 schema.name,
@@ -379,7 +379,7 @@ trait IngestionJob extends SparkJob {
             val end = Timestamp.from(Instant.now())
             val err = Utils.exceptionAsString(exception)
             AuditLog(
-              Settings.jobId,
+              s"${settings.comet.jobId}",
               path.map(_.toString).mkString(","),
               domain.name,
               schema.name,
@@ -431,7 +431,7 @@ object IngestionUtil {
     import session.implicits._
     val rejectedPath = new Path(DatasetArea.rejected(domainName), schemaName)
     val rejectedPathName = rejectedPath.toString
-    val jobid = Settings.jobId
+    val jobid = s"${settings.comet.jobId}"
     val rejectedTypedRDD = rejectedRDD.map { err =>
       (jobid, now, domainName, schemaName, err, rejectedPathName)
     }

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -124,7 +124,7 @@ trait IngestionJob extends SparkJob {
           domain = domain.name,
           schema = schema.name
         )
-        new IndexJob(config, Settings.storageHandler).run()
+        new IndexJob(config, settings.storageHandler).run()
       case Some(IndexSink.BQ) =>
         val (createDisposition: String, writeDisposition: String) = Utils.getBQDisposition(
           meta.getWriteMode()

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -427,7 +427,7 @@ object IngestionUtil {
     domainName: String,
     schemaName: String,
     now: Timestamp
-  )(implicit /* TODO: make me explicit */ settings: Settings): (DataFrame, Path) = {
+  )(implicit settings: Settings): (DataFrame, Path) = {
     import session.implicits._
     val rejectedPath = new Path(DatasetArea.rejected(domainName), schemaName)
     val rejectedPathName = rejectedPath.toString

--- a/src/main/scala/com/ebiznext/comet/job/ingest/JsonIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/JsonIngestionJob.scala
@@ -20,7 +20,7 @@
 
 package com.ebiznext.comet.job.ingest
 
-import com.ebiznext.comet.config.{DatasetArea, StorageArea}
+import com.ebiznext.comet.config.{DatasetArea, Settings, StorageArea}
 import com.ebiznext.comet.schema.handlers.StorageHandler
 import com.ebiznext.comet.schema.model._
 import org.apache.hadoop.fs.Path
@@ -47,7 +47,8 @@ class JsonIngestionJob(
   val types: List[Type],
   val path: List[Path],
   val storageHandler: StorageHandler
-) extends IngestionJob {
+)(implicit val settings: Settings)
+    extends IngestionJob {
 
   /**
     * load the json as an RDD of String

--- a/src/main/scala/com/ebiznext/comet/job/ingest/PositionIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/PositionIngestionJob.scala
@@ -20,6 +20,7 @@
 
 package com.ebiznext.comet.job.ingest
 
+import com.ebiznext.comet.config.Settings
 import com.ebiznext.comet.schema.handlers.StorageHandler
 import com.ebiznext.comet.schema.model._
 import org.apache.hadoop.fs.Path
@@ -44,7 +45,8 @@ class PositionIngestionJob(
   types: List[Type],
   path: List[Path],
   storageHandler: StorageHandler
-) extends DsvIngestionJob(domain, schema, types, path, storageHandler) {
+)(implicit settings: Settings)
+    extends DsvIngestionJob(domain, schema, types, path, storageHandler) {
 
   /**
     * Load dataset using spark csv reader and all metadata. Does not infer schema.

--- a/src/main/scala/com/ebiznext/comet/job/ingest/SimpleJsonIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/SimpleJsonIngestionJob.scala
@@ -20,6 +20,7 @@
 
 package com.ebiznext.comet.job.ingest
 
+import com.ebiznext.comet.config.Settings
 import com.ebiznext.comet.schema.handlers.StorageHandler
 import com.ebiznext.comet.schema.model._
 import org.apache.hadoop.fs.Path
@@ -44,7 +45,8 @@ class SimpleJsonIngestionJob(
   types: List[Type],
   path: List[Path],
   storageHandler: StorageHandler
-) extends DsvIngestionJob(domain, schema, types, path, storageHandler) {
+)(implicit settings: Settings)
+    extends DsvIngestionJob(domain, schema, types, path, storageHandler) {
 
   override def loadDataSet(): Try[DataFrame] = {
     try {

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
@@ -29,7 +29,8 @@ class MetricsJob(
   schema: Schema,
   stage: Stage,
   storageHandler: StorageHandler
-) extends SparkJob {
+)(implicit val settings: Settings)
+    extends SparkJob {
 
   override def name: String = "Compute metrics job"
 

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
@@ -49,7 +49,7 @@ class MetricsJob(
 
   def getLockPath(path: String): Path = {
     new Path(
-      Settings.comet.lock.path,
+      settings.comet.lock.path,
       "metrics" + path
         .replace("{domain}", domain.name)
         .replace("{schema}", schema.name)
@@ -319,7 +319,7 @@ root
     logger.info("Continuous Attributes -> " + continAttrs.mkString(","))
     val discreteOps: List[DiscreteMetric] = Metrics.discreteMetrics
     val continuousOps: List[ContinuousMetric] = Metrics.continuousMetrics
-    val savePath: Path = getMetricsPath(Settings.comet.metrics.path)
+    val savePath: Path = getMetricsPath(settings.comet.metrics.path)
     val count = dataUse.count()
     val discreteDataset = Metrics.computeDiscretMetric(dataUse, discAttrs, discreteOps)
     val continuousDataset = Metrics.computeContinuousMetric(dataUse, continAttrs, continuousOps)
@@ -333,8 +333,8 @@ root
         timestamp,
         stage
       )
-    val lockPath = getLockPath(Settings.comet.metrics.path)
-    val waitTimeMillis = Settings.comet.lock.metricsTimeout
+    val lockPath = getLockPath(settings.comet.metrics.path)
+    val waitTimeMillis = settings.comet.lock.metricsTimeout
     val locker = new FileLock(lockPath, storageHandler)
     val metricsResult = if (locker.tryLock(waitTimeMillis)) {
       Try(allMetricsDf.foreach(allMetricsDf => save(allMetricsDf, savePath)))

--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
@@ -49,7 +49,8 @@ class AutoTask(
   views: Option[Map[String, String]],
   task: AutoTaskDesc,
   storageHandler: StorageHandler
-) extends SparkJob {
+)(implicit val settings: Settings)
+    extends SparkJob {
 
   def run(): Try[SparkSession] = {
     udf.foreach { udf =>

--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
@@ -55,7 +55,11 @@ class AutoTask(
   def run(): Try[SparkSession] = {
     udf.foreach { udf =>
       val udfInstance: UdfRegistration =
-        Class.forName(udf).newInstance.asInstanceOf[UdfRegistration]
+        Class
+          .forName(udf)
+          .getDeclaredConstructor(Seq.empty: _*)
+          .newInstance()
+          .asInstanceOf[UdfRegistration]
       udfInstance.register(session)
     }
     views.getOrElse(Map()).foreach {

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -39,7 +39,7 @@ object InferSchemaHandler {
     */
   def createAttributes(
     schema: StructType
-  )(implicit /* TODO: make me explicit */ settings: Settings): List[Attribute] = {
+  )(implicit settings: Settings): List[Attribute] = {
     schema
       .map(
         row =>
@@ -154,7 +154,7 @@ object InferSchemaHandler {
     * @param savePath path to save files.
     */
   def generateYaml(domain: Domain, savePath: String)(
-    implicit /* TODO: make me explicit */ settings: Settings
+    implicit settings: Settings
   ): Unit = {
     val obj = settings.storageHandler.read(new Path(savePath))
     val objw = new StringWriter()

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -52,8 +52,7 @@ object InferSchemaHandler {
                 row.dataType.typeName,
                 Some(false),
                 !row.nullable,
-                attributes = Some(createAttributes(row.dataType.asInstanceOf[StructType])),
-                settings = settings
+                attributes = Some(createAttributes(row.dataType.asInstanceOf[StructType]))
               )
 
             case "array" =>
@@ -66,8 +65,7 @@ object InferSchemaHandler {
                   elemType.typeName,
                   Some(true),
                   !row.nullable,
-                  attributes = Some(createAttributes(elemType.asInstanceOf[StructType])),
-                  settings = settings
+                  attributes = Some(createAttributes(elemType.asInstanceOf[StructType]))
                 )
               else
                 // if it is a regular array. {ages: [21, 25]}
@@ -75,9 +73,7 @@ object InferSchemaHandler {
                   row.name,
                   elemType.typeName,
                   Some(true),
-                  !row.nullable,
-                  settings = settings
-                )
+                  !row.nullable)
 
             // if the datatype is a simple Attribute
             case _ =>
@@ -85,9 +81,7 @@ object InferSchemaHandler {
                 row.name,
                 row.dataType.typeName,
                 Some(false),
-                !row.nullable,
-                settings = settings
-              )
+                !row.nullable)
         }
       )
       .toList

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -69,19 +69,11 @@ object InferSchemaHandler {
                 )
               else
                 // if it is a regular array. {ages: [21, 25]}
-                Attribute(
-                  row.name,
-                  elemType.typeName,
-                  Some(true),
-                  !row.nullable)
+                Attribute(row.name, elemType.typeName, Some(true), !row.nullable)
 
             // if the datatype is a simple Attribute
             case _ =>
-              Attribute(
-                row.name,
-                row.dataType.typeName,
-                Some(false),
-                !row.nullable)
+              Attribute(row.name, row.dataType.typeName, Some(false), !row.nullable)
         }
       )
       .toList

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -37,7 +37,9 @@ object InferSchemaHandler {
     * @param schema Schema so that we find all Attributes
     * @return List of Attributes
     */
-  def createAttributes(schema: StructType): List[Attribute] = {
+  def createAttributes(
+    schema: StructType
+  )(implicit /* TODO: make me explicit */ settings: Settings): List[Attribute] = {
     schema
       .map(
         row =>
@@ -50,7 +52,8 @@ object InferSchemaHandler {
                 row.dataType.typeName,
                 Some(false),
                 !row.nullable,
-                attributes = Some(createAttributes(row.dataType.asInstanceOf[StructType]))
+                attributes = Some(createAttributes(row.dataType.asInstanceOf[StructType])),
+                settings = settings
               )
 
             case "array" =>
@@ -63,14 +66,28 @@ object InferSchemaHandler {
                   elemType.typeName,
                   Some(true),
                   !row.nullable,
-                  attributes = Some(createAttributes(elemType.asInstanceOf[StructType]))
+                  attributes = Some(createAttributes(elemType.asInstanceOf[StructType])),
+                  settings = settings
                 )
               else
                 // if it is a regular array. {ages: [21, 25]}
-                Attribute(row.name, elemType.typeName, Some(true), !row.nullable)
+                Attribute(
+                  row.name,
+                  elemType.typeName,
+                  Some(true),
+                  !row.nullable,
+                  settings = settings
+                )
 
             // if the datatype is a simple Attribute
-            case _ => Attribute(row.name, row.dataType.typeName, Some(false), !row.nullable)
+            case _ =>
+              Attribute(
+                row.name,
+                row.dataType.typeName,
+                Some(false),
+                !row.nullable,
+                settings = settings
+              )
         }
       )
       .toList
@@ -150,7 +167,9 @@ object InferSchemaHandler {
     * @param domain   Domain case class
     * @param savePath path to save files.
     */
-  def generateYaml(domain: Domain, savePath: String): Unit = {
+  def generateYaml(domain: Domain, savePath: String)(
+    implicit /* TODO: make me explicit */ settings: Settings
+  ): Unit = {
     val obj = Settings.storageHandler.read(new Path(savePath))
     val objw = new StringWriter()
     objw.write(obj)

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -156,7 +156,7 @@ object InferSchemaHandler {
   def generateYaml(domain: Domain, savePath: String)(
     implicit /* TODO: make me explicit */ settings: Settings
   ): Unit = {
-    val obj = Settings.storageHandler.read(new Path(savePath))
+    val obj = settings.storageHandler.read(new Path(savePath))
     val objw = new StringWriter()
     objw.write(obj)
     Main.mapper.writeValue(objw, domain)

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/LaunchHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/LaunchHandler.scala
@@ -45,7 +45,9 @@ trait LaunchHandler {
     * @param path   : absolute path where the source dataset  (JSON / CSV / ...) is located
     * @return success / failure
     */
-  def ingest(workflow: IngestionWorkflow, domain: Domain, schema: Schema, path: Path): Boolean =
+  def ingest(workflow: IngestionWorkflow, domain: Domain, schema: Schema, path: Path)(
+    implicit /* TODO: make me explicit */ settings: Settings
+  ): Boolean =
     ingest(workflow, domain, schema, path :: Nil)
 
   /**
@@ -62,21 +64,25 @@ trait LaunchHandler {
     domain: Domain,
     schema: Schema,
     paths: List[Path]
-  ): Boolean
+  )(implicit /* TODO: make me explicit */ settings: Settings): Boolean
 
   /**
     * Index into elasticsearch
     *
     * @param config
     */
-  def index(workflow: IngestionWorkflow, config: IndexConfig): Boolean
+  def index(workflow: IngestionWorkflow, config: IndexConfig)(
+    implicit /* TODO: make me explicit */ settings: Settings
+  ): Boolean
 
   /**
     * Load to BigQuery
     *
     * @param config
     */
-  def bqload(workflow: IngestionWorkflow, config: BigQueryLoadConfig): Boolean
+  def bqload(workflow: IngestionWorkflow, config: BigQueryLoadConfig)(
+    implicit /* TODO: make me explicit */ settings: Settings
+  ): Boolean
 }
 
 /**
@@ -98,7 +104,7 @@ class SimpleLauncher extends LaunchHandler with StrictLogging {
     domain: Domain,
     schema: Schema,
     paths: List[Path]
-  ): Boolean = {
+  )(implicit /* TODO: make me explicit */ settings: Settings): Boolean = {
     logger.info(s"Launch Ingestion: ${domain.name} ${schema.name} $paths ")
     workflow.ingest(domain.name, schema.name, paths)
     true
@@ -109,7 +115,9 @@ class SimpleLauncher extends LaunchHandler with StrictLogging {
     *
     * @param config
     */
-  override def index(workflow: IngestionWorkflow, config: IndexConfig): Boolean = {
+  override def index(workflow: IngestionWorkflow, config: IndexConfig)(
+    implicit /* TODO: make me explicit */ settings: Settings
+  ): Boolean = {
     logger.info(s"Launch index: ${config}")
     workflow.index(config)
     true
@@ -120,7 +128,9 @@ class SimpleLauncher extends LaunchHandler with StrictLogging {
     *
     * @param config
     */
-  override def bqload(workflow: IngestionWorkflow, config: BigQueryLoadConfig): Boolean = {
+  override def bqload(workflow: IngestionWorkflow, config: BigQueryLoadConfig)(
+    implicit /* TODO: make me explicit */ settings: Settings
+  ): Boolean = {
     logger.info(s"Launch bq: ${config}")
     workflow.bqload(config)
     true
@@ -172,7 +182,7 @@ class AirflowLauncher extends LaunchHandler with StrictLogging {
     domain: Domain,
     schema: Schema,
     paths: List[Path]
-  ): Boolean = {
+  )(implicit /* TODO: make me explicit */ settings: Settings): Boolean = {
     val endpoint = Settings.comet.airflow.endpoint
     val ingest = Settings.comet.airflow.ingest
     val url = s"$endpoint/dags/$ingest/dag_runs"
@@ -189,7 +199,9 @@ class AirflowLauncher extends LaunchHandler with StrictLogging {
     *
     * @param config
     */
-  override def index(workflow: IngestionWorkflow, config: IndexConfig): Boolean = {
+  override def index(workflow: IngestionWorkflow, config: IndexConfig)(
+    implicit /* TODO: make me explicit */ settings: Settings
+  ): Boolean = {
     val endpoint = Settings.comet.airflow.endpoint
     val url = s"$endpoint/dags/comet_index/dag_runs"
     // comet index --domain domain --schema schema --resource index-name/type-name --id type-id --mapping mapping
@@ -214,7 +226,9 @@ class AirflowLauncher extends LaunchHandler with StrictLogging {
     *
     * @param config
     */
-  override def bqload(workflow: IngestionWorkflow, config: BigQueryLoadConfig): Boolean = {
+  override def bqload(workflow: IngestionWorkflow, config: BigQueryLoadConfig)(
+    implicit /* TODO: make me explicit */ settings: Settings
+  ): Boolean = {
     val endpoint = Settings.comet.airflow.endpoint
     val url = s"$endpoint/dags/comet_bqload/dag_runs"
     val params = List(

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/LaunchHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/LaunchHandler.scala
@@ -183,8 +183,8 @@ class AirflowLauncher extends LaunchHandler with StrictLogging {
     schema: Schema,
     paths: List[Path]
   )(implicit /* TODO: make me explicit */ settings: Settings): Boolean = {
-    val endpoint = Settings.comet.airflow.endpoint
-    val ingest = Settings.comet.airflow.ingest
+    val endpoint = settings.comet.airflow.endpoint
+    val ingest = settings.comet.airflow.ingest
     val url = s"$endpoint/dags/$ingest/dag_runs"
     val command =
       s"""ingest ${domain.name} ${schema.name} ${paths.mkString(",")}"""
@@ -202,7 +202,7 @@ class AirflowLauncher extends LaunchHandler with StrictLogging {
   override def index(workflow: IngestionWorkflow, config: IndexConfig)(
     implicit /* TODO: make me explicit */ settings: Settings
   ): Boolean = {
-    val endpoint = Settings.comet.airflow.endpoint
+    val endpoint = settings.comet.airflow.endpoint
     val url = s"$endpoint/dags/comet_index/dag_runs"
     // comet index --domain domain --schema schema --resource index-name/type-name --id type-id --mapping mapping
     //    --format parquet|json|json-array --dataset datasetPath
@@ -229,7 +229,7 @@ class AirflowLauncher extends LaunchHandler with StrictLogging {
   override def bqload(workflow: IngestionWorkflow, config: BigQueryLoadConfig)(
     implicit /* TODO: make me explicit */ settings: Settings
   ): Boolean = {
-    val endpoint = Settings.comet.airflow.endpoint
+    val endpoint = settings.comet.airflow.endpoint
     val url = s"$endpoint/dags/comet_bqload/dag_runs"
     val params = List(
       s"--source_file ${config.sourceFile}",

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/LaunchHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/LaunchHandler.scala
@@ -46,7 +46,7 @@ trait LaunchHandler {
     * @return success / failure
     */
   def ingest(workflow: IngestionWorkflow, domain: Domain, schema: Schema, path: Path)(
-    implicit /* TODO: make me explicit */ settings: Settings
+    implicit settings: Settings
   ): Boolean =
     ingest(workflow, domain, schema, path :: Nil)
 
@@ -64,7 +64,7 @@ trait LaunchHandler {
     domain: Domain,
     schema: Schema,
     paths: List[Path]
-  )(implicit /* TODO: make me explicit */ settings: Settings): Boolean
+  )(implicit settings: Settings): Boolean
 
   /**
     * Index into elasticsearch
@@ -72,7 +72,7 @@ trait LaunchHandler {
     * @param config
     */
   def index(workflow: IngestionWorkflow, config: IndexConfig)(
-    implicit /* TODO: make me explicit */ settings: Settings
+    implicit settings: Settings
   ): Boolean
 
   /**
@@ -81,7 +81,7 @@ trait LaunchHandler {
     * @param config
     */
   def bqload(workflow: IngestionWorkflow, config: BigQueryLoadConfig)(
-    implicit /* TODO: make me explicit */ settings: Settings
+    implicit settings: Settings
   ): Boolean
 }
 
@@ -104,7 +104,7 @@ class SimpleLauncher extends LaunchHandler with StrictLogging {
     domain: Domain,
     schema: Schema,
     paths: List[Path]
-  )(implicit /* TODO: make me explicit */ settings: Settings): Boolean = {
+  )(implicit settings: Settings): Boolean = {
     logger.info(s"Launch Ingestion: ${domain.name} ${schema.name} $paths ")
     workflow.ingest(domain.name, schema.name, paths)
     true
@@ -116,7 +116,7 @@ class SimpleLauncher extends LaunchHandler with StrictLogging {
     * @param config
     */
   override def index(workflow: IngestionWorkflow, config: IndexConfig)(
-    implicit /* TODO: make me explicit */ settings: Settings
+    implicit settings: Settings
   ): Boolean = {
     logger.info(s"Launch index: ${config}")
     workflow.index(config)
@@ -129,7 +129,7 @@ class SimpleLauncher extends LaunchHandler with StrictLogging {
     * @param config
     */
   override def bqload(workflow: IngestionWorkflow, config: BigQueryLoadConfig)(
-    implicit /* TODO: make me explicit */ settings: Settings
+    implicit settings: Settings
   ): Boolean = {
     logger.info(s"Launch bq: ${config}")
     workflow.bqload(config)
@@ -182,7 +182,7 @@ class AirflowLauncher extends LaunchHandler with StrictLogging {
     domain: Domain,
     schema: Schema,
     paths: List[Path]
-  )(implicit /* TODO: make me explicit */ settings: Settings): Boolean = {
+  )(implicit settings: Settings): Boolean = {
     val endpoint = settings.comet.airflow.endpoint
     val ingest = settings.comet.airflow.ingest
     val url = s"$endpoint/dags/$ingest/dag_runs"
@@ -200,7 +200,7 @@ class AirflowLauncher extends LaunchHandler with StrictLogging {
     * @param config
     */
   override def index(workflow: IngestionWorkflow, config: IndexConfig)(
-    implicit /* TODO: make me explicit */ settings: Settings
+    implicit settings: Settings
   ): Boolean = {
     val endpoint = settings.comet.airflow.endpoint
     val url = s"$endpoint/dags/comet_index/dag_runs"
@@ -227,7 +227,7 @@ class AirflowLauncher extends LaunchHandler with StrictLogging {
     * @param config
     */
   override def bqload(workflow: IngestionWorkflow, config: BigQueryLoadConfig)(
-    implicit /* TODO: make me explicit */ settings: Settings
+    implicit settings: Settings
   ): Boolean = {
     val endpoint = settings.comet.airflow.endpoint
     val url = s"$endpoint/dags/comet_bqload/dag_runs"

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
@@ -20,22 +20,47 @@
 
 package com.ebiznext.comet.schema.handlers
 
-import com.ebiznext.comet.config.DatasetArea
+import com.ebiznext.comet.config.{DatasetArea, Settings}
 import com.ebiznext.comet.schema.model._
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.annotation.JsonIgnoreType
+import com.fasterxml.jackson.databind.{InjectableValues, ObjectMapper}
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.ser.DefaultSerializerProvider
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import org.apache.hadoop.fs.Path
+
+object SchemaHandler {
+
+  // https://github.com/FasterXML/jackson-databind/issues/962
+  @JsonIgnoreType
+  private class MixinsForObjectMapper
+
+}
 
 /**
   * Handles access to datasets metadata,  eq. domains / types / schemas.
   *
   * @param storage : Underlying filesystem manager
   */
-class SchemaHandler(storage: StorageHandler) {
+class SchemaHandler(storage: StorageHandler)(implicit settings: Settings) {
+
   // uses Jackson YAML for parsing, relies on SnakeYAML for low level handling
-  val mapper: ObjectMapper = new ObjectMapper(new YAMLFactory())
-  mapper.registerModule(DefaultScalaModule)
+  val mapper: ObjectMapper with ScalaObjectMapper = {
+    val mapper = new ObjectMapper(new YAMLFactory()) with ScalaObjectMapper
+    mapper.registerModule(DefaultScalaModule)
+    mapper.registerModule(
+      new SimpleModule()
+        .setMixInAnnotation(classOf[ObjectMapper], classOf[SchemaHandler.MixinsForObjectMapper])
+    )
+    mapper.setInjectableValues({
+      val iv = new InjectableValues.Std()
+      iv.addValue(classOf[Settings], settings)
+      iv: InjectableValues
+    })
+    mapper
+  }
 
   /**
     * All defined types.

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
@@ -81,7 +81,7 @@ trait StorageHandler extends StrictLogging {
   * HDFS Filesystem Handler
   */
 class HdfsStorageHandler(fileSystem: Option[String])(
-  implicit /* TODO: make me explicit */ settings: Settings
+  implicit settings: Settings
 ) extends StorageHandler {
 
   val conf = new Configuration()

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
@@ -105,7 +105,7 @@ class HdfsStorageHandler(fileSystem: Option[String])(
 
   normalizedFileSystem.foreach(fs => conf.set("fs.defaultFS", fs))
   import scala.collection.JavaConverters._
-  Settings.comet.hadoop.asScala.toMap.foreach {
+  settings.comet.hadoop.asScala.toMap.foreach {
     case (k, v) =>
       conf.set(k, v)
   }

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
@@ -76,7 +76,9 @@ trait StorageHandler extends StrictLogging {
 /**
   * HDFS Filesystem Handler
   */
-class HdfsStorageHandler(fileSystem: Option[String]) extends StorageHandler {
+class HdfsStorageHandler(fileSystem: Option[String])(
+  implicit /* TODO: make me explicit */ settings: Settings
+) extends StorageHandler {
 
   val conf = new Configuration()
   conf.set(

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
@@ -71,6 +71,7 @@ trait StorageHandler extends StrictLogging {
   def touch(path: Path): Try[Unit]
 
   def lockAcquisitionPollTime: FiniteDuration
+  def lockRefreshPollTime: FiniteDuration
 
   def unzip(source: Path, targetDir: Path): Try[Unit]
 
@@ -102,6 +103,7 @@ class HdfsStorageHandler(fileSystem: Option[String])(
   }
 
   override def lockAcquisitionPollTime: FiniteDuration = settings.comet.lock.pollTime
+  override def lockRefreshPollTime: FiniteDuration = settings.comet.lock.refreshTime
 
   normalizedFileSystem.foreach(fs => conf.set("fs.defaultFS", fs))
   import scala.collection.JavaConverters._

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
@@ -30,6 +30,7 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
 import org.apache.spark.sql.execution.streaming.FileStreamSource.Timestamp
 
+import scala.concurrent.duration.FiniteDuration
 import scala.util.Try
 
 /**
@@ -69,6 +70,8 @@ trait StorageHandler extends StrictLogging {
 
   def touch(path: Path): Try[Unit]
 
+  def lockAcquisitionPollTime: FiniteDuration
+
   def unzip(source: Path, targetDir: Path): Try[Unit]
 
 }
@@ -97,6 +100,8 @@ class HdfsStorageHandler(fileSystem: Option[String])(
         fs
     }
   }
+
+  override def lockAcquisitionPollTime: FiniteDuration = settings.comet.lock.pollTime
 
   normalizedFileSystem.foreach(fs => conf.set("fs.defaultFS", fs))
   import scala.collection.JavaConverters._

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/package.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/package.scala
@@ -21,6 +21,7 @@
 package com.ebiznext.comet.schema
 
 import org.apache.hadoop.fs.RemoteIterator
+import scala.language.implicitConversions
 
 package object handlers {
 

--- a/src/main/scala/com/ebiznext/comet/schema/model/AutoJobDesc.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/AutoJobDesc.scala
@@ -20,7 +20,7 @@
 
 package com.ebiznext.comet.schema.model
 
-import com.ebiznext.comet.config.{DatasetArea, StorageArea}
+import com.ebiznext.comet.config.{DatasetArea, Settings, StorageArea}
 import com.fasterxml.jackson.annotation.JsonIgnore
 import org.apache.hadoop.fs.Path
 
@@ -52,7 +52,7 @@ case class AutoTaskDesc(
   @JsonIgnore
   def getIndexSink(): Option[IndexSink] = index
 
-  def getTargetPath(defaultArea: StorageArea): Path = {
+  def getTargetPath(defaultArea: StorageArea)(implicit settings: Settings): Path = {
     val targetArea = area.getOrElse(defaultArea)
     new Path(DatasetArea.path(domain, targetArea.value), dataset)
   }

--- a/src/main/scala/com/ebiznext/comet/schema/model/Domain.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Domain.scala
@@ -70,7 +70,9 @@ case class Domain(
     *         that will be replaced by the schema attributes dynamically
     *         computed mappings
     */
-  def mapping(schema: Schema): Option[String] = {
+  def mapping(
+    schema: Schema
+  )(implicit /* TODO: make me explicit */ settings: Settings): Option[String] = {
     val template = new Path(new Path(DatasetArea.mapping, this.name), schema.name + ".json")
     if (Settings.storageHandler.exists(template))
       Some(Settings.storageHandler.read(template))
@@ -104,7 +106,9 @@ case class Domain(
     *
     * @return
     */
-  def checkValidity(): Either[List[String], Boolean] = {
+  def checkValidity()(
+    implicit /* TODO: make me explicit */ settings: Settings
+  ): Either[List[String], Boolean] = {
     val errorList: mutable.MutableList[String] = mutable.MutableList.empty
 
     // Check Domain name validity

--- a/src/main/scala/com/ebiznext/comet/schema/model/Domain.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Domain.scala
@@ -74,8 +74,8 @@ case class Domain(
     schema: Schema
   )(implicit /* TODO: make me explicit */ settings: Settings): Option[String] = {
     val template = new Path(new Path(DatasetArea.mapping, this.name), schema.name + ".json")
-    if (Settings.storageHandler.exists(template))
-      Some(Settings.storageHandler.read(template))
+    if (settings.storageHandler.exists(template))
+      Some(settings.storageHandler.read(template))
     else
       None
   }
@@ -133,7 +133,7 @@ case class Domain(
 
     // TODO Validate directory
     val inputDir = new Path(this.directory)
-    if (!Settings.storageHandler.exists(inputDir)) {
+    if (!settings.storageHandler.exists(inputDir)) {
       errorList += s"$directory not found"
     }
     if (errorList.nonEmpty)

--- a/src/main/scala/com/ebiznext/comet/schema/model/Domain.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Domain.scala
@@ -72,7 +72,7 @@ case class Domain(
     */
   def mapping(
     schema: Schema
-  )(implicit /* TODO: make me explicit */ settings: Settings): Option[String] = {
+  )(implicit settings: Settings): Option[String] = {
     val template = new Path(new Path(DatasetArea.mapping, this.name), schema.name + ".json")
     if (settings.storageHandler.exists(template))
       Some(settings.storageHandler.read(template))
@@ -107,7 +107,7 @@ case class Domain(
     * @return
     */
   def checkValidity()(
-    implicit /* TODO: make me explicit */ settings: Settings
+    implicit settings: Settings
   ): Either[List[String], Boolean] = {
     val errorList: mutable.MutableList[String] = mutable.MutableList.empty
 

--- a/src/main/scala/com/ebiznext/comet/schema/model/Metadata.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Metadata.scala
@@ -26,6 +26,7 @@ import com.ebiznext.comet.schema.model.WriteMode.APPEND
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer, JsonNode}
+import scala.language.postfixOps
 
 /**
   * Specify Schema properties.

--- a/src/main/scala/com/ebiznext/comet/schema/model/PrivacyLevel.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/PrivacyLevel.scala
@@ -20,7 +20,10 @@
 
 package com.ebiznext.comet.schema.model
 
+import java.util.Locale
+
 import com.ebiznext.comet.config.Settings
+import com.ebiznext.comet.schema.model.PrivacyLevel.getClass
 import com.ebiznext.comet.utils.Encryption
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
@@ -40,29 +43,48 @@ import scala.reflect.runtime.universe
 sealed case class PrivacyLevel(value: String) {
   override def toString: String = value
 
-  def encrypt(s: String): String = PrivacyLevel.all(value)._1.encrypt(s)
+  def encrypt(s: String)(implicit /* TODO: make me explicit */ settings: Settings): String =
+    PrivacyLevel.ForSettings(settings).all(value)._1.encrypt(s)
 
 }
 
 object PrivacyLevel {
-  lazy val all = Settings.comet.privacy.options.asScala.map {
-    case (k, objName) =>
+
+  case class ForSettings(settings: Settings) {
+
+    private def make(schemeName: String, encryptionObject: String): Encryption = {
       val runtimeMirror = universe.runtimeMirror(getClass.getClassLoader)
-      val module = runtimeMirror.staticModule(objName)
+      val module = runtimeMirror.staticModule(encryptionObject)
       val obj: universe.ModuleMirror = runtimeMirror.reflectModule(module)
       val encryption = obj.instance.asInstanceOf[Encryption]
-      (k.toUpperCase(), (encryption, new PrivacyLevel(k.toUpperCase())))
+      encryption
+
+    }
+
+    def get(schemeName: String): Encryption = {
+      val encryptionObject = settings.comet.privacy.options.asScala(schemeName)
+      make(schemeName, encryptionObject)
+    }
+
+    lazy val all = settings.comet.privacy.options.asScala.map {
+      case (k, objName) =>
+        val encryption = make(k, objName)
+        val key = k.toUpperCase(Locale.ROOT)
+        (key, (encryption, new PrivacyLevel(key)))
+    }
+
+    // Improve Scan performance
+    def fromString(value: String): PrivacyLevel = all(value.toUpperCase())._2
+
   }
 
-  // Improve Scan performance
-  lazy val None = all("NONE")._2
-
-  def fromString(value: String): PrivacyLevel = all(value.toUpperCase())._2
+  val None: PrivacyLevel = PrivacyLevel("NONE")
 }
 
 class PrivacyLevelDeserializer extends JsonDeserializer[PrivacyLevel] {
+
   override def deserialize(jp: JsonParser, ctx: DeserializationContext): PrivacyLevel = {
     val value = jp.readValueAs[String](classOf[String])
-    PrivacyLevel.fromString(value)
+    PrivacyLevel(value.toUpperCase(Locale.ROOT)) /* TODO: prior to 2020-02-25 we enforced a valid PrivacyLevel at deser time */
   }
 }

--- a/src/main/scala/com/ebiznext/comet/schema/model/PrivacyLevel.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/PrivacyLevel.scala
@@ -43,7 +43,7 @@ import scala.reflect.runtime.universe
 sealed case class PrivacyLevel(value: String) {
   override def toString: String = value
 
-  def encrypt(s: String)(implicit /* TODO: make me explicit */ settings: Settings): String =
+  def encrypt(s: String)(implicit settings: Settings): String =
     PrivacyLevel.ForSettings(settings).all(value)._1.encrypt(s)
 
 }

--- a/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
@@ -218,7 +218,7 @@ case class Schema(
          |      },
          |
          |"properties": {
-         |£ATTRIBUTES£
+         |__ATTRIBUTES__
          |}
          |    }
          |  }

--- a/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
@@ -192,8 +192,7 @@ case class Schema(
   def continuousAttrs()(implicit settings: Settings): List[Attribute] =
     attributes.filter(_.getMetricType() == MetricType.CONTINUOUS)
 
-  def mapping(template: Option[String], domainName: String)
-             (implicit settings: Settings): String = {
+  def mapping(template: Option[String], domainName: String)(implicit settings: Settings): String = {
     val attrs = attributes.map(_.mapping()).mkString(",")
     val properties =
       s"""

--- a/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
@@ -23,6 +23,7 @@ package com.ebiznext.comet.schema.model
 import java.util.regex.Pattern
 
 import com.ebiznext.comet.config.Settings
+import com.ebiznext.comet.utils.TextSubstitutionEngine
 import com.google.cloud.bigquery.{Field, LegacySQLTypeName}
 import org.apache.spark.sql.types._
 
@@ -200,7 +201,9 @@ case class Schema(
          |$attrs
          |}""".stripMargin
 
-    template.getOrElse {
+    val tse = TextSubstitutionEngine("PROPERTIES" -> properties, "ATTRIBUTES" -> attrs)
+
+    tse.apply(template.getOrElse {
       s"""
          |{
          |  "index_patterns": ["${domainName}_$name", "${domainName}_$name-*"],
@@ -213,12 +216,14 @@ case class Schema(
          |      "_source": {
          |        "enabled": true
          |      },
-         |__PROPERTIES__
+         |
+         |"properties": {
+         |£ATTRIBUTES£
+         |}
          |    }
          |  }
-         |}""".stripMargin.replace("__PROPERTIES__", properties)
-    }
-
+         |}""".stripMargin
+    })
   }
 
   def mergedMetadata(domainMetadata: Option[Metadata]): Metadata = {

--- a/src/main/scala/com/ebiznext/comet/schema/model/atlas/AtlasModel.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/atlas/AtlasModel.scala
@@ -433,7 +433,7 @@ class AtlasModel(urls: Array[String], basicAuthUsernamePassword: Array[String])
       Array(dom.name),
       dom.name,
       dom.comment.getOrElse(""),
-      Settings.comet.atlas.owner,
+      settings.comet.atlas.owner,
       dom.directory,
       dom.metadata,
       dom.extensions.map(_.toArray),

--- a/src/main/scala/com/ebiznext/comet/utils/FileLock.scala
+++ b/src/main/scala/com/ebiznext/comet/utils/FileLock.scala
@@ -21,7 +21,7 @@ import scala.util.{Failure, Success}
   * @param storageHandler Filesystem Handler
   */
 class FileLock(path: Path, storageHandler: StorageHandler) extends StrictLogging {
-  val checkinPeriod = 5000L
+  def checkinPeriod: Long = storageHandler.lockAcquisitionPollTime.toMillis
   val fileWatcher = new LockWatcher(path, storageHandler, checkinPeriod)
 
   /**

--- a/src/main/scala/com/ebiznext/comet/utils/SparkJob.scala
+++ b/src/main/scala/com/ebiznext/comet/utils/SparkJob.scala
@@ -1,6 +1,6 @@
 package com.ebiznext.comet.utils
 
-import com.ebiznext.comet.config.SparkEnv
+import com.ebiznext.comet.config.{Settings, SparkEnv}
 import com.ebiznext.comet.schema.model.Metadata
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.spark.sql.functions._
@@ -14,6 +14,8 @@ import scala.util.Try
   */
 trait SparkJob extends StrictLogging {
   def name: String
+  implicit def settings: Settings /* TODO: make me explicit */
+
   lazy val sparkEnv: SparkEnv = new SparkEnv(name)
   lazy val session: SparkSession = sparkEnv.session
 

--- a/src/main/scala/com/ebiznext/comet/utils/TextSubstitutionEngine.scala
+++ b/src/main/scala/com/ebiznext/comet/utils/TextSubstitutionEngine.scala
@@ -7,7 +7,7 @@ import scala.annotation.tailrec
   * substitution in a way that is more reliable and faster than applying a sequence of [[String#replace]]
   * operations.
   *
-  * The default start and end variable separators are £ and £, respectively, but can be configured to be
+  * The default start and end variable separators are \_\_ and \_\_, respectively, but can be configured to be
   * anything suitable.
   */
 final class TextSubstitutionEngine private (
@@ -49,7 +49,7 @@ final class TextSubstitutionEngine private (
                 case Some(substitutionValue) =>
                   buffer.append(sourceContent.substring(start, index))
                   buffer.append(substitutionValue)
-                  val nextEvent = sourceContent.indexOf("£", index + patternEnd.length)
+                  val nextEvent = sourceContent.indexOf("__", index + patternEnd.length)
                   recursiveApply(buffer, nextIndex + patternEnd.length, nextEvent)
               }
           }
@@ -59,8 +59,8 @@ final class TextSubstitutionEngine private (
     /* we don't use fileContent.replace(pattern1, value1).replace(pattern2, value2) etc. as:
        1. String#replace internally compiles a regex (!)
        2. it is difficult to manage priorities between patterns and what happens if one pattern match overlaps another
-       (e.g if we have ££COMET_TEST_ROOT££ in the resource file, the correct output is £COMET_TEST_ROOT£ not
-       £/tmp/foobar/£)
+       (e.g if we have ____COMET_TEST_ROOT____ in the resource file, the correct output is __COMET_TEST_ROOT__ not
+       __/tmp/foobar/__)
      */
 
     val firstEvent = sourceContent.indexOf(patternStart)
@@ -74,8 +74,8 @@ final class TextSubstitutionEngine private (
 }
 
 object TextSubstitutionEngine {
-  val DefaultSubstitutionPatternStart = "£"
-  val DefaultSubstitutionPatternEnd = "£"
+  val DefaultSubstitutionPatternStart = "__"
+  val DefaultSubstitutionPatternEnd = "__"
 
   def apply(
     patternStart: String,

--- a/src/main/scala/com/ebiznext/comet/utils/TextSubstitutionEngine.scala
+++ b/src/main/scala/com/ebiznext/comet/utils/TextSubstitutionEngine.scala
@@ -1,0 +1,96 @@
+package com.ebiznext.comet.utils
+
+import scala.annotation.tailrec
+
+/**
+  * This class provides a basic text substitution engine, suitable for performing basic variable
+  * substitution in a way that is more reliable and faster than applying a sequence of [[String#replace]]
+  * operations.
+  *
+  * The default start and end variable separators are £ and £, respectively, but can be configured to be
+  * anything suitable.
+  */
+final class TextSubstitutionEngine private (
+  substitutions: Map[String, String],
+  patternStart: String,
+  patternEnd: String
+) {
+
+  /**
+    * perform variable substitutions on a piece of text content
+    * @param sourceContent
+    * @return sourceContent after performing substitutions
+    */
+  def apply(sourceContent: String): String = {
+    @tailrec
+    def recursiveApply(buffer: StringBuilder, start: Int, nextEvent: Int): String = {
+      sourceContent.indexOf(patternStart, start) match {
+        case -1 =>
+          /* this is it, we're done! */
+          buffer.append(sourceContent.substring(start))
+          buffer.toString()
+
+        case index =>
+          val endIndex = sourceContent.indexOf(patternEnd, index + patternStart.length)
+          endIndex match {
+            case -1 =>
+              throw new IllegalArgumentException(
+                s"at position ${index}, unclosed ${patternStart}substitution${patternEnd}\n   in fileContent=${sourceContent}"
+              )
+
+            case nextIndex =>
+              val substitutionName = sourceContent.substring(index + patternStart.length, nextIndex)
+              substitutions.get(substitutionName) match {
+                case None =>
+                  throw new IllegalArgumentException(
+                    s"at position ${index}, unknown substitution ${patternStart}${substitutionName}${patternEnd}\n   in fileContent=${sourceContent}"
+                  )
+
+                case Some(substitutionValue) =>
+                  buffer.append(sourceContent.substring(start, index))
+                  buffer.append(substitutionValue)
+                  val nextEvent = sourceContent.indexOf("£", index + patternEnd.length)
+                  recursiveApply(buffer, nextIndex + patternEnd.length, nextEvent)
+              }
+          }
+      }
+    }
+
+    /* we don't use fileContent.replace(pattern1, value1).replace(pattern2, value2) etc. as:
+       1. String#replace internally compiles a regex (!)
+       2. it is difficult to manage priorities between patterns and what happens if one pattern match overlaps another
+       (e.g if we have ££COMET_TEST_ROOT££ in the resource file, the correct output is £COMET_TEST_ROOT£ not
+       £/tmp/foobar/£)
+     */
+
+    val firstEvent = sourceContent.indexOf(patternStart)
+    if (firstEvent < 0) {
+      sourceContent /* NO substitution — break here immediately */
+    } else {
+      val result = recursiveApply(new StringBuilder, 0, firstEvent)
+      result
+    }
+  }
+}
+
+object TextSubstitutionEngine {
+  val DefaultSubstitutionPatternStart = "£"
+  val DefaultSubstitutionPatternEnd = "£"
+
+  def apply(
+    patternStart: String,
+    patternEnd: String,
+    variables: Seq[(String, String)]
+  ): TextSubstitutionEngine =
+    new TextSubstitutionEngine(variables.toMap + ("" -> ""), patternStart, patternEnd)
+
+  /**
+    * This is the default constructor, where one supplies variable substitutions
+    * @param variables any number of variable substitutions to be performed.
+    * @return a [[TextSubstitutionEngine]] configured with default substitution pattern start and ends.
+    *
+    * @note recursive variable substitution is not performed.
+    */
+  def apply(variables: (String, String)*): TextSubstitutionEngine =
+    apply(DefaultSubstitutionPatternStart, DefaultSubstitutionPatternEnd, variables)
+}

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -186,7 +186,7 @@ class IngestionWorkflow(
             ingestingPath
           }
           try {
-            if (Settings.comet.grouped)
+            if (settings.comet.grouped)
               launchHandler.ingest(this, domain, schema, ingestingPaths.toList)
             else
               ingestingPaths.foreach(launchHandler.ingest(this, domain, schema, _))
@@ -272,7 +272,7 @@ class IngestionWorkflow(
           .run()
       case CHEW =>
         ChewerJob.run(
-          s"${Settings.comet.chewerPrefix}.${domain.name}.${schema.name}",
+          s"${settings.comet.chewerPrefix}.${domain.name}.${schema.name}",
           domain,
           schema,
           schemaHandler.types,
@@ -285,7 +285,7 @@ class IngestionWorkflow(
     })
     ingestionResult match {
       case Success(_) =>
-        if (Settings.comet.archive) {
+        if (settings.comet.archive) {
           ingestingPath.foreach { ingestingPath =>
             val archivePath =
               new Path(DatasetArea.archive(domain.name), ingestingPath.getName)
@@ -358,7 +358,7 @@ class IngestionWorkflow(
       action.run() match {
         case Success(_) =>
           task.getIndexSink() match {
-            case Some(IndexSink.ES) if Settings.comet.elasticsearch.active =>
+            case Some(IndexSink.ES) if settings.comet.elasticsearch.active =>
               index(job, task)
             case Some(IndexSink.BQ) =>
               val (createDisposition, writeDisposition) = Utils.getBQDisposition(task.write)

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -408,7 +408,7 @@ class IngestionWorkflow(
   def metric(cliConfig: MetricsConfig): Unit = {
     //Lookup for the domain given as prompt arguments, if is found then find the given schema in this domain
     val cmdArgs = for {
-      domain <- Settings.schemaHandler.getDomain(cliConfig.domain)
+      domain <- settings.schemaHandler.getDomain(cliConfig.domain)
       schema <- domain.schemas.find(_.name == cliConfig.schema)
     } yield (domain, schema)
 

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -71,7 +71,7 @@ class IngestionWorkflow(
   def loadLanding(): Unit = {
     logger.info("LoadLanding")
     domains.foreach { domain =>
-      val storageHandler = Settings.storageHandler
+      val storageHandler = settings.storageHandler
       val inputDir = new Path(domain.directory)
       logger.info(s"Scanning $inputDir")
       storageHandler.list(inputDir, domain.getAck()).foreach { path =>
@@ -386,7 +386,7 @@ class IngestionWorkflow(
   }
 
   def index(config: IndexConfig): Try[SparkSession] = {
-    new IndexJob(config, Settings.storageHandler).run()
+    new IndexJob(config, settings.storageHandler).run()
   }
 
   def bqload(
@@ -397,7 +397,7 @@ class IngestionWorkflow(
   }
 
   def atlas(config: AtlasConfig): Unit = {
-    new AtlasJob(config, Settings.storageHandler).run()
+    new AtlasJob(config, settings.storageHandler).run()
   }
 
   /**

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -56,7 +56,7 @@ class IngestionWorkflow(
   storageHandler: StorageHandler,
   schemaHandler: SchemaHandler,
   launchHandler: LaunchHandler
-)(implicit /* TODO: make me explicit */ settings: Settings)
+)(implicit settings: Settings)
     extends StrictLogging {
   val domains: List[Domain] = schemaHandler.domains
 

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -56,7 +56,8 @@ class IngestionWorkflow(
   storageHandler: StorageHandler,
   schemaHandler: SchemaHandler,
   launchHandler: LaunchHandler
-) extends StrictLogging {
+)(implicit /* TODO: make me explicit */ settings: Settings)
+    extends StrictLogging {
   val domains: List[Domain] = schemaHandler.domains
 
   /**

--- a/src/test/resources/expected/yml/position_serialization_211.yml
+++ b/src/test/resources/expected/yml/position_serialization_211.yml
@@ -14,11 +14,3 @@ position:
   trim: "NONE"
 default: null
 tags: null
-tpe:
-  name: "string"
-  pattern: ".+"
-  primitiveType: "string"
-  zone: null
-  sample: "Hello World"
-  comment: "Any set of chars"
-  indexMapping: null

--- a/src/test/resources/expected/yml/position_serialization_212.yml
+++ b/src/test/resources/expected/yml/position_serialization_212.yml
@@ -6,6 +6,7 @@ required: true
 privacy: "NONE"
 comment: null
 rename: null
+metricType: null
 attributes: null
 position:
   first: 1

--- a/src/test/resources/expected/yml/position_serialization_212.yml
+++ b/src/test/resources/expected/yml/position_serialization_212.yml
@@ -13,10 +13,3 @@ position:
   trim: "NONE"
 default: null
 tags: null
-tpe:
-  name: "string"
-  pattern: ".+"
-  primitiveType: "string"
-  zone: null
-  sample: "Hello World"
-  comment: "Any set of chars"

--- a/src/test/resources/quickstart/metadata/domains/hr.yml
+++ b/src/test/resources/quickstart/metadata/domains/hr.yml
@@ -1,6 +1,6 @@
 name: "hr"
-directory: "/tmp/incoming/hr"
-metadata:
+directory: "£COMET_TEST_ROOT£/incoming/hr"
+metadata:>
   mode: "FILE"
   format: "JSON"
 schemas:

--- a/src/test/resources/quickstart/metadata/domains/hr.yml
+++ b/src/test/resources/quickstart/metadata/domains/hr.yml
@@ -1,5 +1,5 @@
 name: "hr"
-directory: "£COMET_TEST_ROOT£/incoming/hr"
+directory: "__COMET_TEST_ROOT__/incoming/hr"
 metadata:>
   mode: "FILE"
   format: "JSON"

--- a/src/test/resources/quickstart/metadata/domains/sales.yml
+++ b/src/test/resources/quickstart/metadata/domains/sales.yml
@@ -1,5 +1,5 @@
 name: "sales"
-directory: "£COMET_TEST_ROOT£/incoming/sales"
+directory: "__COMET_TEST_ROOT__/incoming/sales"
 metadata:
   mode: "FILE"
   format: "DSV"

--- a/src/test/resources/quickstart/metadata/domains/sales.yml
+++ b/src/test/resources/quickstart/metadata/domains/sales.yml
@@ -1,5 +1,5 @@
 name: "sales"
-directory: "/tmp/incoming/sales"
+directory: "£COMET_TEST_ROOT£/incoming/sales"
 metadata:
   mode: "FILE"
   format: "DSV"

--- a/src/test/resources/sample/DOMAIN.yml
+++ b/src/test/resources/sample/DOMAIN.yml
@@ -1,6 +1,6 @@
 ---
 name: "DOMAIN"
-directory: "/tmp/DOMAIN"
+directory: "£COMET_TEST_ROOT£/DOMAIN"
 metadata:
   mode: "FILE"
   format: "DSV"

--- a/src/test/resources/sample/DOMAIN.yml
+++ b/src/test/resources/sample/DOMAIN.yml
@@ -1,6 +1,6 @@
 ---
 name: "DOMAIN"
-directory: "£COMET_TEST_ROOT£/DOMAIN"
+directory: "__COMET_TEST_ROOT__/DOMAIN"
 metadata:
   mode: "FILE"
   format: "DSV"

--- a/src/test/resources/sample/dream/dream.yml
+++ b/src/test/resources/sample/dream/dream.yml
@@ -1,6 +1,6 @@
 ---
 name: "dream"
-directory: "£COMET_TEST_ROOT£/dream"
+directory: "__COMET_TEST_ROOT__/dream"
 metadata:
   mode: "FILE"
   format: "DSV"

--- a/src/test/resources/sample/dream/dream.yml
+++ b/src/test/resources/sample/dream/dream.yml
@@ -1,6 +1,6 @@
 ---
 name: "dream"
-directory: "/tmp/dream"
+directory: "£COMET_TEST_ROOT£/dream"
 metadata:
   mode: "FILE"
   format: "DSV"

--- a/src/test/resources/sample/json/json.yml
+++ b/src/test/resources/sample/json/json.yml
@@ -1,6 +1,6 @@
 ---
 name: "json"
-directory: "£COMET_TEST_ROOT£/json"
+directory: "__COMET_TEST_ROOT__/json"
 metadata:
   mode: "FILE"
   format: "JSON"

--- a/src/test/resources/sample/json/json.yml
+++ b/src/test/resources/sample/json/json.yml
@@ -1,6 +1,6 @@
 ---
 name: "json"
-directory: "/tmp/json"
+directory: "£COMET_TEST_ROOT£/json"
 metadata:
   mode: "FILE"
   format: "JSON"

--- a/src/test/resources/sample/position/position.yml
+++ b/src/test/resources/sample/position/position.yml
@@ -1,6 +1,6 @@
 ---
 name: "position"
-directory: "/tmp/position"
+directory: "£COMET_TEST_ROOT£/position"
 ack: ""
 metadata:
   mode: "FILE"

--- a/src/test/resources/sample/position/position.yml
+++ b/src/test/resources/sample/position/position.yml
@@ -1,6 +1,6 @@
 ---
 name: "position"
-directory: "£COMET_TEST_ROOT£/position"
+directory: "__COMET_TEST_ROOT__/position"
 ack: ""
 metadata:
   mode: "FILE"

--- a/src/test/resources/sample/simple-json-locations/locations.yml
+++ b/src/test/resources/sample/simple-json-locations/locations.yml
@@ -1,6 +1,6 @@
 ---
 name: "locations"
-directory: "£COMET_TEST_ROOT£"
+directory: "__COMET_TEST_ROOT__"
 metadata:
   mode: "FILE"
   format: "SIMPLE_JSON"

--- a/src/test/resources/sample/simple-json-locations/locations.yml
+++ b/src/test/resources/sample/simple-json-locations/locations.yml
@@ -1,6 +1,6 @@
 ---
 name: "locations"
-directory: "/tmp"
+directory: "£COMET_TEST_ROOT£"
 metadata:
   mode: "FILE"
   format: "SIMPLE_JSON"

--- a/src/test/scala-2.11/com/ebiznext/comet/TestHelperAux.scala
+++ b/src/test/scala-2.11/com/ebiznext/comet/TestHelperAux.scala
@@ -20,6 +20,17 @@
 
 package com.ebiznext.comet
 
+import scala.io.Source
+
 private object TestHelperAux {
   val versionSuffix: String = "211" // We are under scala 2.11
+
+  def using[ /* A <: AutoCloseable, */ B](resource: Source /* A */ )(f: Source /* A */ => B): B =
+    // Source wasn't yet AutoCloseable in Scala 2.11 (!)
+    try {
+      f(resource)
+    } finally {
+      resource.close()
+    }
+
 }

--- a/src/test/scala-2.12/com/ebiznext/comet/TestHelperAux.scala
+++ b/src/test/scala-2.12/com/ebiznext/comet/TestHelperAux.scala
@@ -20,6 +20,16 @@
 
 package com.ebiznext.comet
 
+import scala.io.Source
+
 private object TestHelperAux {
   val versionSuffix: String = "212" // We are under scala 2.12
+
+  def using[A <: AutoCloseable, B](resource: A)(f: A => B): B =
+    try {
+      f(resource)
+    } finally {
+      resource.close()
+    }
+
 }

--- a/src/test/scala/com/ebiznext/comet/TestHelper.scala
+++ b/src/test/scala/com/ebiznext/comet/TestHelper.scala
@@ -37,7 +37,13 @@ import com.fasterxml.jackson.databind.{InjectableValues, ObjectMapper}
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
-import com.typesafe.config.{Config, ConfigFactory, ConfigParseOptions, ConfigResolveOptions}
+import com.typesafe.config.{
+  Config,
+  ConfigFactory,
+  ConfigParseOptions,
+  ConfigResolveOptions,
+  ConfigValueFactory
+}
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.filefilter.TrueFileFilter
@@ -75,7 +81,10 @@ trait TestHelper extends FlatSpec with Matchers with BeforeAndAfterAll with Stri
         |""".stripMargin,
       ConfigParseOptions.defaults().setAllowMissing(false)
     )
-    val testConfig = ConfigFactory.load(rootConfig, ConfigResolveOptions.noSystem())
+    val testConfig =
+      ConfigFactory
+        .load(rootConfig, ConfigResolveOptions.noSystem())
+        .withValue("lock.poll-time", ConfigValueFactory.fromAnyRef("5 ms")) // in local mode we don't need to wait quite as much as we do on a real cluster
 
     testConfig
   }

--- a/src/test/scala/com/ebiznext/comet/TestHelper.scala
+++ b/src/test/scala/com/ebiznext/comet/TestHelper.scala
@@ -38,7 +38,13 @@ import com.fasterxml.jackson.databind.{InjectableValues, ObjectMapper}
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
-import com.typesafe.config.{Config, ConfigFactory, ConfigParseOptions, ConfigResolveOptions, ConfigValueFactory}
+import com.typesafe.config.{
+  Config,
+  ConfigFactory,
+  ConfigParseOptions,
+  ConfigResolveOptions,
+  ConfigValueFactory
+}
 import com.typesafe.scalalogging.StrictLogging
 import org.apache.commons.io.FileUtils
 import org.apache.commons.io.filefilter.TrueFileFilter
@@ -115,7 +121,6 @@ trait TestHelper extends FlatSpec with Matchers with BeforeAndAfterAll with Stri
     using(Source.fromFile(path))(readSourceContentAsString)
 
   def readFileContent(path: Path): String = readFileContent(path.toUri.getPath)
-
 
   /** substitution patterns for test sample file resources.
     *

--- a/src/test/scala/com/ebiznext/comet/TestHelper.scala
+++ b/src/test/scala/com/ebiznext/comet/TestHelper.scala
@@ -177,24 +177,21 @@ trait TestHelper extends FlatSpec with Matchers with BeforeAndAfterAll with Stri
             "string",
             Some(false),
             false,
-            Some(PrivacyLevel.None),
-            settings = settings
+            Some(PrivacyLevel.None)
           ),
           Attribute(
             "lastname",
             "string",
             Some(false),
             false,
-            Some(PrivacyLevel("SHA1")),
-            settings = settings
+            Some(PrivacyLevel("SHA1"))
           ),
           Attribute(
             "age",
             "age",
             Some(false),
             false,
-            Some(PrivacyLevel("HIDE")),
-            settings = settings
+            Some(PrivacyLevel("HIDE"))
           )
         ),
         Some(Metadata(withHeader = Some(true))),

--- a/src/test/scala/com/ebiznext/comet/TestHelper.scala
+++ b/src/test/scala/com/ebiznext/comet/TestHelper.scala
@@ -62,13 +62,16 @@ trait TestHelper extends FlatSpec with Matchers with BeforeAndAfterAll with Stri
     )
   )
 
+  import TestHelperAux.using
+  private def readSourceContentAsString(source: Source): String = source.getLines().mkString("\n")
+
   def loadFile(filename: String)(implicit codec: Codec): String = {
     val stream: InputStream = getClass.getResourceAsStream(filename)
-    scala.io.Source.fromInputStream(stream).getLines().mkString("\n")
+    using(Source.fromInputStream(stream))(readSourceContentAsString)
   }
 
   def readFileContent(path: String): String =
-    Source.fromFile(path).getLines.mkString("\n")
+    using(Source.fromFile(path))(readSourceContentAsString)
 
   def readFileContent(path: Path): String = readFileContent(path.toUri.getPath)
 

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandlerSpec.scala
@@ -14,9 +14,9 @@ class InferSchemaHandlerSpec extends TestHelper {
       .option("inferSchema", value = true)
       .json(Seq(ComplexjsonStr).toDS)
 
-    val complexAttr2 = Attribute("key", "long", Some(false), required = false, settings = settings)
+    val complexAttr2 = Attribute("key", "long", Some(false), required = false)
     val complexAttr3 =
-      Attribute("value", "long", Some(false), required = false, settings = settings)
+      Attribute("value", "long", Some(false), required = false)
 
     val complexAttr1: List[Attribute] = List(
       Attribute(
@@ -24,8 +24,7 @@ class InferSchemaHandlerSpec extends TestHelper {
         "struct",
         Some(false),
         required = false,
-        attributes = Some(List(complexAttr2, complexAttr3)),
-        settings = settings
+        attributes = Some(List(complexAttr2, complexAttr3))
       )
     )
 
@@ -44,8 +43,8 @@ class InferSchemaHandlerSpec extends TestHelper {
     val simpleAttr: List[Attribute] = InferSchemaHandler.createAttributes(df1.schema)
 
     val simpleAttr1: List[Attribute] = List(
-      Attribute("key", "string", Some(false), required = false, settings = settings),
-      Attribute("value", "long", Some(false), required = false, settings = settings)
+      Attribute("key", "string", Some(false), required = false),
+      Attribute("value", "long", Some(false), required = false)
     )
     simpleAttr shouldBe simpleAttr1
   }
@@ -71,8 +70,8 @@ class InferSchemaHandlerSpec extends TestHelper {
     val arrayAttr: List[Attribute] = InferSchemaHandler.createAttributes(df1.schema)
 
     val arrayAttr1: List[Attribute] = List(
-      Attribute("id", "long", Some(false), required = false, settings = settings),
-      Attribute("name", "string", Some(true), required = false, settings = settings)
+      Attribute("id", "long", Some(false), required = false),
+      Attribute("name", "string", Some(true), required = false)
     )
 
     arrayAttr shouldBe arrayAttr1
@@ -91,10 +90,10 @@ class InferSchemaHandlerSpec extends TestHelper {
     val dsv: List[Attribute] = InferSchemaHandler.createAttributes(df1.schema)
 
     val dsv1: List[Attribute] = List(
-      Attribute("first name", "string", Some(false), required = false, settings = settings),
-      Attribute("last name", "string", Some(false), required = false, settings = settings),
-      Attribute("age", "string", Some(false), required = false, settings = settings),
-      Attribute("ok", "string", Some(false), required = false, settings = settings)
+      Attribute("first name", "string", Some(false), required = false),
+      Attribute("last name", "string", Some(false), required = false),
+      Attribute("age", "string", Some(false), required = false),
+      Attribute("ok", "string", Some(false), required = false)
     )
     dsv shouldBe dsv1
 
@@ -112,9 +111,9 @@ class InferSchemaHandlerSpec extends TestHelper {
     val dsv: List[Attribute] = InferSchemaHandler.createAttributes(df1.schema)
 
     val dsv1: List[Attribute] = List(
-      Attribute("_c0", "string", Some(false), required = false, settings = settings),
-      Attribute("_c1", "string", Some(false), required = false, settings = settings),
-      Attribute("_c2", "integer", Some(false), required = false, settings = settings)
+      Attribute("_c0", "string", Some(false), required = false),
+      Attribute("_c1", "string", Some(false), required = false),
+      Attribute("_c2", "integer", Some(false), required = false)
     )
     dsv shouldBe dsv1
 

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandlerSpec.scala
@@ -4,9 +4,9 @@ import com.ebiznext.comet.schema.model.Attribute
 
 class InferSchemaHandlerSpec extends TestHelper {
 
-  import sparkSession.implicits._
-
   "CreateAttributes" should "create the correct list of attributes for a complex Json" in {
+    val sparkImplicits = sparkSession.implicits
+    import sparkImplicits._
 
     val ComplexjsonStr = """{ "metadata": { "key": 84896, "value": 54 }}"""
 
@@ -34,6 +34,9 @@ class InferSchemaHandlerSpec extends TestHelper {
   }
 
   "CreateAttributes" should "create the correct list of attributes for a simple Json" in {
+    val sparkImplicits = sparkSession.implicits
+    import sparkImplicits._
+
     val SimpleJsonStr = """{ "key": "Fares", "value": 3 }}"""
 
     val df1 = sparkSession.read
@@ -50,6 +53,9 @@ class InferSchemaHandlerSpec extends TestHelper {
   }
 
   "CreateAttributes" should "create the correct list of attributes for an array Json" in {
+    val sparkImplicits = sparkSession.implicits
+    import sparkImplicits._
+
     val arrayJson = """
       |[
       |	{

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandlerSpec.scala
@@ -14,8 +14,9 @@ class InferSchemaHandlerSpec extends TestHelper {
       .option("inferSchema", value = true)
       .json(Seq(ComplexjsonStr).toDS)
 
-    val complexAttr2 = Attribute("key", "long", Some(false), required = false)
-    val complexAttr3 = Attribute("value", "long", Some(false), required = false)
+    val complexAttr2 = Attribute("key", "long", Some(false), required = false, settings = settings)
+    val complexAttr3 =
+      Attribute("value", "long", Some(false), required = false, settings = settings)
 
     val complexAttr1: List[Attribute] = List(
       Attribute(
@@ -23,7 +24,8 @@ class InferSchemaHandlerSpec extends TestHelper {
         "struct",
         Some(false),
         required = false,
-        attributes = Some(List(complexAttr2, complexAttr3))
+        attributes = Some(List(complexAttr2, complexAttr3)),
+        settings = settings
       )
     )
 
@@ -42,8 +44,8 @@ class InferSchemaHandlerSpec extends TestHelper {
     val simpleAttr: List[Attribute] = InferSchemaHandler.createAttributes(df1.schema)
 
     val simpleAttr1: List[Attribute] = List(
-      Attribute("key", "string", Some(false), required = false),
-      Attribute("value", "long", Some(false), required = false)
+      Attribute("key", "string", Some(false), required = false, settings = settings),
+      Attribute("value", "long", Some(false), required = false, settings = settings)
     )
     simpleAttr shouldBe simpleAttr1
   }
@@ -69,8 +71,8 @@ class InferSchemaHandlerSpec extends TestHelper {
     val arrayAttr: List[Attribute] = InferSchemaHandler.createAttributes(df1.schema)
 
     val arrayAttr1: List[Attribute] = List(
-      Attribute("id", "long", Some(false), required = false),
-      Attribute("name", "string", Some(true), required = false)
+      Attribute("id", "long", Some(false), required = false, settings = settings),
+      Attribute("name", "string", Some(true), required = false, settings = settings)
     )
 
     arrayAttr shouldBe arrayAttr1
@@ -89,10 +91,10 @@ class InferSchemaHandlerSpec extends TestHelper {
     val dsv: List[Attribute] = InferSchemaHandler.createAttributes(df1.schema)
 
     val dsv1: List[Attribute] = List(
-      Attribute("first name", "string", Some(false), required = false),
-      Attribute("last name", "string", Some(false), required = false),
-      Attribute("age", "string", Some(false), required = false),
-      Attribute("ok", "string", Some(false), required = false)
+      Attribute("first name", "string", Some(false), required = false, settings = settings),
+      Attribute("last name", "string", Some(false), required = false, settings = settings),
+      Attribute("age", "string", Some(false), required = false, settings = settings),
+      Attribute("ok", "string", Some(false), required = false, settings = settings)
     )
     dsv shouldBe dsv1
 
@@ -110,9 +112,9 @@ class InferSchemaHandlerSpec extends TestHelper {
     val dsv: List[Attribute] = InferSchemaHandler.createAttributes(df1.schema)
 
     val dsv1: List[Attribute] = List(
-      Attribute("_c0", "string", Some(false), required = false),
-      Attribute("_c1", "string", Some(false), required = false),
-      Attribute("_c2", "integer", Some(false), required = false)
+      Attribute("_c0", "string", Some(false), required = false, settings = settings),
+      Attribute("_c1", "string", Some(false), required = false, settings = settings),
+      Attribute("_c2", "integer", Some(false), required = false, settings = settings)
     )
     dsv shouldBe dsv1
 

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandlerSpec.scala
@@ -12,7 +12,7 @@ class InferSchemaHandlerSpec extends TestHelper {
 
     val df = sparkSession.read
       .option("inferSchema", value = true)
-      .json(Seq(ComplexjsonStr).toDS.rdd)
+      .json(Seq(ComplexjsonStr).toDS)
 
     val complexAttr2 = Attribute("key", "long", Some(false), required = false)
     val complexAttr3 = Attribute("value", "long", Some(false), required = false)
@@ -37,7 +37,7 @@ class InferSchemaHandlerSpec extends TestHelper {
 
     val df1 = sparkSession.read
       .option("inferSchema", value = true)
-      .json(Seq(SimpleJsonStr).toDS.rdd)
+      .json(Seq(SimpleJsonStr).toDS)
 
     val simpleAttr: List[Attribute] = InferSchemaHandler.createAttributes(df1.schema)
 
@@ -64,7 +64,7 @@ class InferSchemaHandlerSpec extends TestHelper {
 
     val df1 = sparkSession.read
       .option("inferSchema", value = true)
-      .json(Seq(arrayJson).toDS.rdd)
+      .json(Seq(arrayJson).toDS)
 
     val arrayAttr: List[Attribute] = InferSchemaHandler.createAttributes(df1.schema)
 

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaJobSpec.scala
@@ -6,22 +6,22 @@ import org.apache.spark.sql.Dataset
 
 class InferSchemaJobSpec extends TestHelper {
 
-  val dataset_csv: Dataset[String] = sparkSession.read
+  lazy val dataset_csv: Dataset[String] = sparkSession.read
     .textFile("src/test/resources/sample/SCHEMA-VALID-NOHEADER.dsv")
 
-  val dataset_psv: Dataset[String] = sparkSession.read
+  lazy val dataset_psv: Dataset[String] = sparkSession.read
     .textFile("src/test/resources/quickstart/incoming/sales/customers-2018-01-01.psv")
 
-  val dataset_json: Dataset[String] = sparkSession.read
+  lazy val dataset_json: Dataset[String] = sparkSession.read
     .textFile("src/test/resources/sample/json/complex.json")
 
-  val dataset_jsonArray: Dataset[String] = sparkSession.read
+  lazy val dataset_jsonArray: Dataset[String] = sparkSession.read
     .textFile("src/test/resources/quickstart/incoming/hr/sellers-2018-01-01.json")
 
-  val dataset_jsonArrayMultiline: Dataset[String] = sparkSession.read
+  lazy val dataset_jsonArrayMultiline: Dataset[String] = sparkSession.read
     .textFile("src/test/resources/sample/simple-json-locations/locations.json")
 
-  val inferSchemaJob: InferSchemaJob = new InferSchemaJob()
+  lazy val inferSchemaJob: InferSchemaJob = new InferSchemaJob()
 
   "GetSeparatorSemiColon" should "succeed" in {
 

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/InferSchemaJobSpec.scala
@@ -21,39 +21,41 @@ class InferSchemaJobSpec extends TestHelper {
   val dataset_jsonArrayMultiline: Dataset[String] = sparkSession.read
     .textFile("src/test/resources/sample/simple-json-locations/locations.json")
 
+  val inferSchemaJob: InferSchemaJob = new InferSchemaJob()
+
   "GetSeparatorSemiColon" should "succeed" in {
 
-    InferSchemaJob.getSeparator(dataset_csv) shouldBe ";"
+    inferSchemaJob.getSeparator(dataset_csv) shouldBe ";"
 
   }
 
   "GetSeparatorPipe" should "succeed" in {
 
-    InferSchemaJob.getSeparator(dataset_psv) shouldBe "|"
+    inferSchemaJob.getSeparator(dataset_psv) shouldBe "|"
 
   }
 
   "GetFormatCSV" should "succeed" in {
 
-    InferSchemaJob.getFormatFile(dataset_csv) shouldBe "DSV"
+    inferSchemaJob.getFormatFile(dataset_csv) shouldBe "DSV"
 
   }
 
   "GetFormatJson" should "succeed" in {
 
-    InferSchemaJob.getFormatFile(dataset_json) shouldBe "JSON"
+    inferSchemaJob.getFormatFile(dataset_json) shouldBe "JSON"
 
   }
 
   "GetFormatArrayJson" should "succeed" in {
 
-    InferSchemaJob.getFormatFile(dataset_jsonArray) shouldBe "ARRAY_JSON"
+    inferSchemaJob.getFormatFile(dataset_jsonArray) shouldBe "ARRAY_JSON"
 
   }
 
   "GetFormatArrayJsonMultiline" should "succeed" in {
 
-    InferSchemaJob.getFormatFile(dataset_jsonArrayMultiline) shouldBe "ARRAY_JSON"
+    inferSchemaJob.getFormatFile(dataset_jsonArrayMultiline) shouldBe "ARRAY_JSON"
 
   }
 

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/PositionIngestionJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/PositionIngestionJobSpec.scala
@@ -38,7 +38,7 @@ class PositionIngestionJobSpec extends TestHelper {
 
       override val datasetDomainName: String = "position"
       override val sourceDatasetPathName: String = "/sample/position/XPOSTBL"
-      logger.info(Settings.comet.datasets)
+      logger.info(settings.comet.datasets)
       loadPending
 
       // Check archive

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/SchemaHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/SchemaHandlerSpec.scala
@@ -233,7 +233,7 @@ class SchemaHandlerSpec extends TestHelper {
         "/sample/simple-json-locations/locations.json"
 
       init()
-      val schema: Option[Schema] = Settings.schemaHandler.domains
+      val schema: Option[Schema] = settings.schemaHandler.domains
         .find(_.name == "locations")
         .flatMap(_.schemas.find(_.name == "locations"))
       val expected: String =

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/SchemaHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/SchemaHandlerSpec.scala
@@ -215,10 +215,9 @@ class SchemaHandlerSpec extends TestHelper {
 
     val typesPath = new Path(DatasetArea.types, "types.yml")
 
-    storageHandler.write(loadFile("/sample/types.yml"), typesPath)
+    deliverTestFile("/sample/types.yml", typesPath)
 
     readFileContent(typesPath) shouldBe loadFile("/sample/types.yml")
-
   }
 
   "Mapping Schema" should "produce valid template" in {

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/StatDescJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/StatDescJobSpec.scala
@@ -19,26 +19,29 @@ class StatDescJobSpec extends TestHelper {
   /**
     * Read the data .csv
     */
+  lazy val dataInitialUsed = {
 
-  val dataInitialUsed = sparkSession.read
-    .format("csv")
-    .option("header", "true") //reading the headers
-    .option("mode", "DROPMALFORMED")
-    .option("inferSchema", "true")
-    .load("./src/test/resources/iris.csv")
+    val value = sparkSession.read
+      .format("csv")
+      .option("header", "true") //reading the headers
+      .option("mode", "DROPMALFORMED")
+      .option("inferSchema", "true")
+      .load("./src/test/resources/iris.csv")
 
-  /**
-    * Descriptive statistics of the dataframe for Quantitative variable:
-    */
-  dataInitialUsed.printSchema()
+    /**
+      * Descriptive statistics of the dataframe for Quantitative variable:
+      */
+    value.printSchema()
+    value
+  }
 
-  val result0 = computeContinuousMetric(
+  lazy val result0 = computeContinuousMetric(
     dataInitialUsed,
     listContnuousAttributes,
     continuousMetrics
   )
 
-  val result1 = computeContinuousMetric(
+  lazy val result1 = computeContinuousMetric(
     dataInitialUsed,
     listContnuousAttributes,
     partialContinuousMetric
@@ -47,11 +50,15 @@ class StatDescJobSpec extends TestHelper {
   /**
     * 1- test : Test on the mean of the dimension
     */
-  val dimensionTable = (partialContinuousMetric.size + 1) * (listContnuousAttributes.size + 1)
+  lazy val dimensionTable = {
+    val dimensionTable =
+    (partialContinuousMetric.size + 1) * (listContnuousAttributes.size + 1)
+    logger.info(s"-->$dimensionTable")
 
-  logger.info(s"-->$dimensionTable")
+    dimensionTable
+  }
 
-  val dimensionDataframe = result1.map { result1 =>
+  lazy val dimensionDataframe = result1.map { result1 =>
     result1.printSchema()
     (result1.columns.size - 1) * (result1
       .select(col("attribute"))
@@ -68,11 +75,10 @@ class StatDescJobSpec extends TestHelper {
   /**
     * 2- test : Test for all values of the Mean
     */
-
-  val meanList: List[Double] =
+  lazy val meanList: List[Double] =
     listContnuousAttributes.map(name => dataInitialUsed.select(avg(name)).first().getDouble(0))
 
-  val meanListTable: List[Double] = result0.map { result0 =>
+  lazy val meanListTable: List[Double] = result0.map { result0 =>
     result0.select(col("mean")).collect().map(_.getDouble(0)).toList
   } getOrElse (Nil)
 
@@ -83,12 +89,11 @@ class StatDescJobSpec extends TestHelper {
   /**
     * 3- test : Test for all values of the Min
     */
-
-  val minList: List[Double] = listContnuousAttributes.map(
+  lazy val minList: List[Double] = listContnuousAttributes.map(
     name => dataInitialUsed.select(min(name)).first().getDouble(0)
   )
 
-  val minListTable: List[Double] = result0.map { result0 =>
+  lazy val minListTable: List[Double] = result0.map { result0 =>
     result0.select(col("min")).collect().map(_.getDouble(0)).toList
   } getOrElse (Nil)
 
@@ -99,12 +104,11 @@ class StatDescJobSpec extends TestHelper {
   /**
     * 4- test : Test for all values of the Max
     */
-
-  val maxList: List[Double] = listContnuousAttributes.map(
+  lazy val maxList: List[Double] = listContnuousAttributes.map(
     name => dataInitialUsed.select(max(name)).first().getDouble(0)
   )
 
-  val maxListTable: List[Double] = result0.map { result0 =>
+  lazy val maxListTable: List[Double] = result0.map { result0 =>
     result0.select(col("max")).collect().map(_.getDouble(0)).toList
   } getOrElse (Nil)
 
@@ -115,11 +119,10 @@ class StatDescJobSpec extends TestHelper {
   /**
     * 5- test : Test for all values of the standardDev
     */
-
-  val stddevList: List[Double] =
+  lazy val stddevList: List[Double] =
     listContnuousAttributes.map(name => dataInitialUsed.select(stddev(name)).first().getDouble(0))
 
-  val stddevListTable: List[Double] = result0.map { result0 =>
+  lazy val stddevListTable: List[Double] = result0.map { result0 =>
     result0.select(col("standardDev")).collect().map(_.getDouble(0)).toList
   } getOrElse Nil
 
@@ -130,13 +133,13 @@ class StatDescJobSpec extends TestHelper {
   /**
     * 6- test : Test for all values of the Skewness
     */
-
-  val skewnessList: List[Double] =
+  lazy val skewnessList: List[Double] =
     listContnuousAttributes.map(name => dataInitialUsed.select(skewness(name)).first().getDouble(0))
 
-  val skewnessListTable: List[Double] = result0.map { result0 =>
+  lazy val skewnessListTable: List[Double] = result0.map { result0 =>
     result0.select(col("skewness")).collect().map(_.getDouble(0)).toList
   } getOrElse (Nil)
+
   "All values of The Skewness" should "be tested" in {
     assert(skewnessList.zip(skewnessListTable).map(x => x._1 - x._2).sum <= 0.001)
   }
@@ -144,11 +147,10 @@ class StatDescJobSpec extends TestHelper {
   /**
     * 7- test : Test for all values of the kurtosis
     */
-
-  val kurtosisList: List[Double] =
+  lazy val kurtosisList: List[Double] =
     listContnuousAttributes.map(name => dataInitialUsed.select(kurtosis(name)).first().getDouble(0))
 
-  val kurtosisListTable: List[Double] = result0.map { result0 =>
+  lazy val kurtosisListTable: List[Double] = result0.map { result0 =>
     result0.select(col("kurtosis")).collect().map(_.getDouble(0)).toList
   } getOrElse (Nil)
 

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
@@ -20,6 +20,8 @@
 
 package com.ebiznext.comet.schema.handlers
 
+import java.util.regex.Pattern
+
 import com.ebiznext.comet.TestHelper
 import com.ebiznext.comet.config.Settings
 import com.ebiznext.comet.schema.model._
@@ -35,6 +37,60 @@ class StorageHandlerSpec extends TestHelper {
   lazy val pathBusiness = new Path(cometTestRoot + "/business.yml")
 
   "Domain Case Class" should "be written as yaml and read correctly" in {
+    val domain = Domain(
+      "DOMAIN",
+      s"${cometTestRoot}/incoming/DOMAIN",
+      Some(
+        Metadata(
+          Some(Mode.FILE),
+          Some(Format.DSV),
+          None,
+          Some(false),
+          Some(false),
+          Some(false),
+          Some(";"),
+          Some("\""),
+          Some("\\"),
+          Some(WriteMode.APPEND),
+          None
+        )
+      ),
+      List(
+        Schema(
+          "User",
+          Pattern.compile("SCHEMA-.*.dsv"),
+          List(
+            Attribute(
+              "firstname",
+              "string",
+              Some(false),
+              false,
+              Some(PrivacyLevel.None)
+            ),
+            Attribute(
+              "lastname",
+              "string",
+              Some(false),
+              false,
+              Some(PrivacyLevel("SHA1"))
+            ),
+            Attribute(
+              "age",
+              "age",
+              Some(false),
+              false,
+              Some(PrivacyLevel("HIDE"))
+            )
+          ),
+          Some(Metadata(withHeader = Some(true))),
+          None,
+          Some("Schema Comment"),
+          Some(List("SQL1", "SQL2")),
+          None
+        )
+      ),
+      Some("Domain Comment")
+    )
 
     storageHandler.write(mapper.writeValueAsString(domain), pathDomain)
 

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
@@ -21,17 +21,18 @@
 package com.ebiznext.comet.schema.handlers
 
 import com.ebiznext.comet.TestHelper
+import com.ebiznext.comet.config.Settings
 import com.ebiznext.comet.schema.model._
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
 
 class StorageHandlerSpec extends TestHelper {
 
-  lazy val pathDomain = new Path(TestHelper.tempFile + "/domain.yml")
+  lazy val pathDomain = new Path(cometTestRoot + "/domain.yml")
 
-  lazy val pathType = new Path(TestHelper.tempFile + "/types.yml")
+  lazy val pathType = new Path(cometTestRoot + "/types.yml")
 
-  lazy val pathBusiness = new Path(TestHelper.tempFile + "/business.yml")
+  lazy val pathBusiness = new Path(cometTestRoot + "/business.yml")
 
   "Domain Case Class" should "be written as yaml and read correctly" in {
 
@@ -92,7 +93,13 @@ class StorageHandlerSpec extends TestHelper {
     )
     val businessJob =
       AutoJobDesc("business1", List(businessTask1), None, Some("parquet"), Some(true))
-    storageHandler.write(mapper.writeValueAsString(businessJob), pathBusiness)
+
+    val businessJobDef = mapper
+      .writer()
+      .withAttribute(classOf[Settings], settings)
+      .writeValueAsString(businessJob)
+
+    storageHandler.write(businessJobDef, pathBusiness)
     logger.info(readFileContent(pathBusiness))
     readFileContent(pathBusiness) shouldBe loadFile("/expected/yml/business.yml")
   }

--- a/src/test/scala/com/ebiznext/comet/schema/model/SchemaSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/model/SchemaSpec.scala
@@ -37,7 +37,8 @@ class SchemaSpec extends TestHelper {
       "invalid-type", // should raise error non existent type
       Some(true),
       true,
-      Some(PrivacyLevel("MD5")) // Should raise an error. Privacy cannot be applied on types other than string
+      Some(PrivacyLevel("MD5")), // Should raise an error. Privacy cannot be applied on types other than string
+      settings = settings
     )
 
     attr.checkValidity() shouldBe Left(List("Invalid Type invalid-type"))
@@ -49,7 +50,8 @@ class SchemaSpec extends TestHelper {
       "long",
       Some(true),
       true,
-      Some(PrivacyLevel("MD5")) // Should raise an error. Privacy cannot be applied on types other than string
+      Some(PrivacyLevel("MD5")), // Should raise an error. Privacy cannot be applied on types other than string
+      settings = settings
     )
     attr.checkValidity() shouldBe
     Left(
@@ -66,7 +68,8 @@ class SchemaSpec extends TestHelper {
       Some(true),
       true,
       Some(PrivacyLevel("MD5")), // Should raise an error. Privacy cannot be applied on types other than string
-      attributes = Some(List[Attribute]())
+      attributes = Some(List[Attribute]()),
+      settings = settings
     )
     val expectedErrors = List(
       "Attribute Attribute(attr,long,Some(true),true,Some(MD5),None,None,None,Some(List()),None,None,None) : string is the only supported primitive type for an attribute when privacy is requested",
@@ -80,7 +83,8 @@ class SchemaSpec extends TestHelper {
   "Position serialization" should "output all fields" in {
     val yml = loadFile(s"/expected/yml/position_serialization_${versionSuffix}.yml")
 
-    val attr = Attribute("hello", position = Some(Position(1, 2, Some(Trim.NONE))))
+    val attr =
+      Attribute("hello", position = Some(Position(1, 2, Some(Trim.NONE))), settings = settings)
     val writer = new StringWriter()
     mapper.writer().writeValue(writer, attr)
     logger.info("--" + writer.toString + "--")

--- a/src/test/scala/com/ebiznext/comet/schema/model/SchemaSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/model/SchemaSpec.scala
@@ -37,8 +37,7 @@ class SchemaSpec extends TestHelper {
       "invalid-type", // should raise error non existent type
       Some(true),
       true,
-      Some(PrivacyLevel("MD5")), // Should raise an error. Privacy cannot be applied on types other than string
-      settings = settings
+      Some(PrivacyLevel("MD5")) // Should raise an error. Privacy cannot be applied on types other than string
     )
 
     attr.checkValidity() shouldBe Left(List("Invalid Type invalid-type"))
@@ -50,8 +49,7 @@ class SchemaSpec extends TestHelper {
       "long",
       Some(true),
       true,
-      Some(PrivacyLevel("MD5")), // Should raise an error. Privacy cannot be applied on types other than string
-      settings = settings
+      Some(PrivacyLevel("MD5")) // Should raise an error. Privacy cannot be applied on types other than stringsettings = settings
     )
     attr.checkValidity() shouldBe
     Left(
@@ -68,8 +66,7 @@ class SchemaSpec extends TestHelper {
       Some(true),
       true,
       Some(PrivacyLevel("MD5")), // Should raise an error. Privacy cannot be applied on types other than string
-      attributes = Some(List[Attribute]()),
-      settings = settings
+      attributes = Some(List[Attribute]())
     )
     val expectedErrors = List(
       "Attribute Attribute(attr,long,Some(true),true,Some(MD5),None,None,None,Some(List()),None,None,None) : string is the only supported primitive type for an attribute when privacy is requested",
@@ -84,7 +81,7 @@ class SchemaSpec extends TestHelper {
     val yml = loadFile(s"/expected/yml/position_serialization_${versionSuffix}.yml")
 
     val attr =
-      Attribute("hello", position = Some(Position(1, 2, Some(Trim.NONE))), settings = settings)
+      Attribute("hello", position = Some(Position(1, 2, Some(Trim.NONE))))
     val writer = new StringWriter()
     mapper.writer().writeValue(writer, attr)
     logger.info("--" + writer.toString + "--")


### PR DESCRIPTION
## Summary
This PR solves the race condition between various test suites, by removing the shared & mutable configuration singleton and putting it on the stack instead (there is still only one instance in production code, and as many instances as there are test suites)

Related issue: #95 

PR Type: Bug fix

Status: WIP

Breaking change? *MAYBE* (eventually, Yes)

## Description
### Solution
This PR moves the instances formerly within the `Settings`object into a `Settings` instance. For now, the old `Settings.comet`, `Settings.storageHandler`, `Settings.schemaHandler` lazy variables are (at least temporarily) transformed into trampolines that keep the former syntax available (at least as long as an implicit `Settings` instance is around)

As a result of this PR:
* each test suite runs in its own directory, insulated from any other instance (but still sharing the global `SparkSession` instance)
* each test suite may now define programmatic overrides on the configuration used to load the `Settings`. This may be useful in #96 for instance, to enable testing with/without JDBC indexing.


### How has this been tested?
`sbt clean test` is green. (**EDIT**: it was green but actually failing, due to files remaining in my `/tmp` which are no longer delivered there. Thanks, Travis)

### Other changes

When under test, LockFile's polling period is now reduced to 5 milliseconds (down from 5000 milliseconds), which halves the time required to run the test suite (from 53 seconds to 26 seconds) on this machine.

It would not have been possible to reduce this polling period before without significantly augmenting the chances of having multiple test suites stomping on each other's data.

### Deploy Notes
none

### Remaining Todos
This should be done before merging this PR:
* [x] - Find the remaining cases where files are expected in the absolute `/tmp` (they are no longer delivered there)
* [x] - Chase the 85-odd instances of uses of the now deprecated `Settings$.comet`(& friends) trampolines
* [x] - Review whether the Settings instances currently passed around via implicits should remain implicits or should be turned into explicit values (**RFC**)

