### PR TITLE
Indexing in ES / BQ / JDBC should be active if active.index is not valued to None

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -57,10 +57,6 @@ hadoop {
 }
 
 audit {
-  active = true
-  active = ${?COMET_AUDIT_ACTIVE}
-
-  #  path = ${root}"/metrics/{domain}/{schema}"
   path = ${root}"/audit"
   path = ${?COMET_AUDIT_PATH}
 

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -144,7 +144,6 @@ object Settings extends StrictLogging {
 
   final case class Audit(
     path: String,
-    active: Boolean,
     index: IndexSinkSettings,
     maxErrors: Int
   )

--- a/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
@@ -1,7 +1,6 @@
 package com.ebiznext.comet.job.bqload
 
 import com.ebiznext.comet.config.Settings
-import com.ebiznext.comet.config.Settings.IndexSinkSettings
 import com.ebiznext.comet.utils.{SparkJob, Utils}
 import com.google.cloud.bigquery.testing.RemoteBigQueryHelper
 import com.google.cloud.bigquery.{Schema => BQSchema, _}
@@ -9,7 +8,7 @@ import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration
 import com.google.cloud.hadoop.io.bigquery.output.BigQueryTimePartitioning
 import org.apache.spark.sql.{SaveMode, SparkSession}
 
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 class BigQueryLoadJob(
   cliConfig: BigQueryLoadConfig,
@@ -48,7 +47,8 @@ class BigQueryLoadJob(
     scala.Option(bigquery.getTable(tableId)) getOrElse {
 
       val tableDefinitionBuilder = maybeSchema.fold(StandardTableDefinition.newBuilder()) {
-        schema => StandardTableDefinition.of(schema).toBuilder
+        schema =>
+          StandardTableDefinition.of(schema).toBuilder
       }
 
       cliConfig.outputPartition.foreach { outputPartition =>
@@ -174,25 +174,7 @@ class BigQueryLoadJob(
     * @return : Spark Session used for the job
     */
   override def run(): Try[SparkSession] = {
-    val res = settings.comet.audit.index match {
-      case _: IndexSinkSettings.BigQuery if settings.comet.audit.active =>
-        runBQSparkConnector()
-
-      case _: IndexSinkSettings.BigQuery =>
-        logger.info("BigQuery Audit selected, but audit is inactive — no output")
-        Success(session)
-
-      case _ =>
-        logger.warn(
-          "BigQuery Audit not selected, yet BigQueryLoadJob attempted — no output"
-        ) // TODO: shouldn't this be an IllegalStateException?
-        Success(session)
-    }
-
-    res match {
-      case Success(_)         =>
-      case Failure(exception) => Utils.logException(logger, exception)
-    }
-    res
+    val res = runBQSparkConnector()
+    Utils.logFailure(res, logger)
   }
 }

--- a/src/main/scala/com/ebiznext/comet/job/jdbcload/JdbcLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/jdbcload/JdbcLoadJob.scala
@@ -1,12 +1,11 @@
 package com.ebiznext.comet.job.jdbcload
 
 import com.ebiznext.comet.config.Settings
-import com.ebiznext.comet.config.Settings.IndexSinkSettings
 import com.ebiznext.comet.utils.{SparkJob, Utils}
 import com.google.cloud.bigquery.JobInfo.WriteDisposition
 import org.apache.spark.sql.{SaveMode, SparkSession}
 
-import scala.util.{Success, Try}
+import scala.util.Try
 
 class JdbcLoadJob(
   cliConfig: JdbcLoadConfig
@@ -54,21 +53,7 @@ class JdbcLoadJob(
     * @return : Spark Session used for the job
     */
   override def run(): Try[SparkSession] = {
-    val res = settings.comet.audit.index match {
-      case _: IndexSinkSettings.Jdbc if settings.comet.audit.active =>
-        runJDBC()
-
-      case _: IndexSinkSettings.Jdbc =>
-        logger.info("JDBC Audit selected, but audit is inactive — no output")
-        Success(session)
-
-      case _ =>
-        logger.warn(
-          "JDBC Audit not selected, yet JdbcLoadJob attempted — no output"
-        ) // TODO: shouldn't this be an IllegalStateException?
-        Success(session)
-    }
-
+    val res = runJDBC()
     Utils.logFailure(res, logger)
   }
 }


### PR DESCRIPTION
## Summary
Audit may be active or not. In this PR, audit is always active. Only indexing is optional.
Also, Indexing was not effective when audit.active is false which make no sense.
To disable indexing, simply set comet.audit.index to None
**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**



