### PR TITLE
syntax correction in reference.conf

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,13 +1,13 @@
 root = "/tmp"
 root = ${?COMET_ROOT}
 
-datasets = "${root}/datasets"
+datasets = ${root}"/datasets"
 datasets = ${?COMET_DATASETS}
 
-metadata = "${root}/metadata"
+metadata = ${root}"/metadata"
 metadata = ${?COMET_METADATA}
 
-tmpdir = "${root}/comet_tmp"
+tmpdir = ${root}"/comet_tmp"
 tmpdir = ${?COMET_TMPDIR}
 
 archive = true
@@ -43,7 +43,7 @@ chewer-prefix = "comet.chewer"
 chewer-prefix = ${?COMET_CHEWER_PREFIX}
 
 lock {
-  path = "${root}/locks"
+  path = ${root}"/locks"
   path = ${?COMET_LOCK_PATH}
 
   ingestion-timeout = -1
@@ -60,8 +60,8 @@ audit {
   active = true
   active = ${?COMET_AUDIT_ACTIVE}
 
-  #  path = "${root}/metrics/{domain}/{schema}"
-  path = "${root}/audit"
+  #  path = ${root}"/metrics/{domain}/{schema}"
+  path = ${root}"/audit"
   path = ${?COMET_AUDIT_PATH}
 
   audit-timeout = -1
@@ -82,8 +82,8 @@ metrics {
   active = false
   active = ${?COMET_METRICS_ACTIVE}
 
-  #  path = "${root}/metrics/{domain}/{schema}"
-  path = "${root}/metrics/{domain}"
+  #  path = ${root}"/metrics/{domain}/{schema}"
+  path = ${root}"/metrics/{domain}"
   path = ${?COMET_METRICS_PATH}
 
   discrete-max-cardinality = 10


### PR DESCRIPTION
## Summary
Minor correction in reference.conf syntax

**PR Type: Bug Fix **

**Status: Ready to review**

**Breaking change? No**

## Description
the substitution of a an existing configuration element is not applied when loading reference.conf because of a misplaced double quote

### How has this been tested?
using existing test  and running comet locally


