### PR TITLE
fix: [CDP-100] don't write the AuditLog subject to logging level >= INFO but unconditionally

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -348,30 +348,28 @@ trait IngestionJob extends SparkJob {
         dataset match {
           case Success(dataset) =>
             val (rejectedRDD, acceptedRDD) = ingest(dataset)
-            logger.whenInfoEnabled {
-              val inputCount = dataset.count()
-              val acceptedCount = acceptedRDD.count()
-              val rejectedCount = rejectedRDD.count()
-              val inputFiles = dataset.inputFiles.mkString(",")
-              logger.info(
-                s"ingestion-summary -> files: [$inputFiles], domain: ${domain.name}, schema: ${schema.name}, input: $inputCount, accepted: $acceptedCount, rejected:$rejectedCount"
-              )
-              val end = Timestamp.from(Instant.now())
-              val log = AuditLog(
-                Settings.jobId,
-                inputFiles,
-                domain.name,
-                schema.name,
-                success = true,
-                inputCount,
-                acceptedCount,
-                rejectedCount,
-                start,
-                end.getTime - start.getTime,
-                "success"
-              )
-              SparkAuditLogWriter.append(session, log)
-            }
+            val inputCount = dataset.count()
+            val acceptedCount = acceptedRDD.count()
+            val rejectedCount = rejectedRDD.count()
+            val inputFiles = dataset.inputFiles.mkString(",")
+            logger.info(
+              s"ingestion-summary -> files: [$inputFiles], domain: ${domain.name}, schema: ${schema.name}, input: $inputCount, accepted: $acceptedCount, rejected:$rejectedCount"
+            )
+            val end = Timestamp.from(Instant.now())
+            val log = AuditLog(
+              Settings.jobId,
+              inputFiles,
+              domain.name,
+              schema.name,
+              success = true,
+              inputCount,
+              acceptedCount,
+              rejectedCount,
+              start,
+              end.getTime - start.getTime,
+              "success"
+            )
+            SparkAuditLogWriter.append(session, log)
             schema.postsql.getOrElse(Nil).foreach(session.sql)
             Success(session)
           case Failure(exception) =>

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -358,7 +358,7 @@ trait IngestionJob extends SparkJob {
             )
             val end = Timestamp.from(Instant.now())
             val log = AuditLog(
-              Settings.jobId,
+              s"${settings.comet.jobId}",
               inputFiles,
               domain.name,
               schema.name,


### PR DESCRIPTION
Closes: #100

## Summary
AuditLog information were only written downstream if the logging level was INFO or more. This was a mistake.

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
Make the block of code unconditional

### How has this been tested?
not much; this was a static spot check.


