### PR TITLE
Make code in sync with doc and use hcon depth in env names

### DIFF
--- a/src/main/resources/azure/reference.conf
+++ b/src/main/resources/azure/reference.conf
@@ -83,19 +83,19 @@ metrics {
 
 area {
   pending = "pending"
-  pending = ${?COMET_PENDING}
+  pending = ${?COMET_AREA_PENDING}
   unresolved = "unresolved"
-  unresolved = ${?COMET_UNRESOLVED}
+  unresolved = ${?COMET_AREA_UNRESOLVED}
   archive = "archive"
-  archive = ${?COMET_ARCHIVE}
+  archive = ${?COMET_AREA_ARCHIVE}
   ingesting = "ingesting"
-  ingesting = ${?COMET_INGESTING}
+  ingesting = ${?COMET_AREA_INGESTING}
   accepted = "accepted"
-  accepted = ${?COMET_ACCEPTED}
+  accepted = ${?COMET_AREA_ACCEPTED}
   rejected = "rejected"
-  rejected = ${?COMET_REJECTED}
+  rejected = ${?COMET_AREA_REJECTED}
   business = "business"
-  business = ${?COMET_BUSINESS}
+  business = ${?COMET_AREA_BUSINESS}
 }
 
 privacy {

--- a/src/main/resources/fs/reference.conf
+++ b/src/main/resources/fs/reference.conf
@@ -64,19 +64,19 @@ metrics {
 
 area {
   pending = "pending"
-  pending = ${?COMET_PENDING}
+  pending = ${?COMET_AREA_PENDING}
   unresolved = "unresolved"
-  unresolved = ${?COMET_UNRESOLVED}
+  unresolved = ${?COMET_AREA_UNRESOLVED}
   archive = "archive"
-  archive = ${?COMET_ARCHIVE}
+  archive = ${?COMET_AREA_ARCHIVE}
   ingesting = "ingesting"
-  ingesting = ${?COMET_INGESTING}
+  ingesting = ${?COMET_AREA_INGESTING}
   accepted = "accepted"
-  accepted = ${?COMET_ACCEPTED}
+  accepted = ${?COMET_AREA_ACCEPTED}
   rejected = "rejected"
-  rejected = ${?COMET_REJECTED}
+  rejected = ${?COMET_AREA_REJECTED}
   business = "business"
-  business = ${?COMET_BUSINESS}
+  business = ${?COMET_AREA_BUSINESS}
 }
 
 privacy {

--- a/src/main/resources/gcp/reference.conf
+++ b/src/main/resources/gcp/reference.conf
@@ -83,19 +83,19 @@ metrics {
 
 area {
   pending = "pending"
-  pending = ${?COMET_PENDING}
+  pending = ${?COMET_AREA_PENDING}
   unresolved = "unresolved"
-  unresolved = ${?COMET_UNRESOLVED}
+  unresolved = ${?COMET_AREA_UNRESOLVED}
   archive = "archive"
-  archive = ${?COMET_ARCHIVE}
+  archive = ${?COMET_AREA_ARCHIVE}
   ingesting = "ingesting"
-  ingesting = ${?COMET_INGESTING}
+  ingesting = ${?COMET_AREA_INGESTING}
   accepted = "accepted"
-  accepted = ${?COMET_ACCEPTED}
+  accepted = ${?COMET_AREA_ACCEPTED}
   rejected = "rejected"
-  rejected = ${?COMET_REJECTED}
+  rejected = ${?COMET_AREA_REJECTED}
   business = "business"
-  business = ${?COMET_BUSINESS}
+  business = ${?COMET_AREA_BUSINESS}
 }
 
 privacy {

--- a/src/main/resources/hdfs/reference.conf
+++ b/src/main/resources/hdfs/reference.conf
@@ -83,19 +83,19 @@ metrics {
 
 area {
   pending = "pending"
-  pending = ${?COMET_PENDING}
+  pending = ${?COMET_AREA_PENDING}
   unresolved = "unresolved"
-  unresolved = ${?COMET_UNRESOLVED}
+  unresolved = ${?COMET_AREA_UNRESOLVED}
   archive = "archive"
-  archive = ${?COMET_ARCHIVE}
+  archive = ${?COMET_AREA_ARCHIVE}
   ingesting = "ingesting"
-  ingesting = ${?COMET_INGESTING}
+  ingesting = ${?COMET_AREA_INGESTING}
   accepted = "accepted"
-  accepted = ${?COMET_ACCEPTED}
+  accepted = ${?COMET_AREA_ACCEPTED}
   rejected = "rejected"
-  rejected = ${?COMET_REJECTED}
+  rejected = ${?COMET_AREA_REJECTED}
   business = "business"
-  business = ${?COMET_BUSINESS}
+  business = ${?COMET_AREA_BUSINESS}
 }
 
 privacy {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -245,19 +245,19 @@ jdbc-engines {
 
 area {
   pending = "pending"
-  pending = ${?COMET_PENDING}
+  pending = ${?COMET_AREA_PENDING}
   unresolved = "unresolved"
-  unresolved = ${?COMET_UNRESOLVED}
+  unresolved = ${?COMET_AREA_UNRESOLVED}
   archive = "archive"
-  archive = ${?COMET_ARCHIVE}
+  archive = ${?COMET_AREA_ARCHIVE}
   ingesting = "ingesting"
-  ingesting = ${?COMET_INGESTING}
+  ingesting = ${?COMET_AREA_INGESTING}
   accepted = "accepted"
-  accepted = ${?COMET_ACCEPTED}
+  accepted = ${?COMET_AREA_ACCEPTED}
   rejected = "rejected"
-  rejected = ${?COMET_REJECTED}
+  rejected = ${?COMET_AREA_REJECTED}
   business = "business"
-  business = ${?COMET_BUSINESS}
+  business = ${?COMET_AREA_BUSINESS}
 }
 
 privacy {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -11,7 +11,6 @@ tmpdir = ${root}"/comet_tmp"
 tmpdir = ${?COMET_TMPDIR}
 
 archive = true
-archive = ${?COMET_STAGING}
 archive = ${?COMET_ARCHIVE}
 
 launcher = airflow
@@ -66,6 +65,7 @@ audit {
   max-errors = 100
   index {
     type = "None" # can be BigQuery or Jdbc or None
+    type = ${?COMET_AUDIT_INDEX_TYPE}
 
     # BigQuery options
     bq-dataset = "audit"
@@ -91,6 +91,7 @@ metrics {
 
   index {
     type = "None" # or Jdbc or BigQuery
+    type = ${?COMET_METRICS_INDEX_TYPE}
 
     # BigQuery options
     bq-dataset = "metrics"


### PR DESCRIPTION
## Summary
We have a conflict in the reference file when setting the archive and area.archive param using env variables.
```
archive = true
archive = ${?COMET_ARCHIVE}

area {
  archive = "archive"
  archive = ${?COMET_ARCHIVE}
}
```

Per the doc we should use COMET_AREA_ARCHIVE when setting area.archive through an env var.

We also add two extra env vars form metrics.index.type && audit.index.type

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? Yes**
The area.archive folder would be renamed from true/false to archive.


