### PR TITLE
[enhancement] Pass parameters to my SQL statements

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -317,7 +317,7 @@ spark {
   #  yarn.principal = ${?SPARK_YARN_PRINCIPAL}
   #  yarn.keytab = ${?SPARK_YARN_KEYTAB}
   debug.maxToStringFields = 100
-  master = "local[*]"
+  #master = "local[*]"
   #  sql.catalogImplementation="hive"
   #  sql.catalogImplementation="in-memory"
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -317,7 +317,7 @@ spark {
   #  yarn.principal = ${?SPARK_YARN_PRINCIPAL}
   #  yarn.keytab = ${?SPARK_YARN_KEYTAB}
   debug.maxToStringFields = 100
-  # master = "local[*]"
+  master = "local[*]"
   #  sql.catalogImplementation="hive"
   #  sql.catalogImplementation="in-memory"
 }

--- a/src/main/scala/com/ebiznext/comet/config/DatasetArea.scala
+++ b/src/main/scala/com/ebiznext/comet/config/DatasetArea.scala
@@ -212,7 +212,9 @@ final class StorageAreaSerializer extends JsonSerializer[StorageArea] {
 }
 final class StorageAreaDeserializer extends JsonDeserializer[StorageArea] {
   override def deserialize(jp: JsonParser, ctx: DeserializationContext): StorageArea = {
-    val settings = ctx.findInjectableValue("com.ebiznext.comet.config.Settings",null,null).asInstanceOf[Settings]
+    val settings = ctx
+      .findInjectableValue("com.ebiznext.comet.config.Settings", null, null)
+      .asInstanceOf[Settings]
     require(settings != null, "the DeserializationContext lacks a Settings instance")
 
     val value = jp.readValueAs[String](classOf[String])

--- a/src/main/scala/com/ebiznext/comet/config/DatasetArea.scala
+++ b/src/main/scala/com/ebiznext/comet/config/DatasetArea.scala
@@ -212,7 +212,7 @@ final class StorageAreaSerializer extends JsonSerializer[StorageArea] {
 }
 final class StorageAreaDeserializer extends JsonDeserializer[StorageArea] {
   override def deserialize(jp: JsonParser, ctx: DeserializationContext): StorageArea = {
-    val settings = ctx.getAttribute(classOf[Settings]).asInstanceOf[Settings]
+    val settings = ctx.findInjectableValue("com.ebiznext.comet.config.Settings",null,null).asInstanceOf[Settings]
     require(settings != null, "the DeserializationContext lacks a Settings instance")
 
     val value = jp.readValueAs[String](classOf[String])

--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -104,7 +104,12 @@ object Main extends StrictLogging {
     val arglist = args.toList
     logger.info(s"Running Comet $arglist")
     arglist.head match {
-      case "job" if arglist.length == 2 => workflow.autoJob(arglist(1))
+      case "job" =>
+        if (arglist.length == 2) {
+          workflow.autoJobRun(arglist(1))
+        }else if (arglist.length == 3) {
+          workflow.autoJobRun(arglist(1), Some(arglist(2)))
+        }
       case "import"                     => workflow.loadLanding()
       case "watch" =>
         if (arglist.length == 2) {

--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -109,7 +109,7 @@ object Main extends StrictLogging {
           workflow.autoJobRun(arglist(1))
         else if (arglist.length == 3)
           workflow.autoJobRun(arglist(1), Some(arglist(2)))
-        else logger.error("Number of arguments not respected: Please check your input")
+        else logger.error(s"Number of arguments not respected: Please check your input: $arglist")
       case "import" => workflow.loadLanding()
       case "watch" =>
         if (arglist.length == 2) {

--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -105,12 +105,12 @@ object Main extends StrictLogging {
     logger.info(s"Running Comet $arglist")
     arglist.head match {
       case "job" =>
-        if (arglist.length == 2) {
+        if (arglist.length == 2)
           workflow.autoJobRun(arglist(1))
-        }else if (arglist.length == 3) {
+        else if (arglist.length == 3)
           workflow.autoJobRun(arglist(1), Some(arglist(2)))
-        }
-      case "import"                     => workflow.loadLanding()
+        else logger.error("Number of arguments not respected: Please check your input")
+      case "import" => workflow.loadLanding()
       case "watch" =>
         if (arglist.length == 2) {
           val param = arglist(1)

--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
@@ -29,6 +29,7 @@ import com.ebiznext.comet.utils.SparkJob
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{SaveMode, SparkSession}
 import com.ebiznext.comet.utils.Formatter._
+import scala.language.reflectiveCalls
 import scala.util.{Success, Try}
 
 /**
@@ -39,6 +40,7 @@ import scala.util.{Success, Try}
   * @param name        : Job Name as defined in the YML job description file
   * @param defaultArea : Where the resulting dataset is stored by default if not specified in the task
   * @param task        : Task to run
+  * @param sqlParameters : Sql Parameters to pass to SQL statements
   */
 class AutoTask(
   override val name: String,
@@ -76,7 +78,7 @@ class AutoTask(
     val dataframe = sqlParameters match {
       case Some(mapParams) =>
         session.sql(task.sql.richFormat(mapParams))
-      case _       => session.sql(task.sql)
+      case _ => session.sql(task.sql)
 
     }
     val partitionedDF =

--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
@@ -74,9 +74,8 @@ class AutoTask(
     val mergePath = s"${targetPath.toString}.merge"
 
     val dataframe = sqlParameters match {
-      case Some(m) =>
-        println(task.sql.richFormat(m))
-        session.sql(task.sql.richFormat(m))
+      case Some(mapParams) =>
+        session.sql(task.sql.richFormat(mapParams))
       case _       => session.sql(task.sql)
 
     }

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
@@ -98,7 +98,6 @@ class SchemaHandler(storage: StorageHandler)(implicit settings: Settings) {
       .map(path => mapper.readValue(storage.read(path), classOf[AutoJobDesc]))
       .map(job => job.name -> job)
       .toMap
-
   }
 
   /**

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
@@ -23,6 +23,7 @@ package com.ebiznext.comet.schema.handlers
 import com.ebiznext.comet.config.{DatasetArea, Settings}
 import com.ebiznext.comet.schema.model._
 import com.ebiznext.comet.utils.CometObjectMapper
+import com.fasterxml.jackson.annotation.JacksonInject
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
@@ -23,7 +23,6 @@ package com.ebiznext.comet.schema.handlers
 import com.ebiznext.comet.config.{DatasetArea, Settings}
 import com.ebiznext.comet.schema.model._
 import com.ebiznext.comet.utils.CometObjectMapper
-import com.fasterxml.jackson.annotation.JacksonInject
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper

--- a/src/main/scala/com/ebiznext/comet/schema/model/AutoJobDesc.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/AutoJobDesc.scala
@@ -21,7 +21,7 @@
 package com.ebiznext.comet.schema.model
 
 import com.ebiznext.comet.config.{DatasetArea, Settings, StorageArea}
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty}
+import com.fasterxml.jackson.annotation.JsonIgnore
 import org.apache.hadoop.fs.Path
 
 /**

--- a/src/main/scala/com/ebiznext/comet/schema/model/AutoJobDesc.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/AutoJobDesc.scala
@@ -21,7 +21,7 @@
 package com.ebiznext.comet.schema.model
 
 import com.ebiznext.comet.config.{DatasetArea, Settings, StorageArea}
-import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty}
 import org.apache.hadoop.fs.Path
 
 /**
@@ -41,7 +41,7 @@ case class AutoTaskDesc(
   partition: Option[List[String]] = None,
   presql: Option[List[String]] = None,
   postsql: Option[List[String]] = None,
-  area: Option[String] = None,
+  area: Option[StorageArea] = None,
   index: Option[IndexSink] = None,
   properties: Option[Map[String, String]] = None
 ) {
@@ -54,12 +54,12 @@ case class AutoTaskDesc(
 
   def getTargetPath(defaultArea: StorageArea)(implicit settings: Settings): Path = {
     val targetArea = area.getOrElse(defaultArea)
-    new Path(DatasetArea.path(domain, defaultArea.toString), dataset)
+    new Path(DatasetArea.path(domain, targetArea.value), dataset)
   }
 
   def getHiveDB(defaultArea: StorageArea): String = {
     val targetArea = area.getOrElse(defaultArea)
-    StorageArea.area(domain, null)
+    StorageArea.area(domain, targetArea)
   }
 
 }

--- a/src/main/scala/com/ebiznext/comet/schema/model/AutoJobDesc.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/AutoJobDesc.scala
@@ -41,7 +41,7 @@ case class AutoTaskDesc(
   partition: Option[List[String]] = None,
   presql: Option[List[String]] = None,
   postsql: Option[List[String]] = None,
-  area: Option[StorageArea] = None,
+  area: Option[String] = None,
   index: Option[IndexSink] = None,
   properties: Option[Map[String, String]] = None
 ) {
@@ -54,12 +54,12 @@ case class AutoTaskDesc(
 
   def getTargetPath(defaultArea: StorageArea)(implicit settings: Settings): Path = {
     val targetArea = area.getOrElse(defaultArea)
-    new Path(DatasetArea.path(domain, targetArea.value), dataset)
+    new Path(DatasetArea.path(domain, defaultArea.toString), dataset)
   }
 
   def getHiveDB(defaultArea: StorageArea): String = {
     val targetArea = area.getOrElse(defaultArea)
-    StorageArea.area(domain, targetArea)
+    StorageArea.area(domain, null)
   }
 
 }

--- a/src/main/scala/com/ebiznext/comet/utils/Formatter.scala
+++ b/src/main/scala/com/ebiznext/comet/utils/Formatter.scala
@@ -1,12 +1,20 @@
 package com.ebiznext.comet.utils
 
+import scala.language.implicitConversions
+
 object Formatter extends Formatter
 
 trait Formatter {
 
+  /**
+    * Split a String into a Map
+    * @param str : the string to be splitted
+    * @return
+    */
   implicit def RichFormatter(str: String): Object {
     def richFormat(replacement: Map[String, String]): String
   } = new {
+
     def richFormat(replacement: Map[String, String]): String =
       (str /: replacement) { (res, entry) =>
         res.replaceAll("\\{\\{%s\\}\\}".format(entry._1), entry._2.toString)

--- a/src/main/scala/com/ebiznext/comet/utils/Formatter.scala
+++ b/src/main/scala/com/ebiznext/comet/utils/Formatter.scala
@@ -1,0 +1,15 @@
+package com.ebiznext.comet.utils
+
+object Formatter extends Formatter
+
+trait Formatter {
+
+  implicit def RichFormatter(str: String): Object {
+    def richFormat(replacement: Map[String, String]): String
+  } = new {
+    def richFormat(replacement: Map[String, String]): String =
+      (str /: replacement) { (res, entry) =>
+        res.replaceAll("\\{\\{%s\\}\\}".format(entry._1), entry._2.toString)
+      }
+  }
+}

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -325,7 +325,7 @@ class IngestionWorkflow(
 
   def index(job: AutoJobDesc, task: AutoTaskDesc): Unit = {
     val targetArea = task.area.getOrElse(job.getArea())
-    val targetPath = new Path(DatasetArea.path(task.domain, null), task.dataset)
+    val targetPath = new Path(DatasetArea.path(task.domain, targetArea.value), task.dataset)
     val properties = task.properties
     launchHandler.index(
       this,

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -360,9 +360,11 @@ class IngestionWorkflow(
     val parameters: Option[Map[String, String]] = argParams
       .map {
         _.replaceAll("\\s", "")
-          .split("=")
+          .split(Array(',', '='))
           .grouped(2)
-          .map { case Array(k, v) => k -> v }
+          .map {
+            case Array(k, v) => k -> v
+          }
           .toMap
       }
     autoJob(job, parameters)

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -354,6 +354,7 @@ class IngestionWorkflow(
     * Successively run each task of a job
     *
     * @param jobname : job name as defined in the YML file.
+    * @param argParams : sql parameters to pass to SQL statements.
     */
   def autoJobRun(jobname: String, argParams: Option[String] = None): Unit = {
     val job = schemaHandler.jobs(jobname)

--- a/src/test/resources/expected/datasets/accepted/DOMAIN/User.json
+++ b/src/test/resources/expected/datasets/accepted/DOMAIN/User.json
@@ -1,5 +1,7 @@
 {"firstname": "hayssam", "lastname": "saleh", "age": 121}
 {"firstname": "yoann", "lastname": "baudy", "age": 122}
 {"firstname":  "John", "lastname":  "Doe", "age": 25}
+{"firstname":  "fred", "lastname":  "abruzzi", "age": 25}
 {"firstname":  "test1", "lastname":  "test2", "age": 29}
 {"firstname":  "test3", "lastname":  "test4", "age": 40}
+{"firstname":  "Elon", "lastname":  "Musk", "age": 40}

--- a/src/test/resources/expected/datasets/accepted/DOMAIN/User.json
+++ b/src/test/resources/expected/datasets/accepted/DOMAIN/User.json
@@ -1,2 +1,5 @@
 {"firstname": "hayssam", "lastname": "saleh", "age": 121}
 {"firstname": "yoann", "lastname": "baudy", "age": 122}
+{"firstname":  "John", "lastname":  "Doe", "age": 25}
+{"firstname":  "test1", "lastname":  "test2", "age": 29}
+{"firstname":  "test3", "lastname":  "test4", "age": 40}

--- a/src/test/resources/expected/yml/user.yml
+++ b/src/test/resources/expected/yml/user.yml
@@ -1,0 +1,14 @@
+name: "user"
+views:
+  user_View: "accepted/user"
+tasks:
+  - domain: "user"
+    area: "business"
+    dataset: "user"
+    write: "OVERWRITE"
+    sql: |
+      select firstname,
+        lastname,
+        age
+      from user_View
+      where age={{age}}

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/AutoJobHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/AutoJobHandlerSpec.scala
@@ -5,8 +5,9 @@ import com.ebiznext.comet.config.{Settings, StorageArea}
 import com.ebiznext.comet.schema.model.{AutoJobDesc, AutoTaskDesc, WriteMode}
 import com.ebiznext.comet.workflow.IngestionWorkflow
 import org.apache.hadoop.fs.Path
+import org.scalatest.BeforeAndAfterAll
 
-class AutoJobHandlerSpec extends TestHelper {
+class AutoJobHandlerSpec extends TestHelper with BeforeAndAfterAll {
 
   lazy val pathBusiness = new Path(cometMetadataPath + "/jobs/user.yml")
 
@@ -16,17 +17,17 @@ class AutoJobHandlerSpec extends TestHelper {
 
   lazy val metadataPath = new Path(cometMetadataPath)
 
+  override def beforeAll(): Unit = {
+    sparkSession.read
+      .option("inferSchema", "true")
+      .json(getResPath("/expected/datasets/accepted/DOMAIN/User.json"))
+      .write
+      .mode("overwrite")
+      .parquet(pathAccepted.toString)
+  }
+
   new WithSettings() {
     "trigger AutoJob by passing parameters on SQL statement" should "generate a dataset in business" in {
-      val accepted =
-        sparkSession.read
-          .option("inferSchema", "true")
-          .json(getResPath("/expected/datasets/accepted/DOMAIN/User.json"))
-
-      accepted
-        .write
-        .mode("overwrite")
-        .parquet(pathAccepted.toString)
 
       val businessTask1 = AutoTaskDesc(
         "select firstname, lastname, age from user_View where age={{age}}",
@@ -36,7 +37,14 @@ class AutoJobHandlerSpec extends TestHelper {
         area = Some(StorageArea.fromString("business"))
       )
       val businessJob =
-        AutoJobDesc("user", List(businessTask1), None, Some("parquet"), Some(false), views = Some(Map("user_View" -> "accepted/user")))
+        AutoJobDesc(
+          "user",
+          List(businessTask1),
+          None,
+          Some("parquet"),
+          Some(false),
+          views = Some(Map("user_View" -> "accepted/user"))
+        )
       val schemaHandler = new SchemaHandler(storageHandler)
 
       val businessJobDef = mapper
@@ -48,15 +56,107 @@ class AutoJobHandlerSpec extends TestHelper {
         new IngestionWorkflow(storageHandler, schemaHandler, new SimpleLauncher())
       storageHandler.write(businessJobDef, pathBusiness)
 
-      workflow.autoJobRun("user", Some("age=29"))
+      workflow.autoJobRun("user", Some("age=40"))
+
+      val result = sparkSession.read
+        .load(pathDatasetBusiness.toString)
+        .select("firstname", "lastname", "age")
+        .take(2)
+
+      result.length shouldBe (2)
+
+      result
+        .map(r => (r.getString(0), r.getString(1), r.getLong(2)))
+        .toList should contain allElementsOf List(
+        ("test3", "test4", 40),
+        ("Elon", "Musk", 40)
+      )
+    }
+
+    "trigger AutoJob by passing three parameters on SQL statement" should "generate a dataset in business" in {
+
+      val businessTask1 = AutoTaskDesc(
+        "select firstname, lastname, age from user_View where age={{age}} and lastname={{lastname}} and firstname={{firstname}}",
+        "user",
+        "user",
+        WriteMode.OVERWRITE,
+        area = Some(StorageArea.fromString("business"))
+      )
+      val businessJob =
+        AutoJobDesc(
+          "user",
+          List(businessTask1),
+          None,
+          Some("parquet"),
+          Some(false),
+          views = Some(Map("user_View" -> "accepted/user"))
+        )
+      val schemaHandler = new SchemaHandler(storageHandler)
+
+      val businessJobDef = mapper
+        .writer()
+        .withAttribute(classOf[Settings], settings)
+        .writeValueAsString(businessJob)
+
+      val workflow =
+        new IngestionWorkflow(storageHandler, schemaHandler, new SimpleLauncher())
+      storageHandler.write(businessJobDef, pathBusiness)
+
+      workflow.autoJobRun("user", Some("age=25, lastname='Doe', firstname='John'"))
+
+      val result = sparkSession.read
+        .load(pathDatasetBusiness.toString)
+        .select("firstname", "lastname", "age")
+        .take(2)
+
+      result.length shouldBe (1)
+      result
+        .map(r => (r.getString(0), r.getString(1), r.getLong(2)))
+        .toList should contain allElementsOf List(
+        ("John", "Doe", 25)
+      )
+    }
+
+    "trigger AutoJob with no parameters on SQL statement" should "generate a dataset in business" in {
+
+      val businessTask1 = AutoTaskDesc(
+        "select firstname, lastname, age from user_View",
+        "user",
+        "user",
+        WriteMode.OVERWRITE,
+        area = Some(StorageArea.fromString("business"))
+      )
+      val businessJob =
+        AutoJobDesc(
+          "user",
+          List(businessTask1),
+          None,
+          Some("parquet"),
+          Some(false),
+          views = Some(Map("user_View" -> "accepted/user"))
+        )
+      val schemaHandler = new SchemaHandler(storageHandler)
+
+      val businessJobDef = mapper
+        .writer()
+        .withAttribute(classOf[Settings], settings)
+        .writeValueAsString(businessJob)
+
+      val workflow =
+        new IngestionWorkflow(storageHandler, schemaHandler, new SimpleLauncher())
+      storageHandler.write(businessJobDef, pathBusiness)
+
+      workflow.autoJobRun("user")
 
       sparkSession.read
         .load(pathDatasetBusiness.toString)
         .select("firstname", "lastname", "age")
-        .take(1)
+        .take(6)
         .map(r => (r.getString(0), r.getString(1), r.getLong(2)))
         .toList should contain allElementsOf List(
-        ("test1", "test2", 29)
+        ("John", "Doe", 25),
+        ("fred", "abruzzi", 25),
+        ("test3", "test4", 40)
       )
     }
   }

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/AutoJobHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/AutoJobHandlerSpec.scala
@@ -1,0 +1,63 @@
+package com.ebiznext.comet.schema.handlers
+
+import com.ebiznext.comet.TestHelper
+import com.ebiznext.comet.config.{Settings, StorageArea}
+import com.ebiznext.comet.schema.model.{AutoJobDesc, AutoTaskDesc, WriteMode}
+import com.ebiznext.comet.workflow.IngestionWorkflow
+import org.apache.hadoop.fs.Path
+
+class AutoJobHandlerSpec extends TestHelper {
+
+  lazy val pathBusiness = new Path(cometMetadataPath + "/jobs/user.yml")
+
+  lazy val pathDatasetBusiness = new Path(cometDatasetsPath + "/business/user/user")
+
+  lazy val pathAccepted = new Path(cometDatasetsPath + "/accepted/user")
+
+  lazy val metadataPath = new Path(cometMetadataPath)
+
+  new WithSettings() {
+    "trigger AutoJob by passing parameters on SQL statement" should "generate a dataset in business" in {
+      val accepted =
+        sparkSession.read
+          .option("inferSchema", "true")
+          .json(getResPath("/expected/datasets/accepted/DOMAIN/User.json"))
+
+      accepted
+        .write
+        .mode("overwrite")
+        .parquet(pathAccepted.toString)
+
+      val businessTask1 = AutoTaskDesc(
+        "select firstname, lastname, age from user_View where age={{age}}",
+        "user",
+        "user",
+        WriteMode.OVERWRITE,
+        area = Some(StorageArea.fromString("business"))
+      )
+      val businessJob =
+        AutoJobDesc("user", List(businessTask1), None, Some("parquet"), Some(false), views = Some(Map("user_View" -> "accepted/user")))
+      val schemaHandler = new SchemaHandler(storageHandler)
+
+      val businessJobDef = mapper
+        .writer()
+        .withAttribute(classOf[Settings], settings)
+        .writeValueAsString(businessJob)
+
+      val workflow =
+        new IngestionWorkflow(storageHandler, schemaHandler, new SimpleLauncher())
+      storageHandler.write(businessJobDef, pathBusiness)
+
+      workflow.autoJobRun("user", Some("age=29"))
+
+      sparkSession.read
+        .load(pathDatasetBusiness.toString)
+        .select("firstname", "lastname", "age")
+        .take(1)
+        .map(r => (r.getString(0), r.getString(1), r.getLong(2)))
+        .toList should contain allElementsOf List(
+        ("test1", "test2", 29)
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Summary
The goal of this pull request, is to give users the possibility to pass parameters, to 
their sql statements with an AutoJob.

**Related Issue: #135**

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**


## Give users the possibility  to pass parameters, to their sql statements with an AutoJob.
### Solution
We can now pass sql parameters to our sql task, for example here we can pass "age" as a parameter :
name: "user"
views:
  user_View: "accepted/user"
tasks:
  - domain: "user"
    area: "business"
    dataset: "user"
    write: "OVERWRITE"
    sql: |
      select firstname,
        lastname,
        age
      from user_View
      where age={{age}}

### How has this been tested?
Unit tests are done to verify if an AutoJob can accept or not an sql statement with parameters (AutoJobHandlerSpec)

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ x ] My code follows the code style of this project.
- [  ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.



