### PR TITLE
[FIX] BigQuery can't infer the Schema of the Dataset if the Table is Partitioned

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
@@ -1,12 +1,14 @@
 package com.ebiznext.comet.job.bqload
 
 import com.ebiznext.comet.config.Settings
+import com.ebiznext.comet.job.conversion.bigquery._
+import com.ebiznext.comet.job.conversion.syntax._
 import com.ebiznext.comet.utils.{SparkJob, Utils}
 import com.google.cloud.bigquery.testing.RemoteBigQueryHelper
 import com.google.cloud.bigquery.{Schema => BQSchema, _}
 import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration
 import com.google.cloud.hadoop.io.bigquery.output.BigQueryTimePartitioning
-import org.apache.spark.sql.{SaveMode, SparkSession}
+import org.apache.spark.sql.{DataFrame, SaveMode, SparkSession}
 
 import scala.util.Try
 
@@ -15,8 +17,9 @@ class BigQueryLoadJob(
   maybeSchema: scala.Option[BQSchema] = None
 )(implicit val settings: Settings)
     extends SparkJob {
+  import cliConfig._
 
-  override def name: String = s"bqload-${cliConfig.outputDataset}-${cliConfig.outputTable}"
+  override def name: String = s"bqload-${outputDataset}-${outputTable}"
 
   val conf = session.sparkContext.hadoopConfiguration
   logger.info(s"BigQuery Config $cliConfig")
@@ -27,30 +30,33 @@ class BigQueryLoadJob(
   val projectId = conf.get("fs.gs.project.id")
   val bucket = conf.get("fs.defaultFS")
 
-  val tableId = TableId.of(cliConfig.outputDataset, cliConfig.outputTable)
+  val tableId = TableId.of(outputDataset, outputTable)
 
   def getOrCreateDataset(): Dataset = {
-    val datasetId = DatasetId.of(projectId, cliConfig.outputDataset)
+    val datasetId = DatasetId.of(projectId, outputDataset)
     val dataset = scala.Option(bigquery.getDataset(datasetId))
     dataset.getOrElse {
       val datasetInfo = DatasetInfo
-        .newBuilder(cliConfig.outputDataset)
-        .setLocation(cliConfig.getLocation())
+        .newBuilder(outputDataset)
+        .setLocation(getLocation())
         .build
       bigquery.create(datasetInfo)
     }
   }
 
-  def getOrCreateTable(): Table = {
+  def getOrCreateTable(df: DataFrame): Table = {
     getOrCreateDataset()
     import com.google.cloud.bigquery.{StandardTableDefinition, TableInfo}
     scala.Option(bigquery.getTable(tableId)) getOrElse {
 
-      val tableDefinitionBuilder = maybeSchema.fold(StandardTableDefinition.newBuilder()) {
-        schema => StandardTableDefinition.of(schema).toBuilder
-      }
+      val tableDefinitionBuilder =
+        outputPartition match {
+          case Some(_) =>
+            StandardTableDefinition.of(df.to[BQSchema]).toBuilder
+          case _ => StandardTableDefinition.newBuilder()
+        }
 
-      cliConfig.outputPartition.foreach { outputPartition =>
+      outputPartition.foreach { outputPartition =>
         import com.google.cloud.bigquery.TimePartitioning
         val timeField =
           if (List("_PARTITIONDATE", "_PARTITIONTIME").contains(outputPartition))
@@ -63,7 +69,7 @@ class BigQueryLoadJob(
               .setRequirePartitionFilter(true)
               .setField(outputPartition)
 
-        val timeFieldWithExpiration = cliConfig.days
+        val timeFieldWithExpiration = days
           .map(_ * 3600 * 24 * 1000L)
           .map(ms => timeField.setExpirationMs(ms))
           .getOrElse(timeField)
@@ -81,17 +87,16 @@ class BigQueryLoadJob(
     val conf = session.sparkContext.hadoopConfiguration
     logger.info(s"BigQuery Config $cliConfig")
 
-    val projectId = conf.get("fs.gs.project.id")
     val bucket = conf.get("fs.gs.system.bucket")
 
-    val inputPath = cliConfig.sourceFile
+    val inputPath = sourceFile
     logger.info(s"Input path $inputPath")
 
     logger.info(s"Temporary GCS path $bucket")
     session.conf.set("temporaryGcsBucket", bucket)
 
     val writeDisposition = JobInfo.WriteDisposition.valueOf(cliConfig.writeDisposition)
-    val tableId = TableId.of(cliConfig.outputDataset, cliConfig.outputTable)
+    val tableId = TableId.of(outputDataset, outputTable)
     val finalWriteDisposition = writeDisposition match {
       case JobInfo.WriteDisposition.WRITE_TRUNCATE =>
         logger.info(s"Deleting table $tableId")
@@ -101,51 +106,46 @@ class BigQueryLoadJob(
       case _ =>
         writeDisposition
     }
-    val table = getOrCreateTable()
-
-    def bqPartition() = {
-      conf.set(
-        BigQueryConfiguration.OUTPUT_TABLE_WRITE_DISPOSITION_KEY,
-        finalWriteDisposition.toString
-      )
-      conf.set(
-        BigQueryConfiguration.OUTPUT_TABLE_CREATE_DISPOSITION_KEY,
-        cliConfig.createDisposition
-      )
-      cliConfig.outputPartition.foreach { outputPartition =>
-        import com.google.cloud.hadoop.repackaged.bigquery.com.google.api.services.bigquery.model.TimePartitioning
-        val timeField =
-          if (List("_PARTITIONDATE", "_PARTITIONTIME").contains(outputPartition))
-            new TimePartitioning().setType("DAY").setRequirePartitionFilter(true)
-          else
-            new TimePartitioning()
-              .setType("DAY")
-              .setRequirePartitionFilter(true)
-              .setField(outputPartition)
-        val timePartitioning =
-          new BigQueryTimePartitioning(
-            timeField
-          )
-
-        conf.set(BigQueryConfiguration.OUTPUT_TABLE_PARTITIONING_KEY, timePartitioning.getAsJson)
-      }
-    }
-
     Try {
-      bqPartition()
-
       val sourceDF =
         inputPath match {
           case Left(path) => session.read.parquet(path)
           case Right(df)  => df
         }
 
-      val bqTable = s"${cliConfig.outputDataset}.${cliConfig.outputTable}"
-      /*
-      val parquetDF = maybeSchema.fold(sourceDF) { schema =>
-        session.createDataFrame(sourceDF.rdd, schema.sparkType())
+      val table = getOrCreateTable(sourceDF)
+
+      def bqPartition(): Unit = {
+        conf.set(
+          BigQueryConfiguration.OUTPUT_TABLE_WRITE_DISPOSITION_KEY,
+          finalWriteDisposition.toString
+        )
+        conf.set(
+          BigQueryConfiguration.OUTPUT_TABLE_CREATE_DISPOSITION_KEY,
+          createDisposition
+        )
+        outputPartition.foreach { outputPartition =>
+          import com.google.cloud.hadoop.repackaged.bigquery.com.google.api.services.bigquery.model.TimePartitioning
+          val timeField =
+            if (List("_PARTITIONDATE", "_PARTITIONTIME").contains(outputPartition))
+              new TimePartitioning().setType("DAY").setRequirePartitionFilter(true)
+            else
+              new TimePartitioning()
+                .setType("DAY")
+                .setRequirePartitionFilter(true)
+                .setField(outputPartition)
+          val timePartitioning =
+            new BigQueryTimePartitioning(
+              timeField
+            )
+
+          conf.set(BigQueryConfiguration.OUTPUT_TABLE_PARTITIONING_KEY, timePartitioning.getAsJson)
+        }
       }
-       */
+
+      bqPartition()
+
+      val bqTable = s"${outputDataset}.${outputTable}"
 
       val stdTableDefinition =
         bigquery.getTable(table.getTableId).getDefinition.asInstanceOf[StandardTableDefinition]
@@ -176,4 +176,5 @@ class BigQueryLoadJob(
     val res = runBQSparkConnector()
     Utils.logFailure(res, logger)
   }
+
 }

--- a/src/main/scala/com/ebiznext/comet/job/conversion/Convertible.scala
+++ b/src/main/scala/com/ebiznext/comet/job/conversion/Convertible.scala
@@ -1,0 +1,17 @@
+package com.ebiznext.comet.job.conversion
+
+trait Convertible[A, B] extends (A => B)
+
+trait ConvertibleWith[A, CoA, B] extends ((A, CoA) => B)
+
+package object syntax {
+
+  implicit class ConvertibleOps[A](a: A) {
+
+    def to[B](implicit convert: Convertible[A, B]): B = convert(a)
+
+    def to[B, WithA](adjuvant: WithA)(implicit convert: ConvertibleWith[A, WithA, B]): B =
+      convert(a, adjuvant)
+  }
+
+}

--- a/src/main/scala/com/ebiznext/comet/job/conversion/bigquery.scala
+++ b/src/main/scala/com/ebiznext/comet/job/conversion/bigquery.scala
@@ -1,0 +1,80 @@
+package com.ebiznext.comet.job.conversion
+
+import com.google.cloud.bigquery.{Field, LegacySQLTypeName, Schema => BQSchema}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.types._
+
+/**
+  *
+  * Conversion between Spark DataFrame Schema and BigQuery Schema
+  */
+object bigquery {
+
+  implicit val sparkToBq: Convertible[DataFrame, BQSchema] = new Convertible[DataFrame, BQSchema] {
+    override def apply(v1: DataFrame): BQSchema = bqSchema(v1)
+  }
+
+  /**
+    *
+    * @param df Spark DataFrame
+    * @return
+    */
+  private[conversion] def bqSchema(df: DataFrame): BQSchema = {
+    def convert(sparkType: DataType): LegacySQLTypeName = {
+
+      val BQ_NUMERIC_PRECISION = 38
+      val BQ_NUMERIC_SCALE = 9
+      lazy val NUMERIC_SPARK_TYPE =
+        DataTypes.createDecimalType(BQ_NUMERIC_PRECISION, BQ_NUMERIC_SCALE)
+
+      sparkType match {
+        case BooleanType                                     => LegacySQLTypeName.BOOLEAN
+        case ByteType | LongType | IntegerType               => LegacySQLTypeName.INTEGER
+        case DoubleType | FloatType                          => LegacySQLTypeName.FLOAT
+        case StringType                                      => LegacySQLTypeName.STRING
+        case BinaryType                                      => LegacySQLTypeName.BYTES
+        case DateType                                        => LegacySQLTypeName.DATE
+        case TimestampType                                   => LegacySQLTypeName.TIMESTAMP
+        case DecimalType.SYSTEM_DEFAULT | NUMERIC_SPARK_TYPE => LegacySQLTypeName.NUMERIC
+        case _                                               => throw new IllegalArgumentException(s"Unsupported type:$sparkType")
+      }
+    }
+    val fields = fieldsSchemaAsMap(df.schema)
+      .map {
+        case (field: String, dataType: DataType) =>
+          Field
+            .newBuilder(
+              field,
+              convert(dataType)
+            )
+            .setMode(Field.Mode.NULLABLE)
+            .setDescription("")
+            .build()
+      }
+    BQSchema.of(fields: _*)
+  }
+
+  /**
+    *
+    * The aim of this function is to retrieve columns and nested columns
+    * with their types from a spark schema
+    * @param schema Spark Schema
+    * @return List of Spark Columns with their Type
+    */
+  private def fieldsSchemaAsMap(schema: DataType): List[(String, DataType)] = {
+    val fullName: String => String = name => name
+    schema match {
+      case StructType(fields: Array[StructField]) =>
+        fields.toList.flatMap {
+          case StructField(name, inner: StructType, _, _) =>
+            (fullName(name), inner) +: fieldsSchemaAsMap(inner)
+          case StructField(name, inner: ArrayType, _, _) =>
+            (fullName(name), inner) +: fieldsSchemaAsMap(inner.elementType)
+          case StructField(name, inner: DataType, _, _) =>
+            List[(String, DataType)]((fullName(name), inner))
+        }
+      case _ => List.empty[(String, DataType)]
+    }
+  }
+
+}

--- a/src/main/scala/com/ebiznext/comet/job/conversion/bigquery.scala
+++ b/src/main/scala/com/ebiznext/comet/job/conversion/bigquery.scala
@@ -5,8 +5,8 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types._
 
 /**
-  *
-  * Conversion between Spark DataFrame Schema and BigQuery Schema
+  * [X] whatever
+  * Conversion between [X] Schema and BigQuery Schema
   */
 object bigquery {
 

--- a/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
@@ -22,9 +22,10 @@ package com.ebiznext.comet.schema.model
 
 import java.util.regex.Pattern
 
+import com.ebiznext.comet.job.conversion.bigquery._
 import com.ebiznext.comet.schema.handlers.SchemaHandler
 import com.ebiznext.comet.utils.TextSubstitutionEngine
-import com.google.cloud.bigquery.{Field, LegacySQLTypeName}
+import com.google.cloud.bigquery.Field
 import org.apache.spark.sql.types._
 
 import scala.collection.mutable
@@ -94,25 +95,6 @@ case class Schema(
   import com.google.cloud.bigquery.{Schema => BQSchema}
 
   def bqSchema(schemaHandler: SchemaHandler): BQSchema = {
-    def convert(sparkType: DataType): LegacySQLTypeName = {
-
-      val BQ_NUMERIC_PRECISION = 38
-      val BQ_NUMERIC_SCALE = 9
-      lazy val NUMERIC_SPARK_TYPE =
-        DataTypes.createDecimalType(BQ_NUMERIC_PRECISION, BQ_NUMERIC_SCALE)
-
-      sparkType match {
-        case BooleanType                                     => LegacySQLTypeName.BOOLEAN
-        case ByteType | LongType | IntegerType               => LegacySQLTypeName.INTEGER
-        case DoubleType | FloatType                          => LegacySQLTypeName.FLOAT
-        case StringType                                      => LegacySQLTypeName.STRING
-        case BinaryType                                      => LegacySQLTypeName.BYTES
-        case DateType                                        => LegacySQLTypeName.DATE
-        case TimestampType                                   => LegacySQLTypeName.TIMESTAMP
-        case DecimalType.SYSTEM_DEFAULT | NUMERIC_SPARK_TYPE => LegacySQLTypeName.NUMERIC
-        case _                                               => throw new IllegalArgumentException(s"Unsupported type:$sparkType")
-      }
-    }
     val fields = attributes map { attribute =>
       Field
         .newBuilder(


### PR DESCRIPTION
## Summary
A correction to the problem described in #217 

**Related Issue: #217**

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
We have to pass the schema to bq for **Partitioned** Table.

### How has this been tested?
Run an autojob with index BQ active, a Partitioned Table is created in BigQuery, for example :

```
name: "person_agg"
views:
  person_View: "accepted/person/person"
tasks:
  - domain: "person_agg_domain"
    area: "business"
    dataset: "person_agg_kpis"
    write: "OVERWRITE"
    sql: |
      select name, to_date({{date_event}}, "yyyy-dd-MM") AS event_date,
      current_timestamp() AS processing_time 
      from person_View
    partition: ["event_date"]
    index: "BQ"
    properties:
      timestamp: event_date 
```


## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ * ] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.



