### PR TITLE
Codecov badge in the main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://travis-ci.com/ebiznext/comet-data-pipeline.svg?branch=master)](https://travis-ci.com/ebiznext/comet-data-pipeline)
 [![Scala Steward badge](https://img.shields.io/badge/Scala_Steward-helping-blue.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAQCAMAAAARSr4IAAAAVFBMVEUAAACHjojlOy5NWlrKzcYRKjGFjIbp293YycuLa3pYY2LSqql4f3pCUFTgSjNodYRmcXUsPD/NTTbjRS+2jomhgnzNc223cGvZS0HaSD0XLjbaSjElhIr+AAAAAXRSTlMAQObYZgAAAHlJREFUCNdNyosOwyAIhWHAQS1Vt7a77/3fcxxdmv0xwmckutAR1nkm4ggbyEcg/wWmlGLDAA3oL50xi6fk5ffZ3E2E3QfZDCcCN2YtbEWZt+Drc6u6rlqv7Uk0LdKqqr5rk2UCRXOk0vmQKGfc94nOJyQjouF9H/wCc9gECEYfONoAAAAASUVORK5CYII=)](https://scala-steward.org)
+[![codecov](https://codecov.io/gh/ebiznext/comet-data-pipeline/branch/master/graph/badge.svg)](https://codecov.io/gh/ebiznext/comet-data-pipeline)
 
 # About Comet Data Pipeline
 


### PR DESCRIPTION
## Summary
One-liner to integrate the codecov badge on the Readme (provides access to the codecov report ==> we'll be able to pick code-testing tasks easier)


