### PR TITLE
Add support for Storage level

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -335,4 +335,5 @@ airflow {
 internal {
   # See https://spark.apache.org/docs/latest/api/java/index.html?org/apache/spark/storage/StorageLevel.html
   cache-storage-level = "MEMORY_ONLY"
+  cache-storage-level = ${?COMET_INTERNAL_CACHE_STORAGE_LEVEL}
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -331,3 +331,8 @@ airflow {
   endpoint = ${?AIRFLOW_ENDPOINT}
 }
 
+
+internal {
+  # See https://spark.apache.org/docs/latest/api/java/index.html?org/apache/spark/storage/StorageLevel.html
+  cache-storage-level = "MEMORY_ONLY"
+}

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -40,6 +40,7 @@ import com.typesafe.config.{Config, ConfigValueFactory}
 import com.typesafe.scalalogging.{Logger, StrictLogging}
 import configs.Configs
 import configs.syntax._
+import org.apache.spark.storage.StorageLevel
 import org.slf4j.MDC
 
 import scala.concurrent.duration.FiniteDuration
@@ -212,6 +213,8 @@ object Settings extends StrictLogging {
 
   final case class Atlas(uri: String, user: String, password: String, owner: String)
 
+  final case class Internal(cacheStorageLevel: String)
+
   /**
     *
     * @param datasets       : Absolute path, datasets root folder beneath which each area is defined.
@@ -249,8 +252,13 @@ object Settings extends StrictLogging {
     jdbcEngines: Map[String, JdbcEngine],
     atlas: Atlas,
     privacy: Privacy,
-    fileSystem: Option[String]
+    fileSystem: Option[String],
+    internal: Option[Internal]
   ) extends Serializable {
+
+    val cacheStorageLevel = internal
+      .map(__ => StorageLevel.fromString(__.cacheStorageLevel))
+      .getOrElse(StorageLevel.MEMORY_ONLY)
 
     @throws(classOf[ObjectStreamException])
     protected def writeReplace: AnyRef = {

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -213,7 +213,7 @@ object Settings extends StrictLogging {
 
   final case class Atlas(uri: String, user: String, password: String, owner: String)
 
-  final case class Internal(cacheStorageLevel: String)
+  final case class Internal(cacheStorageLevel: StorageLevel)
 
   /**
     *
@@ -256,9 +256,7 @@ object Settings extends StrictLogging {
     internal: Option[Internal]
   ) extends Serializable {
 
-    val cacheStorageLevel = internal
-      .map(__ => StorageLevel.fromString(__.cacheStorageLevel))
-      .getOrElse(StorageLevel.MEMORY_ONLY)
+    val cacheStorageLevel = internal.map(_.cacheStorageLevel).getOrElse(StorageLevel.MEMORY_ONLY)
 
     @throws(classOf[ObjectStreamException])
     protected def writeReplace: AnyRef = {
@@ -291,6 +289,11 @@ object Settings extends StrictLogging {
   private implicit val indexSinkSettinsConfigs: Configs[IndexSinkSettings] =
     Configs.derive[IndexSinkSettings]
   private implicit val jdbcEngineConfigs: Configs[JdbcEngine] = Configs.derive[JdbcEngine]
+
+  private implicit val internalConfigs: Configs[Internal] = Configs.derive[Internal]
+
+  private implicit val storageLevelConfigs: Configs[StorageLevel] =
+    Configs[String].map(StorageLevel.fromString)
 
   def apply(config: Config): Settings = {
     val jobId = UUID.randomUUID().toString

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -213,7 +213,7 @@ object Settings extends StrictLogging {
 
   final case class Atlas(uri: String, user: String, password: String, owner: String)
 
-  final case class Internal(cacheStorageLevel: StorageLevel)
+  final case class Internal(cacheStorageLevel: StorageLevel) {}
 
   /**
     *
@@ -290,10 +290,8 @@ object Settings extends StrictLogging {
     Configs.derive[IndexSinkSettings]
   private implicit val jdbcEngineConfigs: Configs[JdbcEngine] = Configs.derive[JdbcEngine]
 
-  private implicit val internalConfigs: Configs[Internal] = Configs.derive[Internal]
-
   private implicit val storageLevelConfigs: Configs[StorageLevel] =
-    Configs[String].map(StorageLevel.fromString)
+    Configs[String].map(StorageLevel.fromString).map(_.asInstanceOf[StorageLevel])
 
   def apply(config: Config): Settings = {
     val jobId = UUID.randomUUID().toString

--- a/src/main/scala/com/ebiznext/comet/database/extractor/ExtractScriptGen.scala
+++ b/src/main/scala/com/ebiznext/comet/database/extractor/ExtractScriptGen.scala
@@ -93,7 +93,7 @@ object Main extends App with StrictLogging {
   val domains: List[Domain] = schemaHandler.domains
 
   val arglist = args.toList
-  logger.info(s"Running Comet $arglist")
+  logger.info(s"Running Cet $arglist")
 
   ExtractScriptGenConfig.parse(args) match {
     case Some(config) =>

--- a/src/main/scala/com/ebiznext/comet/database/extractor/ExtractScriptGen.scala
+++ b/src/main/scala/com/ebiznext/comet/database/extractor/ExtractScriptGen.scala
@@ -93,7 +93,7 @@ object Main extends App with StrictLogging {
   val domains: List[Domain] = schemaHandler.domains
 
   val arglist = args.toList
-  logger.info(s"Running Cet $arglist")
+  logger.info(s"Running Comet $arglist")
 
   ExtractScriptGenConfig.parse(args) match {
     case Some(config) =>

--- a/src/main/scala/com/ebiznext/comet/job/ingest/DsvIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/DsvIngestionJob.scala
@@ -32,6 +32,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.storage.StorageLevel
 
 import scala.util.{Failure, Success, Try}
 
@@ -268,7 +269,7 @@ object DsvIngestionUtil {
             )
           }
         }
-      } cache ()
+      } persist (settings.comet.cacheStorageLevel)
 
     val rejectedRDD: RDD[String] = checkedRDD
       .filter(_.isRejected)

--- a/src/main/scala/com/ebiznext/comet/job/ingest/DsvIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/DsvIngestionJob.scala
@@ -32,7 +32,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions.GenericRowWithSchema
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.storage.StorageLevel
 
 import scala.util.{Failure, Success, Try}
 

--- a/src/main/scala/com/ebiznext/comet/job/ingest/JsonIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/JsonIngestionJob.scala
@@ -28,7 +28,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.execution.datasources.json.JsonIngestionUtil
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Encoders, Row}
-import org.apache.spark.storage.StorageLevel
 
 import scala.util.{Failure, Success, Try}
 

--- a/src/test/scala/com/ebiznext/comet/config/ConfigSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/config/ConfigSpec.scala
@@ -1,0 +1,34 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ *
+ */
+
+package com.ebiznext.comet.config
+
+import com.ebiznext.comet.TestHelper
+import org.apache.spark.storage.StorageLevel
+
+class ConfigSpec extends TestHelper {
+
+  val internalConfig =
+    new WithSettings() {
+      "Custom Storage Level" should "be derived correctly" in {
+        settings.comet.internal.map(_.cacheStorageLevel) shouldEqual Some(StorageLevel.MEMORY_ONLY)
+      }
+    }
+}


### PR DESCRIPTION
## Summary
This will allow for example Comet to work efficiently on memory constrained environments
Sometimes, we are working in a constrained memory env. This lead sometimes Comet to reexcute the whole transformation many times. We solve that by allowing the user to choose the storage level
**PR Type: Enhancement**

**Status: Ready to review**

**Breaking change? No**
