### PR TITLE
Let user specify custom delimiter in the command line

### DIFF
--- a/src/main/scala/com/ebiznext/comet/schema/generator/SchemaGen.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/SchemaGen.scala
@@ -41,7 +41,7 @@ object SchemaGen extends LazyLogging {
     *     - Separator : µ  //TODO perhaps read this from reference.conf
     * @param domain
     */
-  def genPostEncryptionDomain(domain: Domain, privacy: Seq[String]): Domain = {
+  def genPostEncryptionDomain(domain: Domain, separator: String, privacy: Seq[String]): Domain = {
     val postEncryptSchemas: List[Schema] = domain.schemas.map { schema =>
       val metadata = for {
         metadata <- schema.metadata
@@ -51,7 +51,7 @@ object SchemaGen extends LazyLogging {
           throw new Exception("Not Implemented")
         metadata.copy(
           format = Some(Format.DSV),
-          separator = Some("µ"),
+          separator = Some(separator),
           withHeader = Some(false) //TODO set to true, and make sure files are written with a header ?
         )
       }
@@ -103,7 +103,7 @@ object Main extends App {
         } yield {
           val preEncrypt = genPreEncryptionDomain(domain, config.privacy)
           writeDomainYaml(preEncrypt, outputPath, "pre-encrypt-" + preEncrypt.name)
-          val postEncrypt = genPostEncryptionDomain(domain, config.privacy)
+          val postEncrypt = genPostEncryptionDomain(domain, "µ", config.privacy)
           writeDomainYaml(postEncrypt, outputPath, "post-encrypt-" + domain.name)
         }
       } else {

--- a/src/main/scala/com/ebiznext/comet/schema/generator/SchemaGen.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/SchemaGen.scala
@@ -103,7 +103,7 @@ object Main extends App {
         } yield {
           val preEncrypt = genPreEncryptionDomain(domain, config.privacy)
           writeDomainYaml(preEncrypt, outputPath, "pre-encrypt-" + preEncrypt.name)
-          val postEncrypt = genPostEncryptionDomain(domain, "µ", config.privacy)
+          val postEncrypt = genPostEncryptionDomain(domain, config.delimiter, config.privacy)
           writeDomainYaml(postEncrypt, outputPath, "post-encrypt-" + domain.name)
         }
       } else {

--- a/src/main/scala/com/ebiznext/comet/schema/generator/SchemaGen.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/SchemaGen.scala
@@ -41,7 +41,7 @@ object SchemaGen extends LazyLogging {
     *     - Separator : µ  //TODO perhaps read this from reference.conf
     * @param domain
     */
-  def genPostEncryptionDomain(domain: Domain, separator: String, privacy: Seq[String]): Domain = {
+  def genPostEncryptionDomain(domain: Domain, delimiter: String, privacy: Seq[String]): Domain = {
     val postEncryptSchemas: List[Schema] = domain.schemas.map { schema =>
       val metadata = for {
         metadata <- schema.metadata
@@ -51,7 +51,7 @@ object SchemaGen extends LazyLogging {
           throw new Exception("Not Implemented")
         metadata.copy(
           format = Some(Format.DSV),
-          separator = Some(separator),
+          separator = Some(delimiter),
           withHeader = Some(false) //TODO set to true, and make sure files are written with a header ?
         )
       }

--- a/src/main/scala/com/ebiznext/comet/schema/generator/SchemaGenConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/SchemaGenConfig.scala
@@ -27,11 +27,13 @@ import scopt.OParser
   *
   * @param files List of Excel files
   * @param encryption Should pre & post encryption YAML be generated ?
+  * @param delimiter : Delimiter to use on generated CSV file after pre-encryption.
   * @param privacy What privacy policies are to be applied at the pre-encrypt step ? All by default.
   */
 case class SchemaGenConfig(
   files: Seq[String] = Nil,
   encryption: Boolean = true,
+  delimiter: String = "µ",
   privacy: Seq[String] = Nil
 )
 
@@ -50,6 +52,10 @@ object SchemaGenConfig extends CliConfig[SchemaGenConfig] {
       opt[Boolean]("encryption")
         .action((x, c) => c.copy(encryption = x))
         .required()
+        .text("If true generate pre and post encryption YML"),
+      opt[String]("delimiter")
+        .action((x, c) => c.copy(delimiter = x))
+        .optional()
         .text("If true generate pre and post encryption YML"),
       opt[Seq[String]]("privacy")
         .action((x, c) => c.copy(privacy = x))

--- a/src/main/scala/com/ebiznext/comet/schema/generator/SchemaGenConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/SchemaGenConfig.scala
@@ -56,7 +56,7 @@ object SchemaGenConfig extends CliConfig[SchemaGenConfig] {
       opt[String]("delimiter")
         .action((x, c) => c.copy(delimiter = x))
         .optional()
-        .text("If true generate pre and post encryption YML"),
+        .text("CSV delimiter to use in post-encrypt YML."),
       opt[Seq[String]]("privacy")
         .action((x, c) => c.copy(privacy = x))
         .optional()

--- a/src/test/scala/com/ebiznext/comet/schema/generator/SchemaGenSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/generator/SchemaGenSpec.scala
@@ -59,7 +59,7 @@ class SchemaGenSpec extends TestHelper {
     }
     "No privacy policies" should "be applied in the post-encrypt step " in {
       domainOpt shouldBe defined
-      val preEncrypt = SchemaGen.genPostEncryptionDomain(domainOpt.get, Nil)
+      val preEncrypt = SchemaGen.genPostEncryptionDomain(domainOpt.get, "µ", Nil)
       validCount(preEncrypt, "HIDE", 0)
       validCount(preEncrypt, "MD5", 0)
       validCount(preEncrypt, "SHA1", 0)
@@ -76,13 +76,23 @@ class SchemaGenSpec extends TestHelper {
       domainOpt.get.schemas
         .flatMap(_.metadata)
         .count(_.format.contains(Format.POSITION)) shouldBe 1
-      val postEncrypt = SchemaGen.genPostEncryptionDomain(domainOpt.get, List("HIDE", "SHA1"))
+      val postEncrypt = SchemaGen.genPostEncryptionDomain(domainOpt.get, "µ", List("HIDE", "SHA1"))
       postEncrypt.schemas
         .flatMap(_.metadata)
         .filter(_.format.contains(Format.POSITION)) shouldBe empty
       validCount(postEncrypt, "HIDE", 0)
       validCount(postEncrypt, "MD5", 2)
       validCount(postEncrypt, "SHA1", 0)
+    }
+    "a custom separator" should "be generated" in {
+      domainOpt shouldBe defined
+      domainOpt.get.schemas
+        .flatMap(_.metadata)
+        .count(_.format.contains(Format.POSITION)) shouldBe 1
+      val postEncrypt = SchemaGen.genPostEncryptionDomain(domainOpt.get, ",", Nil)
+      postEncrypt.schemas
+        .flatMap(_.metadata)
+        .filterNot(_.separator.contains(",")) shouldBe empty
     }
   }
 


### PR DESCRIPTION
## Summary
Let user specify custom delimiter in the command line on pre/post-encrypt YAML generation

**Related Issue: #212 **

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**
