### PR TITLE
Handle correctly subdirectories in Parquet2CSV

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/convert/Parquet2CSV.scala
+++ b/src/main/scala/com/ebiznext/comet/job/convert/Parquet2CSV.scala
@@ -32,11 +32,11 @@ class Parquet2CSV(config: Parquet2CSVConfig, val storageHandler: StorageHandler)
       case (Some(domainName), Some(schemaName)) =>
         List(new Path(new Path(config.inputFolder, domainName), schemaName))
       case (Some(domainName), None) =>
-        storageHandler.list(new Path(config.inputFolder, domainName))
+        storageHandler.listDirectories(new Path(config.inputFolder, domainName))
       case (None, None) =>
         storageHandler
-          .list(config.inputFolder)
-          .flatMap(domainPath => storageHandler.list(domainPath))
+          .listDirectories(config.inputFolder)
+          .flatMap(domainPath => storageHandler.listDirectories(domainPath))
     }
     val outputPath = config.outputFolder match {
       case None         => config.inputFolder
@@ -66,6 +66,8 @@ class Parquet2CSV(config: Parquet2CSVConfig, val storageHandler: StorageHandler)
               storageHandler.move(tmpFile, csvPath)
             }
           }
+          if (config.deleteSource)
+            storageHandler.delete(path)
           Some(csvPath)
         case false =>
           None
@@ -76,6 +78,7 @@ class Parquet2CSV(config: Parquet2CSVConfig, val storageHandler: StorageHandler)
 }
 
 object Parquet2CSV {
+
   def main(args: Array[String]): Unit = {
     implicit val settings: Settings = Settings(ConfigFactory.load())
     settings.publishMDCData()

--- a/src/main/scala/com/ebiznext/comet/job/convert/Parquet2CSVConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/convert/Parquet2CSVConfig.scala
@@ -11,10 +11,9 @@ case class Parquet2CSVConfig(
   outputFolder: Option[Path] = None,
   domainName: Option[String] = None,
   schemaName: Option[String] = None,
-  withHeader: Boolean = false,
   writeMode: Option[WriteMode] = None,
   deleteSource: Boolean = false,
-  separator: String = ",",
+  options: List[(String, String)] = Nil,
   partitions: Int = 1
 )
 
@@ -26,7 +25,7 @@ object Parquet2CSVConfig extends CliConfig[Parquet2CSVConfig] {
     OParser.sequence(
       programName("comet"),
       note(
-        "example => --input_dir /tmp/datasets/accepted/ --output_dir /tmp/datasets/csv/ --domain sales --schema orders --with_header  --separator ,  --partitions 1 --write_mode overwrite"
+        "example => --input_dir /tmp/datasets/accepted/ --output_dir /tmp/datasets/csv/ --domain sales --schema orders --option header=true  --option separator=,  --partitions 1 --write_mode overwrite"
       ),
       head("comet", BuildInfo.version),
       opt[String]("input_dir")
@@ -45,10 +44,6 @@ object Parquet2CSVConfig extends CliConfig[Parquet2CSVConfig] {
         .action((x, c) => c.copy(schemaName = Some(x)))
         .text("Schema Name  ")
         .optional(),
-      opt[Unit]("with_header")
-        .action((_, c) => c.copy(withHeader = true))
-        .text("Include header in output file ?")
-        .optional(),
       opt[Unit]("delete_source")
         .action((_, c) => c.copy(deleteSource = true))
         .text("delete source parquet file ?")
@@ -57,9 +52,12 @@ object Parquet2CSVConfig extends CliConfig[Parquet2CSVConfig] {
         .action((x, c) => c.copy(writeMode = Some(WriteMode.fromString(x))))
         .text(s"One of ${WriteMode.writes}")
         .optional(),
-      opt[String]("separator")
-        .action((x, c) => c.copy(separator = x))
-        .text("Separator to use")
+      opt[String]("option")
+        .action((x, c) => {
+          val option = x.split('=')
+          c.copy(options = c.options :+ (option(0) -> option(1)))
+        })
+        .text("option to use (sep, delimiter, quote, quoteAll, escape, header ...)")
         .optional(),
       opt[String]("partitions")
         .action((x, c) => c.copy(partitions = x.toInt))

--- a/src/main/scala/com/ebiznext/comet/job/convert/Parquet2CSVConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/convert/Parquet2CSVConfig.scala
@@ -13,6 +13,7 @@ case class Parquet2CSVConfig(
   schemaName: Option[String] = None,
   withHeader: Boolean = false,
   writeMode: Option[WriteMode] = None,
+  deleteSource: Boolean = false,
   separator: String = ",",
   partitions: Int = 1
 )
@@ -24,7 +25,9 @@ object Parquet2CSVConfig extends CliConfig[Parquet2CSVConfig] {
     import builder._
     OParser.sequence(
       programName("comet"),
-      note("example => --input_dir /tmp/datasets/accepted/ --output_dir /tmp/datasets/csv/ --domain sales --schema orders --with_header  --separator ,  --partitions 1 --write_mode overwrite"),
+      note(
+        "example => --input_dir /tmp/datasets/accepted/ --output_dir /tmp/datasets/csv/ --domain sales --schema orders --with_header  --separator ,  --partitions 1 --write_mode overwrite"
+      ),
       head("comet", BuildInfo.version),
       opt[String]("input_dir")
         .action((x, c) => c.copy(inputFolder = new Path(x)))
@@ -45,6 +48,10 @@ object Parquet2CSVConfig extends CliConfig[Parquet2CSVConfig] {
       opt[Unit]("with_header")
         .action((_, c) => c.copy(withHeader = true))
         .text("Include header in output file ?")
+        .optional(),
+      opt[Unit]("delete_source")
+        .action((_, c) => c.copy(deleteSource = true))
+        .text("delete source parquet file ?")
         .optional(),
       opt[String]("write_mode")
         .action((x, c) => c.copy(writeMode = Some(WriteMode.fromString(x))))

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/StorageHandler.scala
@@ -54,6 +54,8 @@ trait StorageHandler extends StrictLogging {
 
   def write(data: String, path: Path): Unit
 
+  def listDirectories(path: Path): List[Path]
+
   def list(path: Path, extension: String = "", since: LocalDateTime = LocalDateTime.MIN): List[Path]
 
   def blockSize(path: Path): Long
@@ -85,6 +87,7 @@ class HdfsStorageHandler(fileSystem: Option[String])(
 ) extends StorageHandler {
 
   val conf = new Configuration()
+
   lazy val normalizedFileSystem: Option[String] = {
     fileSystem.map { fs =>
       if (fs.endsWith(":"))
@@ -149,6 +152,9 @@ class HdfsStorageHandler(fileSystem: Option[String])(
     os.writeBytes(data)
     os.close()
   }
+
+  def listDirectories(path: Path): List[Path] =
+    fs.listStatus(path).filter(_.isDirectory).map(_.getPath).toList
 
   /**
     * List all files in folder

--- a/src/test/scala/com/ebiznext/comet/job/convert/Parquet2CSVSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/job/convert/Parquet2CSVSpec.scala
@@ -25,10 +25,9 @@ class Parquet2CSVSpec extends TestHelper {
       Some(new Path(outputDir.pathAsString)),
       Some(domainName),
       Some(schemaName),
-      true,
       Some(WriteMode.ERROR_IF_EXISTS),
       deleteSource = false,
-      "|",
+      options = List("sep" -> "|", "header" -> "true"),
       1
     )
 

--- a/src/test/scala/com/ebiznext/comet/job/convert/Parquet2CSVSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/job/convert/Parquet2CSVSpec.scala
@@ -11,15 +11,28 @@ import scala.io.Source
 case class Schema(id: String, customer: String, amount: Double, seller_id: String)
 
 class Parquet2CSVSpec extends TestHelper {
-
   new WithSettings() {
-    "CreateAttributes" should "create the correct list of attributes for a complex Json" in {
-      val rootDir = File.newTemporaryDirectory()
-      val outputDir = File(rootDir, "output")
-      val domainName = "domain"
-      val domainPath = File(rootDir, domainName).createDirectory()
-      val schemaName = "schema"
-      val schemaPath = File(domainPath, schemaName)
+
+    val rootDir = File.newTemporaryDirectory()
+    val outputDir = File(rootDir, "output")
+    val domainName = "domain"
+    val domainPath = File(rootDir, domainName).createDirectory()
+    val schemaName = "schema"
+    val schemaPath = File(domainPath, schemaName)
+
+    val config = Parquet2CSVConfig(
+      new Path(rootDir.pathAsString),
+      Some(new Path(outputDir.pathAsString)),
+      Some(domainName),
+      Some(schemaName),
+      true,
+      Some(WriteMode.ERROR_IF_EXISTS),
+      deleteSource = false,
+      "|",
+      1
+    )
+
+    def createParquet() = {
       val data = List(
         Schema("12345", "A009701", 123.65, "AQZERD"),
         Schema("56432", "A000000", 23.8, "AQZERD"),
@@ -27,18 +40,12 @@ class Parquet2CSVSpec extends TestHelper {
       )
       val dataFrame = sparkSession.createDataFrame(sparkSession.sparkContext.parallelize(data))
       dataFrame.write.mode(SaveMode.ErrorIfExists).parquet(schemaPath.pathAsString)
-      val config = Parquet2CSVConfig(
-        new Path(rootDir.pathAsString),
-        Some(new Path(outputDir.pathAsString)),
-        Some(domainName),
-        Some(schemaName),
-        true,
-        Some(WriteMode.ERROR_IF_EXISTS),
-        "|",
-        1
-      )
+    }
+
+    "Convert schema" should "succeed" in {
+      createParquet()
       new Parquet2CSV(config, storageHandler).run()
-      val csvFile = File(outputDir, domainName, schemaName + ".csv")
+      val csvFile = File(outputDir.pathAsString, domainName, schemaName + ".csv")
       val result = Source.fromFile(csvFile.pathAsString).getLines().toList
       val expected = List(
         "id|customer|amount|seller_id",
@@ -46,8 +53,38 @@ class Parquet2CSVSpec extends TestHelper {
         "56432|A000000|23.8|AQZERD",
         "12345|A009701|123.65|AQZERD"
       )
+      csvFile.delete()
       rootDir.delete()
       expected should contain theSameElementsAs result
+    }
+    "Convert schema" should "succeed delete source after completion" in {
+      createParquet()
+      val inputPath = File(rootDir.pathAsString, domainName, schemaName)
+      inputPath.exists shouldBe true
+      new Parquet2CSV(config.copy(deleteSource = true), storageHandler).run()
+      inputPath.exists shouldBe false
+      rootDir.delete()
+    }
+    "Convert schema" should "convert all schemas in domain" in {
+      createParquet()
+      val inputPath = File(rootDir.pathAsString, domainName, schemaName)
+      inputPath.exists shouldBe true
+      val csvFile = File(outputDir.pathAsString, domainName, schemaName + ".csv")
+      csvFile.exists shouldBe false
+      new Parquet2CSV(config.copy(schemaName = None), storageHandler).run()
+      csvFile.delete()
+      rootDir.delete()
+    }
+    "Convert schema" should "convert all domains and schemas in path" in {
+      createParquet()
+      val inputPath = File(rootDir.pathAsString, domainName, schemaName)
+      inputPath.exists shouldBe true
+      val csvFile = File(outputDir.pathAsString, domainName, schemaName + ".csv")
+      csvFile.exists shouldBe false
+      new Parquet2CSV(config, storageHandler).run()
+      csvFile.exists shouldBe true
+      csvFile.delete()
+      rootDir.delete()
     }
   }
 }


### PR DESCRIPTION

## Summary
When source domain and/or schema name is not specified, parquet2csv does not handle correctly subdirectory browsing and thus does not convert any parquet file.

This PR also add an option to delete the source parquet file after completion (false by default)

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**

