### PR TITLE
[BUG] Conflict between Spark's guava & Google Cloud's guava

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -129,16 +129,6 @@ val writeNextVersion =
     }
   )
 
-// Shade it or else bigquery wont work because spark comes with an older version of google common.
-assemblyShadeRules in assembly := Seq(
-  ShadeRule
-    .rename(
-      "com.google.cloud.hadoop.io.bigquery.**" -> "shadeio.@1",
-      "com.google.common.**"                   -> "shadebase.@1"
-    )
-    .inAll
-)
-
 assemblyMergeStrategy in assembly := {
   case PathList("META-INF", xs @ _*) => MergeStrategy.discard
   case x => MergeStrategy.first

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -113,7 +113,6 @@ object Versions {
   val esHadoop = "7.6.0"
   val scopt = "4.0.0-RC2"
   val sttp = "1.7.2"
-//  val gcs = "hadoop2-2.0.0"
   val gcs = "hadoop3-2.0.1"
   val hadoopbq = "hadoop3-1.0.0"
   val bq = "1.103.0"
@@ -127,5 +126,7 @@ object Resolvers {
   val allResolvers = Seq(
     typeSafe
   )
+
+  val googleCloudBigDataMavenRepo = "https://repo1.maven.org/maven2/com/google/cloud/bigdataoss"
 
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -82,18 +82,15 @@ object Dependencies {
     "org.apache.spark" %% "spark-mllib" % Versions.spark212 % "provided"
   )
 
+
+  val gcsConnectorShadedJar = s"${Resolvers.googleCloudBigDataMavenRepo}/gcs-connector/${Versions.gcs}/gcs-connector-${Versions.gcs}-shaded.jar"
+  val gcpBigQueryConnectorShadedJar = s"${Resolvers.googleCloudBigDataMavenRepo}/bigquery-connector/${Versions.hadoopbq}/bigquery-connector-${Versions.hadoopbq}-shaded.jar"
+
   val gcp = Seq(
-    "com.google.cloud.bigdataoss" % "gcs-connector" % Versions.gcs exclude ("javax.jms", "jms") exclude ("com.sun.jdmk", "jmxtools") exclude ("com.sun.jmx", "jmxri") excludeAll (jacksonExclusions: _*),
-    "com.google.cloud.bigdataoss" % "bigquery-connector" % Versions.hadoopbq exclude ("javax.jms", "jms") exclude ("com.sun.jdmk", "jmxtools") exclude ("com.sun.jmx", "jmxri") excludeAll (jacksonExclusions: _*),
+    "com.google.cloud.bigdataoss" % "gcs-connector-shaded" % s"${Versions.gcs}-shaded" from gcsConnectorShadedJar exclude ("javax.jms", "jms") exclude ("com.sun.jdmk", "jmxtools") exclude ("com.sun.jmx", "jmxri") excludeAll (jacksonExclusions: _*),
+    "com.google.cloud.bigdataoss" % "bigquery-connector-shaded" % s"${Versions.hadoopbq}-shaded" from gcpBigQueryConnectorShadedJar exclude ("javax.jms", "jms") exclude ("com.sun.jdmk", "jmxtools") exclude ("com.sun.jmx", "jmxri") excludeAll (jacksonExclusions: _*),
     "com.google.cloud" % "google-cloud-bigquery" % Versions.bq exclude ("javax.jms", "jms") exclude ("com.sun.jdmk", "jmxtools") exclude ("com.sun.jmx", "jmxri") excludeAll (jacksonExclusions: _*),
     "com.google.cloud.spark" %% "spark-bigquery-with-dependencies" % "0.12.0-beta"
-    // A more recent version of guava is requierd for the big query connector
-//    "com.google.guava" % "guava" % "28.1-jre",
-    // We include the files below because guava above introduce static constructors which break previous hadoop versions
-//    "org.apache.hadoop" % "hadoop-mapreduce-client-core" % "2.7.3" exclude ("javax.servlet", "servlet-api") exclude ("aopalliance", "aopalliance") exclude ("org.sonatype.sisu.inject", "cglib"),
-//    "org.apache.hadoop" % "hadoop-common" % "2.7.3" exclude ("commons-beanutils", "commons-beanutils") exclude ("commons-beanutils", "commons-beanutils-core") exclude ("javax.servlet", "servlet-api") exclude ("aopalliance", "aopalliance") exclude ("org.sonatype.sisu.inject", "cglib"),
-//    "org.apache.hadoop" % "hadoop-client" % "2.7.3" exclude ("commons-beanutils", "commons-beanutils") exclude ("commons-beanutils", "commons-beanutils-core"),
-//    "org.xerial.snappy" % "snappy-java" % "1.1.7.3"
   )
 
   val esHadoop = Seq(

--- a/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
@@ -114,7 +114,7 @@ class BigQueryLoadJob(
         cliConfig.createDisposition
       )
       cliConfig.outputPartition.foreach { outputPartition =>
-        import com.google.api.services.bigquery.model.TimePartitioning
+        import com.google.cloud.hadoop.repackaged.bigquery.com.google.api.services.bigquery.model.TimePartitioning
         val timeField =
           if (List("_PARTITIONDATE", "_PARTITIONTIME").contains(outputPartition))
             new TimePartitioning().setType("DAY").setRequirePartitionFilter(true)


### PR DESCRIPTION
## Summary
Fix Guava conflict between spark's guava & google's guava.

**Related Issue: #133**

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
Remove manual shading
Use google shaded version of GCS Connector & BQ libs

### How has this been tested?
Unit Test
Deploy in a spark cluster (CDH 2.1.0 with hadoop 2.6)

### Other changes
Assembly take now only 27 seconds comparing with more than 200 seconds when shading manually

### Deploy Notes
Nothing has changed 

### Remaining Todos
This should be done before merging this PR:
* [ ] - Test on DataProc
* [ ] - Test on a Cloudera spark cluster

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change does not requires a change to the documentation.



