### PR TITLE
use DecimalFormat with a positive prefix

### DIFF
--- a/src/main/scala/com/ebiznext/comet/schema/model/PrimitiveType.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/PrimitiveType.scala
@@ -21,7 +21,7 @@
 package com.ebiznext.comet.schema.model
 
 import java.sql.Timestamp
-import java.text.NumberFormat
+import java.text.{DecimalFormat, NumberFormat}
 import java.time._
 import java.time.format.DateTimeFormatter
 import java.time.temporal.TemporalAccessor
@@ -122,7 +122,11 @@ object PrimitiveType {
       else {
         val locale = zone.split('_')
         val currentLocale: Locale = new Locale(locale(0), locale(1))
-        val numberFormatter = NumberFormat.getNumberInstance(currentLocale)
+        val numberFormatter =
+          NumberFormat.getNumberInstance(currentLocale).asInstanceOf[DecimalFormat]
+        str.headOption
+          .withFilter(_.equals('+'))
+          .foreach(_ => numberFormatter.setPositivePrefix("+"))
         numberFormatter.parse(str).doubleValue()
       }
     }

--- a/src/test/scala/com/ebiznext/comet/schema/model/TypesSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/model/TypesSpec.scala
@@ -139,5 +139,36 @@ class TypesSpec extends TestHelper {
 
     }
 
+    "Double Type with a Zone" should "be able to parse a value with a + prefix" in {
+      val stream: InputStream =
+        getClass.getResourceAsStream("/quickstart/metadata/types/default.yml")
+      val lines = scala.io.Source
+          .fromInputStream(stream)
+          .getLines()
+          .mkString("\n") +
+        """
+        |  - name: "signed_double_fr"
+        |    primitiveType: "double"
+        |    pattern: "[+,-]?\\d*\\,{0,1}\\d+"
+        |    sample: "+45.78"
+        |    zone: Fr_fr
+        |    comment: "Floating value with a sign prefix and french decimal point"
+        |""".stripMargin
+      val types = mapper.readValue(lines, classOf[Types])
+      val doubleType = types.types
+        .find(_.name == "double")
+        .get
+      doubleType.matches("+3.14") shouldBe false
+      val signedDoubleType = types.types
+        .find(_.name == "signed_double_fr")
+        .get
+      signedDoubleType.matches("+3,14") shouldBe true
+      signedDoubleType.sparkValue("+3,14") shouldBe 3.14d
+      signedDoubleType.matches("3,14") shouldBe true
+      signedDoubleType.sparkValue("3,14") shouldBe 3.14d
+      signedDoubleType.matches("-3,14") shouldBe true
+      signedDoubleType.sparkValue("-3,14") shouldBe -3.14d
+
+    }
   }
 }


### PR DESCRIPTION
## Summary
Fixing the problem described in issue #225 

**Related Issue: #225**

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? Yes/No**

## Description
### Solution
Use a `DecimalFormatNumber` and set set a `positivePrefix` when necessary

### How has this been tested?
Adding Unit Tests

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



