### PR TITLE
Disable privacy through application.conf

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -39,6 +39,9 @@ file-system = "gs://nps-datastore"
 #file-system = "abfs://cometfs@ebizcomet.dfs.core.windows.net"
 file-system = ${?COMET_FS}
 
+disable-privacy = false
+disable-privacy = ${?COMET_DISABLE_PRIVACY}
+
 chewer-prefix = "comet.chewer"
 chewer-prefix = ${?COMET_CHEWER_PREFIX}
 

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -212,17 +212,18 @@ object Settings extends StrictLogging {
 
   /**
     *
-    * @param datasets    : Absolute path, datasets root folder beneath which each area is defined.
-    * @param metadata    : Absolute path, location where all types / domains and auto jobs are defined
-    * @param metrics     : Absolute path, location where all computed metrics are stored
-    * @param audit       : Absolute path, location where all log are stored
-    * @param archive     : Should we backup the ingested datasets ? true by default
-    * @param writeFormat : Choose between parquet, orc ... Default is parquet
-    * @param launcher    : Cron Job Manager: simple (useful for testing) or airflow ? simple by default
-    * @param analyze     : Should we create basics Hive statistics on the generated dataset ? true by default
-    * @param hive        : Should we create a Hive Table ? true by default
-    * @param area        : see Area above
-    * @param airflow     : Airflow end point. Should be defined even if simple launccher is used instead of airflow.
+    * @param datasets       : Absolute path, datasets root folder beneath which each area is defined.
+    * @param metadata       : Absolute path, location where all types / domains and auto jobs are defined
+    * @param metrics        : Absolute path, location where all computed metrics are stored
+    * @param audit          : Absolute path, location where all log are stored
+    * @param archive        : Should we backup the ingested datasets ? true by default
+    * @param writeFormat    : Choose between parquet, orc ... Default is parquet
+    * @param launcher       : Cron Job Manager : simple (useful for testing) or airflow ? simple by default
+    * @param analyze        : Should we create basics Hive statistics on the generated dataset ? true by default
+    * @param hive           : Should we create a Hive Table ? true by default
+    * @param area           : see Area above
+    * @param airflow        : Airflow end point. Should be defined even if simple launccher is used instead of airflow.
+    * @param disablePrivacy : Disable privacy
     */
   final case class Comet(
     jobId: String,
@@ -247,7 +248,8 @@ object Settings extends StrictLogging {
     jdbcEngines: Map[String, JdbcEngine],
     atlas: Atlas,
     privacy: Privacy,
-    fileSystem: Option[String]
+    fileSystem: Option[String],
+    disablePrivacy: Boolean
   ) extends Serializable {
 
     @throws(classOf[ObjectStreamException])

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -553,7 +553,7 @@ object IngestionUtil {
         colValue
       else
         privacyLevel.crypt(colValue, colMap)
-    val colPatternOK = settings.comet.disablePrivacy || optionalColIsEmpty || colPatternIsValid
+    val colPatternOK = optionalColIsEmpty || colPatternIsValid
     val (sparkValue, colParseOK) =
       if (colPatternOK) {
         Try(tpe.sparkValue(privacy)) match {

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -545,15 +545,15 @@ object IngestionUtil {
       if (trimmedColValue.length == 0) colAttribute.default.getOrElse("")
       else trimmedColValue
 
-    val optionalColIsEmpty = !colAttribute.required && colValue.isEmpty
-    val colPatternIsValid = tpe.matches(colValue)
+    def optionalColIsEmpty = !colAttribute.required && colValue.isEmpty
+    def colPatternIsValid = tpe.matches(colValue)
     val privacyLevel = colAttribute.getPrivacy()
     val privacy =
-      if (privacyLevel == PrivacyLevel.None)
+      if (settings.comet.disablePrivacy || privacyLevel == PrivacyLevel.None)
         colValue
       else
         privacyLevel.crypt(colValue, colMap)
-    val colPatternOK = optionalColIsEmpty || colPatternIsValid
+    val colPatternOK = settings.comet.disablePrivacy || optionalColIsEmpty || colPatternIsValid
     val (sparkValue, colParseOK) =
       if (colPatternOK) {
         Try(tpe.sparkValue(privacy)) match {


### PR DESCRIPTION
## Summary

Add an parameter to `reference.conf` / `application.conf` to make privacy step optional.

**Related Issue: #185 *

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution

Add an parameter to `reference.conf` / `application.conf` to make privacy step optional.

### How has this been tested?
No tests

### Other changes
Turned

```
val optionalColIsEmpty = !colAttribute.required && colValue.isEmpty
val colPatternIsValid = tpe.matches(colValue)
```

Into 

```
def optionalColIsEmpty = !colAttribute.required && colValue.isEmpty
def colPatternIsValid = tpe.matches(colValue)
```

Since they are used only once in here: `val colPatternOK = optionalColIsEmpty || colPatternIsValid` and they should not be called if `settings.comet.disablePrivacy` is `true` to gain some processing time.

## Contributor checklist:
- [X] My code follows the code style of this project.
- [X ] I have updated the documentation accordingly.



