### PR TITLE
Make shaded as a classifier

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -92,8 +92,8 @@ object Dependencies {
     s"${Resolvers.googleCloudBigDataMavenRepo}/bigquery-connector/${Versions.hadoopbq}/bigquery-connector-${Versions.hadoopbq}-shaded.jar"
 
   val gcp = Seq(
-    "com.google.cloud.bigdataoss" % "gcs-connector-shaded" % s"${Versions.gcs}-shaded" from gcsConnectorShadedJar exclude ("javax.jms", "jms") exclude ("com.sun.jdmk", "jmxtools") exclude ("com.sun.jmx", "jmxri") excludeAll (jacksonExclusions: _*),
-    "com.google.cloud.bigdataoss" % "bigquery-connector-shaded" % s"${Versions.hadoopbq}-shaded" from gcpBigQueryConnectorShadedJar exclude ("javax.jms", "jms") exclude ("com.sun.jdmk", "jmxtools") exclude ("com.sun.jmx", "jmxri") excludeAll (jacksonExclusions: _*),
+    "com.google.cloud.bigdataoss" % "gcs-connector" % Versions.gcs from gcsConnectorShadedJar exclude ("javax.jms", "jms") exclude ("com.sun.jdmk", "jmxtools") exclude ("com.sun.jmx", "jmxri") excludeAll (jacksonExclusions: _*) classifier ("shaded"),
+    "com.google.cloud.bigdataoss" % "bigquery-connector" % Versions.hadoopbq from gcpBigQueryConnectorShadedJar exclude ("javax.jms", "jms") exclude ("com.sun.jdmk", "jmxtools") exclude ("com.sun.jmx", "jmxri") excludeAll (jacksonExclusions: _*) classifier ("shaded"),
     "com.google.cloud" % "google-cloud-bigquery" % Versions.bq exclude ("javax.jms", "jms") exclude ("com.sun.jdmk", "jmxtools") exclude ("com.sun.jmx", "jmxri") excludeAll (jacksonExclusions: _*),
     "com.google.cloud.spark" %% "spark-bigquery-with-dependencies" % "0.15.1-beta"
   )


### PR DESCRIPTION
## Summary
Make shaded as a classifier For gcs-connector-shaded & bigquery-connector-shaded,
we will have something like this in the pom.xml file of comet :

```
> <dependency>
>             <groupId>com.google.cloud.bigdataoss</groupId>
>             <artifactId>gcs-connector</artifactId>
>             <version>hadoop3-2.0.1</version>
>             <classifier>shaded</classifier>
> </dependency>
```

```
> <dependency>
>             <groupId>com.google.cloud.bigdataoss</groupId>
>             <artifactId>bigquery-connector</artifactId>
>             <version>hadoop3-1.0.0</version>
>             <classifier>shaded</classifier>
> </dependency>
```

**Status: Ready to review**

**Breaking change? No**