### PR TITLE
split metrics into multiple dataframes:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ scala:
 
 
 script:
+  - jdk_switcher use openjdk8
   - sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 language: scala
 jdk:
   #- oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: trusty
 language: scala
 jdk:
   #- oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: scala
 jdk:
   #- oraclejdk8

--- a/src/main/scala/com/ebiznext/comet/config/DatasetArea.scala
+++ b/src/main/scala/com/ebiznext/comet/config/DatasetArea.scala
@@ -111,6 +111,18 @@ object DatasetArea {
     )
   }
 
+  def discreteMetrics(domain: String, schema: String)(implicit settings: Settings): Path = {
+    new Path(metrics(domain, schema), "discrete")
+  }
+
+  def continuousMetrics(domain: String, schema: String)(implicit settings: Settings): Path = {
+    new Path(metrics(domain, schema), "continuous")
+  }
+
+  def frequenciesMetrics(domain: String, schema: String)(implicit settings: Settings): Path = {
+    new Path(metrics(domain, schema), "frequencies")
+  }
+
   /**
     * Default target folder for autojobs applied to datasets in this domain
     *
@@ -145,7 +157,8 @@ object DatasetArea {
     List(metadata, types, domains).foreach(storage.mkdirs)
   }
 
-  def initDomains(storage: StorageHandler, domains: Iterable[String])(implicit
+  def initDomains(storage: StorageHandler, domains: Iterable[String])(
+    implicit
     settings: Settings
   ): Unit = {
     init(storage)

--- a/src/main/scala/com/ebiznext/comet/config/DatasetArea.scala
+++ b/src/main/scala/com/ebiznext/comet/config/DatasetArea.scala
@@ -157,8 +157,7 @@ object DatasetArea {
     List(metadata, types, domains).foreach(storage.mkdirs)
   }
 
-  def initDomains(storage: StorageHandler, domains: Iterable[String])(
-    implicit
+  def initDomains(storage: StorageHandler, domains: Iterable[String])(implicit
     settings: Settings
   ): Unit = {
     init(storage)

--- a/src/main/scala/com/ebiznext/comet/job/metrics/Metrics.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/Metrics.scala
@@ -8,6 +8,12 @@ import org.apache.spark.sql.{Column, DataFrame}
 
 object Metrics extends StrictLogging {
 
+  case class MetricsDatasets(
+    continuousDF: Option[DataFrame],
+    discreteDF: Option[DataFrame],
+    frequenciesDF: Option[DataFrame]
+  )
+
   /** Case class ContinuousMetric with all corresponding Metrics
     *
     * @param name     : the name of the variable

--- a/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/MetricsJob.scala
@@ -249,7 +249,7 @@ class MetricsJob(
     combinedResult.find(_.isFailure).getOrElse(Success(session))
   }
 
-  private def sinkMetrics(metricsDf: DataFrame, name: String): Try[Unit] = {
+  private def sinkMetrics(metricsDf: DataFrame, table: String): Try[Unit] = {
     if (settings.comet.metrics.active) {
       settings.comet.metrics.index match {
         case Settings.IndexSinkSettings.None =>
@@ -257,7 +257,7 @@ class MetricsJob(
 
         case Settings.IndexSinkSettings.BigQuery(bqDataset) =>
           Try {
-            sinkMetricsToBigQuery(metricsDf, bqDataset)
+            sinkMetricsToBigQuery(metricsDf, bqDataset, table)
           }
 
         case Settings.IndexSinkSettings.Jdbc(jdbcConnection, partitions, batchSize) =>
@@ -278,12 +278,16 @@ class MetricsJob(
     }
   }
 
-  private def sinkMetricsToBigQuery(metricsDf: DataFrame, bqDataset: String): Unit = {
+  private def sinkMetricsToBigQuery(
+    metricsDf: DataFrame,
+    bqDataset: String,
+    bqTable: String
+  ): Unit = {
     if (metricsDf.count() > 0) {
       val config = BigQueryLoadConfig(
         Right(metricsDf),
         outputDataset = bqDataset,
-        outputTable = "metrics",
+        outputTable = bqTable,
         None,
         "parquet",
         "CREATE_IF_NEEDED",

--- a/src/test/scala/com/ebiznext/comet/job/metrics/MetricsJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/job/metrics/MetricsJobSpec.scala
@@ -23,39 +23,55 @@ class MetricsJobSpec extends TestHelper {
   /**
     * schema of metrics
     */
-  val expectedMetricsSchema = StructType(
+  val expectedDiscreteMetricsSchema = StructType(
     Array(
+      StructField("attribute", StringType, nullable = true),
+      StructField("countDistinct", LongType, nullable = true),
+      StructField("missingValuesDiscrete", LongType, nullable = true),
+      StructField("cometMetric", StringType, nullable = true),
+      StructField("jobId", StringType, nullable = true),
       StructField("domain", StringType, nullable = true),
       StructField("schema", StringType, nullable = true),
+      StructField("count", LongType, nullable = true),
+      StructField("cometTime", LongType, nullable = true),
+      StructField("cometStage", StringType, nullable = true)
+    )
+  )
+
+  val expectedContinuousMetricsSchema = StructType(
+    Array(
       StructField("attribute", StringType, nullable = true),
       StructField("min", DoubleType, nullable = true),
       StructField("max", DoubleType, nullable = true),
       StructField("mean", DoubleType, nullable = true),
       StructField("missingValues", LongType, nullable = true),
-      StructField("standardDev", DoubleType, nullable = true),
       StructField("variance", DoubleType, nullable = true),
+      StructField("standardDev", DoubleType, nullable = true),
       StructField("sum", DoubleType, nullable = true),
       StructField("skewness", DoubleType, nullable = true),
       StructField("kurtosis", DoubleType, nullable = true),
       StructField("percentile25", DoubleType, nullable = true),
       StructField("median", DoubleType, nullable = true),
       StructField("percentile75", DoubleType, nullable = true),
-      StructField("countDistinct", LongType, nullable = true),
-      StructField(
-        "catCountFreq",
-        ArrayType(
-          StructType(
-            Array(
-              StructField("category", StringType, nullable = true),
-              StructField("countDiscrete", LongType, nullable = true),
-              StructField("frequency", DoubleType, nullable = true)
-            )
-          )
-        ),
-        nullable = true
-      ),
-      StructField("missingValuesDiscrete", LongType, nullable = true),
+      StructField("cometMetric", StringType, nullable = true),
+      StructField("jobId", StringType, nullable = true),
+      StructField("domain", StringType, nullable = true),
+      StructField("schema", StringType, nullable = true),
       StructField("count", LongType, nullable = true),
+      StructField("cometTime", LongType, nullable = true),
+      StructField("cometStage", StringType, nullable = true)
+    )
+  )
+
+  val expectedFreqMetricsSchema = StructType(
+    Array(
+      StructField("attribute", StringType, nullable = true),
+      StructField("category", StringType, nullable = true),
+      StructField("count", LongType, nullable = true),
+      StructField("frequency", DoubleType, nullable = true),
+      StructField("jobId", StringType, nullable = true),
+      StructField("domain", StringType, nullable = true),
+      StructField("schema", StringType, nullable = true),
       StructField("cometTime", LongType, nullable = true),
       StructField("cometStage", StringType, nullable = true)
     )
@@ -97,7 +113,7 @@ class MetricsJobSpec extends TestHelper {
     */
   lazy val dimensionTable = {
     val dimensionTable =
-    (partialContinuousMetric.size + 1) * (listContnuousAttributes.size + 1)
+      (partialContinuousMetric.size + 1) * (listContnuousAttributes.size + 1)
     logger.info(s"-->$dimensionTable")
 
     dimensionTable
@@ -124,8 +140,8 @@ class MetricsJobSpec extends TestHelper {
     listContnuousAttributes.map(name => dataInitialUsed.select(avg(name)).first().getDouble(0))
 
   lazy val meanListTable: List[Double] = result0.map { result0 =>
-    result0.select(col("mean")).collect().map(_.getDouble(0)).toList
-  } getOrElse Nil
+      result0.select(col("mean")).collect().map(_.getDouble(0)).toList
+    } getOrElse Nil
 
   "All values of The Mean " should "be tested" in {
     assert(meanList.zip(meanListTable).map(x => x._1 - x._2).sum <= 0.00001)
@@ -138,8 +154,8 @@ class MetricsJobSpec extends TestHelper {
     listContnuousAttributes.map(name => dataInitialUsed.select(min(name)).first().getDouble(0))
 
   lazy val minListTable: List[Double] = result0.map { result0 =>
-    result0.select(col("min")).collect().map(_.getDouble(0)).toList
-  } getOrElse Nil
+      result0.select(col("min")).collect().map(_.getDouble(0)).toList
+    } getOrElse Nil
 
   "All values of The Min" should "be tested" in {
     assert(minList.zip(minListTable).map(x => x._1 - x._2).sum <= 0.00001)
@@ -152,8 +168,8 @@ class MetricsJobSpec extends TestHelper {
     listContnuousAttributes.map(name => dataInitialUsed.select(max(name)).first().getDouble(0))
 
   lazy val maxListTable: List[Double] = result0.map { result0 =>
-    result0.select(col("max")).collect().map(_.getDouble(0)).toList
-  } getOrElse Nil
+      result0.select(col("max")).collect().map(_.getDouble(0)).toList
+    } getOrElse Nil
 
   "All values of The Max" should "be tested" in {
     assert(maxList.zip(maxListTable).map(x => x._1 - x._2).sum <= 0.00001)
@@ -166,8 +182,8 @@ class MetricsJobSpec extends TestHelper {
     listContnuousAttributes.map(name => dataInitialUsed.select(stddev(name)).first().getDouble(0))
 
   lazy val stddevListTable: List[Double] = result0.map { result0 =>
-    result0.select(col("standardDev")).collect().map(_.getDouble(0)).toList
-  } getOrElse Nil
+      result0.select(col("standardDev")).collect().map(_.getDouble(0)).toList
+    } getOrElse Nil
 
   "All values of The standardDev" should "be tested" in {
     assert(stddevList.zip(stddevListTable).map(x => x._1 - x._2).sum <= 0.001)
@@ -180,8 +196,8 @@ class MetricsJobSpec extends TestHelper {
     listContnuousAttributes.map(name => dataInitialUsed.select(skewness(name)).first().getDouble(0))
 
   lazy val skewnessListTable: List[Double] = result0.map { result0 =>
-    result0.select(col("skewness")).collect().map(_.getDouble(0)).toList
-  } getOrElse Nil
+      result0.select(col("skewness")).collect().map(_.getDouble(0)).toList
+    } getOrElse Nil
 
   "All values of The Skewness" should "be tested" in {
     assert(skewnessList.zip(skewnessListTable).map(x => x._1 - x._2).sum <= 0.001)
@@ -194,8 +210,8 @@ class MetricsJobSpec extends TestHelper {
     listContnuousAttributes.map(name => dataInitialUsed.select(kurtosis(name)).first().getDouble(0))
 
   lazy val kurtosisListTable: List[Double] = result0.map { result0 =>
-    result0.select(col("kurtosis")).collect().map(_.getDouble(0)).toList
-  } getOrElse Nil
+      result0.select(col("kurtosis")).collect().map(_.getDouble(0)).toList
+    } getOrElse Nil
 
   "All values of The Kurtosis" should "be tested" in {
     assert(kurtosisList.zip(kurtosisListTable).map(x => x._1 - x._2).sum <= 0.001)
@@ -212,27 +228,54 @@ class MetricsJobSpec extends TestHelper {
         cleanMetadata
         cleanDatasets
         loadPending
-        val countAccepted: Long = sparkSession.read
-          .parquet(cometDatasetsPath + s"/accepted/$datasetDomainName/business")
-          .count()
 
-        val path: Path = DatasetArea.metrics("yelp", "business")
-        val metricsDf: DataFrame = sparkSession.read.parquet(path.toString)
-        metricsDf.schema shouldBe expectedMetricsSchema
+        val discretePath: Path = DatasetArea.discreteMetrics("yelp", "business")
+        val discreteMetricsDf: DataFrame = sparkSession.read.parquet(discretePath.toString)
+        discreteMetricsDf.show(false)
+        discreteMetricsDf.schema shouldBe expectedDiscreteMetricsSchema
         import sparkSession.implicits._
-        val metricsSelectedColumns =
-          metricsDf
+        val discreteMetricsSelectedColumns =
+          discreteMetricsDf
             .select("domain", "schema", "attribute")
             .map(r => (r.getString(0), r.getString(1), r.getString(2)))
             .take(7)
-        metricsSelectedColumns should contain allElementsOf Array(
+        discreteMetricsSelectedColumns should contain allElementsOf Array(
           ("yelp", "business", "city"),
           ("yelp", "business", "is_open"),
           ("yelp", "business", "postal_code"),
           ("yelp", "business", "state"),
-          ("yelp", "business", "review_count"),
-          ("yelp", "business", "stars"),
           ("yelp", "business", "is_open")
+        )
+
+        val continuousPath: Path = DatasetArea.continuousMetrics("yelp", "business")
+        val continuousMetricsDf: DataFrame = sparkSession.read.parquet(continuousPath.toString)
+        continuousMetricsDf.show(false)
+        continuousMetricsDf.schema shouldBe expectedContinuousMetricsSchema
+        import sparkSession.implicits._
+        val continuousMetricsSelectedColumns =
+          continuousMetricsDf
+            .select("domain", "schema", "attribute")
+            .map(r => (r.getString(0), r.getString(1), r.getString(2)))
+            .take(7)
+
+        continuousMetricsSelectedColumns should contain allElementsOf Array(
+          ("yelp", "business", "review_count"),
+          ("yelp", "business", "stars")
+        )
+
+        val freqPath: Path = DatasetArea.frequenciesMetrics("yelp", "business")
+        val freqMetricsDf: DataFrame = sparkSession.read.parquet(freqPath.toString)
+        freqMetricsDf.show(false)
+        freqMetricsDf.schema shouldBe expectedFreqMetricsSchema
+        import sparkSession.implicits._
+        val freqMetricsSelectedColumns =
+          freqMetricsDf
+            .select("domain", "schema", "attribute")
+            .map(r => (r.getString(0), r.getString(1), r.getString(2)))
+            .take(7)
+
+        freqMetricsSelectedColumns should contain allElementsOf Array(
+          ("yelp", "business", "city")
         )
       }
     }


### PR DESCRIPTION
## Summary
1. One for the continuous metrics with the following metrics :
- Min
- Max
- Mean
- CountMissValues
- Variance
- Stddev
- Sum
- Skewness
- Kurtosis
- Percentile25
-  Median
-  Percentile75

2. One for the discrete metrics with the following metrics:
- countDistinct
- missingValuesDiscrete

3. One for the frequency of discrete metrics
- category name
- frequency

**Related Issue: #IssueId**

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? Yes**
Metrics are now split among 3 files / tables : continuous / discrete / frequencies 


