### PR TITLE
Bugfix/comments in bq schema

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
@@ -55,7 +55,7 @@ class BigQueryLoadJob(
           case _ =>
             cliConfig.outputPartition match {
               case Some(_) => StandardTableDefinition.of(df.to[BQSchema]).toBuilder
-              case _       => StandardTableDefinition.newBuilder()
+              case None       => StandardTableDefinition.newBuilder()
             }
         }
 

--- a/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
@@ -52,7 +52,9 @@ class BigQueryLoadJob(
         cliConfig.outputPartition match {
           case Some(_) =>
             StandardTableDefinition.of(df.to[BQSchema]).toBuilder
-          case _ => StandardTableDefinition.newBuilder()
+          case _ => maybeSchema.fold(StandardTableDefinition.newBuilder()) {
+            schema => StandardTableDefinition.of(schema).toBuilder
+          }
         }
 
       cliConfig.outputPartition.foreach { outputPartition =>

--- a/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
@@ -52,9 +52,10 @@ class BigQueryLoadJob(
         cliConfig.outputPartition match {
           case Some(_) =>
             StandardTableDefinition.of(df.to[BQSchema]).toBuilder
-          case _ => maybeSchema.fold(StandardTableDefinition.newBuilder()) {
-            schema => StandardTableDefinition.of(schema).toBuilder
-          }
+          case _ =>
+            maybeSchema.fold(StandardTableDefinition.newBuilder()) { schema =>
+              StandardTableDefinition.of(schema).toBuilder
+            }
         }
 
       cliConfig.outputPartition.foreach { outputPartition =>

--- a/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/bqload/BigQueryLoadJob.scala
@@ -49,12 +49,13 @@ class BigQueryLoadJob(
     scala.Option(bigquery.getTable(tableId)) getOrElse {
 
       val tableDefinitionBuilder =
-        cliConfig.outputPartition match {
-          case Some(_) =>
-            StandardTableDefinition.of(df.to[BQSchema]).toBuilder
+        maybeSchema match {
+          case Some(schema) =>
+            StandardTableDefinition.of(schema).toBuilder
           case _ =>
-            maybeSchema.fold(StandardTableDefinition.newBuilder()) { schema =>
-              StandardTableDefinition.of(schema).toBuilder
+            cliConfig.outputPartition match {
+              case Some(_) => StandardTableDefinition.of(df.to[BQSchema]).toBuilder
+              case _       => StandardTableDefinition.newBuilder()
             }
         }
 


### PR DESCRIPTION
## Summary
Fix a regression in loading data to BigQuery. The description of the columns of a schema is not present in the BQ tables although specified in the YAML schema

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
In `BigQueryLoadJob`, use the `maybeSchema` when present to create the Table.  

### How has this been tested?
No regression on existing Unit Tests




