### PR TITLE
[enhancement] Pass parameters to presql statements

### DIFF
--- a/src/test/resources/expected/datasets/accepted/DOMAIN/graduateProgram.json
+++ b/src/test/resources/expected/datasets/accepted/DOMAIN/graduateProgram.json
@@ -1,0 +1,4 @@
+{"id": 0, "degree": "Masters", "department": "School_of_Information", "school": "UC_Berkeley"}
+{"id": 1, "degree": "Masters", "department": "EECS", "school": "UC_Berkeley"}
+{"id": 2, "degree": "Ph.D.", "department": "EECS", "school": "UC_Berkeley"}
+{"id": 3, "degree": "Masters", "department": "IT", "school": "MIT"}

--- a/src/test/resources/expected/yml/graduateProgram.yml
+++ b/src/test/resources/expected/yml/graduateProgram.yml
@@ -1,0 +1,18 @@
+name: "graduateProgram"
+views:
+  graduate_View: "accepted/graduateProgram"
+tasks:
+  - domain: "graduateProgram"
+    area: "business"
+    dataset: "output"
+    write: "OVERWRITE"
+    presql: |
+      create or replace view graduate_agg_view
+      select degree,
+        department,
+        school
+      from graduate_View
+      where school={{school}}
+
+    sql:  |
+            SELECT * FROM graduate_agg_view


### PR DESCRIPTION
## Summary
The goal of this pull request, is to give users the possibility to pass parameters, to
their presql statements with an AutoJob.

**PR Type: Feature **

**Status: Ready to review**

**Breaking change? No**


### Solution
We can now pass sql parameters to our presql task,s for example here we can pass "school" as a parameter :
name: "graduateProgram"
views:
  graduate_View: "accepted/graduateProgram"
tasks:
  - domain: "graduateProgram"
    area: "business"
    dataset: "output"
    write: "OVERWRITE"
    presql: |
      create or replace view graduate_agg_view
      select degree,
        department,
        school
      from graduate_View
      where school={{school}}

    sql:  |
            SELECT * FROM graduate_agg_view

### How has this been tested?
Unit tests.

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ x ] I have updated the documentation accordingly.



