### PR TITLE
BUGFIX : fix write to BQ problem

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -147,9 +147,12 @@ assemblyExcludedJars in assembly := {
   Nil
 }
 
-// poi needs a newer version of commons-compress (> 1.17) than the one shipped with spark (1.4)
+
 assemblyShadeRules in assembly := Seq(
-  ShadeRule.rename("org.apache.commons.compress.**" -> "poiShade.commons.compress.@1").inAll
+  // poi needs a newer version of commons-compress (> 1.17) than the one shipped with spark (1.4)
+  ShadeRule.rename("org.apache.commons.compress.**" -> "poiShade.commons.compress.@1").inAll,
+  //shade it or else writing to bigquery wont work because spark comes with an older version of google common.
+  ShadeRule.rename("com.google.common.**" -> "shade.@0").inAll
 )
 
 // Your profile name of the sonatype account. The default is the same with the organization value


### PR DESCRIPTION
## Summary
Use shading to fix write to BQ  error on DataProc

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**


## Description
Writing to BQ from a spark job on DataProc fails with the following error:
`java.lang.NoSuchMethodError: com.google.common.util.concurrent.MoreExecutors.directExecutor()Ljava/util/concurrent/Executor;`
### Solution
Use shading  on to  com.google.common.* to avoid collision with old versions of these classes present in spark.

### How has this been tested?
Running a job that writes to BQ on GCP

Go over all the following points, and put an `x` in all the boxes that apply.
- [x] My code follows the code style of this project.



