### PR TITLE
Allow the option argument to appear multiple times in parquet2csv

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/Main.scala
+++ b/src/main/scala/com/ebiznext/comet/job/Main.scala
@@ -195,7 +195,7 @@ object Main extends StrictLogging {
           case Some(config) =>
             new Parquet2CSV(config, storageHandler).run()
           case _ =>
-            println(MetricsConfig.usage())
+            println(Parquet2CSVConfig.usage())
         }
 
       case _ => printUsage()

--- a/src/main/scala/com/ebiznext/comet/job/convert/Parquet2CSVConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/convert/Parquet2CSVConfig.scala
@@ -53,6 +53,7 @@ object Parquet2CSVConfig extends CliConfig[Parquet2CSVConfig] {
         .text(s"One of ${WriteMode.writes}")
         .optional(),
       opt[String]("option")
+        .unbounded()
         .action((x, c) => {
           val option = x.split('=')
           c.copy(options = c.options :+ (option(0) -> option(1)))


### PR DESCRIPTION
## Summary
option argument in parquet2cscv is allowed to appear multiple times.
**Related Issue: #IssueId**
#175 
**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**

