### PR TITLE
Row Level Security on GCP

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadConfig.scala
@@ -1,6 +1,7 @@
 package com.ebiznext.comet.job.index.bqload
 
 import buildinfo.BuildInfo
+import com.ebiznext.comet.schema.model.RowLevelSecurity
 import com.ebiznext.comet.utils.CliConfig
 import org.apache.spark.sql.DataFrame
 import scopt.OParser
@@ -14,7 +15,8 @@ case class BigQueryLoadConfig(
   createDisposition: String = "",
   writeDisposition: String = "",
   location: Option[String] = None,
-  days: Option[Int] = None
+  days: Option[Int] = None,
+  rls: Option[RowLevelSecurity] = None
 ) {
   def getLocation(): String = this.location.getOrElse("EU")
 }
@@ -55,6 +57,11 @@ object BigQueryLoadConfig extends CliConfig[BigQueryLoadConfig] {
         .action((x, c) => c.copy(writeDisposition = x))
         .text(
           "Big Query Write disposition https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/WriteDisposition"
+        ),
+      opt[String]("row_level_security")
+        .action((x, c) => c.copy(rls = Some(RowLevelSecurity.parse(x))))
+        .text(
+          "Row Level Security in the --row_level_security name,filter,sa:sa@mail.com,user:user@mail.com,group:group@mail.com "
         )
     )
   }

--- a/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadConfig.scala
@@ -61,7 +61,7 @@ object BigQueryLoadConfig extends CliConfig[BigQueryLoadConfig] {
       opt[String]("row_level_security")
         .action((x, c) => c.copy(rls = Some(RowLevelSecurity.parse(x))))
         .text(
-          "Row Level Security in the --row_level_security name,filter,sa:sa@mail.com,user:user@mail.com,group:group@mail.com "
+          "value is in the form name,filter,sa:sa@mail.com,user:user@mail.com,group:group@mail.com "
         )
     )
   }

--- a/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadJob.scala
@@ -9,6 +9,7 @@ import com.google.cloud.bigquery.testing.RemoteBigQueryHelper
 import com.google.cloud.bigquery.{Schema => BQSchema, _}
 import com.google.cloud.hadoop.io.bigquery.BigQueryConfiguration
 import com.google.cloud.hadoop.io.bigquery.output.BigQueryTimePartitioning
+import org.apache.hadoop.conf.Configuration
 import org.apache.spark.sql.{DataFrame, SaveMode}
 
 import scala.util.Try
@@ -31,6 +32,7 @@ class BigQueryLoadJob(
   val bucket = conf.get("fs.defaultFS")
 
   val tableId = TableId.of(cliConfig.outputDataset, cliConfig.outputTable)
+  val bqTable = s"${cliConfig.outputDataset}.${cliConfig.outputTable}"
 
   private def getOrCreateDataset(): Dataset = {
     val datasetId = DatasetId.of(projectId, cliConfig.outputDataset)
@@ -92,69 +94,81 @@ class BigQueryLoadJob(
     }
   }
 
-  def runBQSparkConnector(): Try[SparkJobResult] = {
+  def prepareConf(): Configuration = {
     val conf = session.sparkContext.hadoopConfiguration
     logger.info(s"BigQuery Config $cliConfig")
-
-    val bucket = conf.get("fs.gs.system.bucket")
-
-    val inputPath = cliConfig.source
-    logger.info(s"Input path $inputPath")
-
-    logger.info(s"Temporary GCS path $bucket")
-    session.conf.set("temporaryGcsBucket", bucket)
+    val bucket = scala.Option(conf.get("fs.gs.system.bucket"))
+    bucket.foreach { bucket =>
+      logger.info(s"Temporary GCS path $bucket")
+      session.conf.set("temporaryGcsBucket", bucket)
+    }
 
     val writeDisposition = JobInfo.WriteDisposition.valueOf(cliConfig.writeDisposition)
-    val tableId = TableId.of(cliConfig.outputDataset, cliConfig.outputTable)
     val finalWriteDisposition = writeDisposition match {
       case JobInfo.WriteDisposition.WRITE_TRUNCATE =>
         logger.info(s"Deleting table $tableId")
-        bigquery.delete(tableId)
+        try {
+          bigquery.delete(tableId)
+        } catch {
+          case e: BigQueryException =>
+            // Log error and continue  (may be table does not exist)
+            Utils.logException(logger, e)
+        }
+
         logger.info(s"Setting Write mode to Append")
         JobInfo.WriteDisposition.WRITE_APPEND
       case _ =>
         writeDisposition
     }
+
+    conf.set(
+      BigQueryConfiguration.OUTPUT_TABLE_WRITE_DISPOSITION_KEY,
+      finalWriteDisposition.toString
+    )
+    conf.set(
+      BigQueryConfiguration.OUTPUT_TABLE_CREATE_DISPOSITION_KEY,
+      cliConfig.createDisposition
+    )
+    cliConfig.outputPartition.foreach { outputPartition =>
+      import com.google.cloud.hadoop.repackaged.bigquery.com.google.api.services.bigquery.model.TimePartitioning
+      val timeField =
+        if (List("_PARTITIONDATE", "_PARTITIONTIME").contains(outputPartition))
+          new TimePartitioning().setType("DAY").setRequirePartitionFilter(true)
+        else
+          new TimePartitioning()
+            .setType("DAY")
+            .setRequirePartitionFilter(true)
+            .setField(outputPartition)
+      val timePartitioning =
+        new BigQueryTimePartitioning(
+          timeField
+        )
+      conf.set(BigQueryConfiguration.OUTPUT_TABLE_PARTITIONING_KEY, timePartitioning.getAsJson)
+    }
+    conf
+  }
+
+  def prepareRLS(): List[String] = {
+    cliConfig.rls.toList.flatMap { rls =>
+      logger.info(s"Applying security $rls")
+      val rlsDelStatement = toBQDelGrant()
+      logger.info(s"All access policies will be deleted using $rlsDelStatement")
+      val rlsCreateStatement = toBQGrant()
+      logger.info(s"All access policies will be created using $rlsCreateStatement")
+      List(rlsDelStatement, rlsCreateStatement)
+    }
+  }
+
+  def runBQSparkConnector(): Try[SparkJobResult] = {
+    prepareConf()
     Try {
       val sourceDF =
-        inputPath match {
+        cliConfig.source match {
           case Left(path) => session.read.parquet(path)
           case Right(df)  => df
         }
 
       val table = getOrCreateTable(sourceDF)
-
-      def bqPartition(): Unit = {
-        conf.set(
-          BigQueryConfiguration.OUTPUT_TABLE_WRITE_DISPOSITION_KEY,
-          finalWriteDisposition.toString
-        )
-        conf.set(
-          BigQueryConfiguration.OUTPUT_TABLE_CREATE_DISPOSITION_KEY,
-          cliConfig.createDisposition
-        )
-        cliConfig.outputPartition.foreach { outputPartition =>
-          import com.google.cloud.hadoop.repackaged.bigquery.com.google.api.services.bigquery.model.TimePartitioning
-          val timeField =
-            if (List("_PARTITIONDATE", "_PARTITIONTIME").contains(outputPartition))
-              new TimePartitioning().setType("DAY").setRequirePartitionFilter(true)
-            else
-              new TimePartitioning()
-                .setType("DAY")
-                .setRequirePartitionFilter(true)
-                .setField(outputPartition)
-          val timePartitioning =
-            new BigQueryTimePartitioning(
-              timeField
-            )
-
-          conf.set(BigQueryConfiguration.OUTPUT_TABLE_PARTITIONING_KEY, timePartitioning.getAsJson)
-        }
-      }
-
-      bqPartition()
-
-      val bqTable = s"${cliConfig.outputDataset}.${cliConfig.outputTable}"
 
       val stdTableDefinition =
         bigquery.getTable(table.getTableId).getDefinition.asInstanceOf[StandardTableDefinition]
@@ -172,15 +186,10 @@ class BigQueryLoadJob(
       logger.info(
         s"BigQuery Saved to ${table.getTableId} now contains ${stdTableDefinitionAfter.getNumRows} rows"
       )
-      cliConfig.rls.foreach { rls =>
-        logger.info(s"Applying security $rls")
-        val rlsDelStatement = toBQDelGrant()
-        bqJobRun(rlsDelStatement)
-        logger.info(s"All access policies deleted using $rlsDelStatement")
-        val rlsCreateStatement = toBQGrant()
-        bqJobRun(rlsCreateStatement)
-        logger.info(s"All access policies created using $rlsCreateStatement")
 
+      prepareRLS().foreach { rlsStatement =>
+        logger.info(s"Applying security $rlsStatement")
+        bqJobRun(rlsStatement)
       }
       SparkJobResult(session)
     }
@@ -210,13 +219,14 @@ class BigQueryLoadJob(
   }
 
   private def toBQDelGrant(): String = {
-      "DROP ALL ROW ACCESS POLICIES ON $outputDataset.$outputTable"
+    import cliConfig._
+    s"DROP ALL ROW ACCESS POLICIES ON $outputDataset.$outputTable"
   }
 
   private def toBQGrant(): String = {
     import cliConfig._
     val rlsGet = rls.getOrElse(throw new Exception("Should never happen"))
-    val grants = rlsGet.grants.map {
+    val grants = rlsGet.grantees().map {
       case (UserType.SA, u) =>
         s"serviceAccount:$u"
       case (t, u) =>
@@ -231,7 +241,7 @@ class BigQueryLoadJob(
       | ON
       |  $outputDataset.$outputTable
       | GRANT TO
-      |  (${grants.mkString(",")})
+      |  (${grants.mkString("\"", "\",\"", "\"")})
       | FILTER USING
       |  ($filter)
       |""".stripMargin

--- a/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadJob.scala
@@ -227,7 +227,7 @@ class BigQueryLoadJob(
     }
   }
 
-  private def toBQDelGrant(): String = {
+  revokeAllPrivileges
     import cliConfig._
     s"DROP ALL ROW ACCESS POLICIES ON $outputDataset.$outputTable"
   }

--- a/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadJob.scala
@@ -204,7 +204,11 @@ class BigQueryLoadJob(
     import java.util.UUID
 
     import scala.collection.JavaConverters._
-    val jobId = JobId.of(UUID.randomUUID.toString)
+    val jobId = JobId
+      .newBuilder()
+      .setJob(UUID.randomUUID.toString)
+      .setLocation(cliConfig.getLocation())
+      .build()
     val config =
       QueryJobConfiguration
         .newBuilder(statement)
@@ -212,7 +216,7 @@ class BigQueryLoadJob(
         .build()
     // Use standard SQL syntax for queries.
     // See: https://cloud.google.com/bigquery/sql-reference/
-    val job = bigquery.create(JobInfo.newBuilder(config).setJobId(jobId).build)
+    val job: Job = bigquery.create(JobInfo.newBuilder(config).setJobId(jobId).build)
     scala.Option(job.waitFor()) match {
       case None =>
         throw new RuntimeException("Job no longer exists")
@@ -253,7 +257,7 @@ class BigQueryLoadJob(
   }
 
   /**
-    * Just to force any spark job to implement its entry point using within the "run" method
+    * Just to force any spark job to implement its entry point within the "run" method
     *
     * @return : Spark Session used for the job
     */

--- a/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadJob.scala
@@ -189,7 +189,12 @@ class BigQueryLoadJob(
 
       prepareRLS().foreach { rlsStatement =>
         logger.info(s"Applying security $rlsStatement")
-        bqJobRun(rlsStatement)
+        try {
+          bqJobRun(rlsStatement)
+        } catch {
+          case e: Exception =>
+            e.printStackTrace()
+        }
       }
       SparkJobResult(session)
     }

--- a/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadJob.scala
@@ -232,7 +232,7 @@ class BigQueryLoadJob(
     s"DROP ALL ROW ACCESS POLICIES ON $outputDataset.$outputTable"
   }
 
-  private def toBQGrant(): String = {
+  private def grantPrivileges(): String = {
     import cliConfig._
     val rlsGet = rls.getOrElse(throw new Exception("Should never happen"))
     val grants = rlsGet.grantees().map {

--- a/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQueryLoadJob.scala
@@ -234,7 +234,7 @@ class BigQueryLoadJob(
 
   private def grantPrivileges(): String = {
     import cliConfig._
-    val rlsGet = rls.getOrElse(throw new Exception("Should never happen"))
+    val rlsRetrieved = rls.getOrElse(throw new Exception("Should never happen"))
     val grants = rlsGet.grantees().map {
       case (UserType.SA, u) =>
         s"serviceAccount:$u"

--- a/src/main/scala/com/ebiznext/comet/job/index/esload/ESLoadConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/esload/ESLoadConfig.scala
@@ -24,6 +24,7 @@ import java.util.regex.Pattern
 
 import buildinfo.BuildInfo
 import com.ebiznext.comet.config.Settings
+import com.ebiznext.comet.schema.model.RowLevelSecurity
 import com.ebiznext.comet.utils.CliConfig
 import org.apache.hadoop.fs.Path
 import scopt.OParser
@@ -36,7 +37,8 @@ case class ESLoadConfig(
   schema: String = "",
   format: String = "",
   dataset: Option[Path] = None,
-  conf: Map[String, String] = Map()
+  conf: Map[String, String] = Map(),
+  rls: Option[List[RowLevelSecurity]] = None
 ) {
 
   def getDataset()(implicit settings: Settings): Path = {

--- a/src/main/scala/com/ebiznext/comet/job/index/jdbcload/JdbcLoadConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/jdbcload/JdbcLoadConfig.scala
@@ -4,6 +4,7 @@ import java.sql.{DriverManager, SQLException}
 
 import buildinfo.BuildInfo
 import com.ebiznext.comet.config.Settings
+import com.ebiznext.comet.schema.model.RowLevelSecurity
 import com.ebiznext.comet.utils.CliConfig
 import com.google.cloud.bigquery.JobInfo.{CreateDisposition, WriteDisposition}
 import org.apache.spark.sql.DataFrame
@@ -19,7 +20,8 @@ case class JdbcLoadConfig(
   user: String = "",
   password: String = "",
   partitions: Int = 1,
-  batchSize: Int = 1000
+  batchSize: Int = 1000,
+  rls: Option[List[RowLevelSecurity]] = None
 )
 
 object JdbcLoadConfig extends CliConfig[JdbcLoadConfig] {

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -149,7 +149,8 @@ trait IngestionJob extends SparkJob {
           writeDisposition = writeDisposition,
           location = meta.getProperties().get("location"),
           outputPartition = meta.getProperties().get("timestamp"),
-          days = meta.getProperties().get("days").map(_.toInt)
+          days = meta.getProperties().get("days").map(_.toInt),
+          rls = schema.rls
         )
         val res = new BigQueryLoadJob(config, Some(schema.bqSchema(schemaHandler))).run()
         res match {

--- a/src/main/scala/com/ebiznext/comet/schema/model/AutoJobDesc.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/AutoJobDesc.scala
@@ -43,7 +43,8 @@ case class AutoTaskDesc(
   postsql: Option[List[String]] = None,
   area: Option[StorageArea] = None,
   index: Option[IndexSink] = None,
-  properties: Option[Map[String, String]] = None
+  properties: Option[Map[String, String]] = None,
+  rls: Option[RowLevelSecurity] = None
 ) {
 
   @JsonIgnore

--- a/src/main/scala/com/ebiznext/comet/schema/model/RowLevelSecurity.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/RowLevelSecurity.scala
@@ -3,8 +3,18 @@ package com.ebiznext.comet.schema.model
 case class RowLevelSecurity(
   name: String,
   predicate: String,
-  grants: List[(UserType, String)]
-)
+  grants: List[String]
+) {
+
+  def grantees(): List[(UserType, String)] = {
+    grants.map { user =>
+      val res = user.split(':')
+      assert(res.length == 2)
+      (UserType.fromString(res(0).trim), res(1).trim)
+    }
+
+  }
+}
 
 object RowLevelSecurity {
 
@@ -14,11 +24,6 @@ object RowLevelSecurity {
     val name = components(0)
     val filter = components(1)
     val users = components.drop(2)
-    val grants = users.map { user =>
-      val res = user.split(':')
-      assert(res.length == 2)
-      (UserType.fromString(res(0)), res(1))
-    }
-    RowLevelSecurity(name, filter, grants.toList)
+    RowLevelSecurity(name, filter, users.toList)
   }
 }

--- a/src/main/scala/com/ebiznext/comet/schema/model/RowLevelSecurity.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/RowLevelSecurity.scala
@@ -1,0 +1,24 @@
+package com.ebiznext.comet.schema.model
+
+case class RowLevelSecurity(
+  name: String,
+  predicate: String,
+  grants: List[(UserType, String)]
+)
+
+object RowLevelSecurity {
+
+  def parse(input: String): RowLevelSecurity = {
+    val components = input.split(',')
+    assert(components.length >= 3)
+    val name = components(0)
+    val filter = components(1)
+    val users = components.drop(2)
+    val grants = users.map { user =>
+      val res = user.split(':')
+      assert(res.length == 2)
+      (UserType.fromString(res(0)), res(1))
+    }
+    RowLevelSecurity(name, filter, grants.toList)
+  }
+}

--- a/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
@@ -63,7 +63,8 @@ case class Schema(
   comment: Option[String],
   presql: Option[List[String]],
   postsql: Option[List[String]],
-  tags: Option[Set[String]] = None
+  tags: Option[Set[String]] = None,
+  rls: Option[RowLevelSecurity] = None
 ) {
 
   /**

--- a/src/main/scala/com/ebiznext/comet/schema/model/UserType.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/UserType.scala
@@ -1,0 +1,65 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one or more
+ *  * contributor license agreements.  See the NOTICE file distributed with
+ *  * this work for additional information regarding copyright ownership.
+ *  * The ASF licenses this file to You under the Apache License, Version 2.0
+ *  * (the "License"); you may not use this file except in compliance with
+ *  * the License.  You may obtain a copy of the License at
+ *  *
+ *  *    http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ *
+ */
+
+package com.ebiznext.comet.schema.model
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.annotation.{JsonDeserialize, JsonSerialize}
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer
+import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer}
+
+/**
+  * Recognized file type format. This will select  the correct parser
+  *
+  * @param value : SIMPLE_JSON, JSON of DSV
+  *              Simple Json is made of a single level attributes of simple types (no arrray or map or sub objects)
+  */
+@JsonSerialize(using = classOf[ToStringSerializer])
+@JsonDeserialize(using = classOf[UserTypeDeserializer])
+sealed case class UserType(value: String) {
+  override def toString: String = value
+}
+
+object UserType {
+
+  def fromString(value: String): UserType = {
+    value.toUpperCase match {
+      case "SA"    => UserType.SA
+      case "USER"  => UserType.USER
+      case "GROUP" => UserType.GROUP
+    }
+  }
+
+  object SA extends UserType("SA")
+
+  object USER extends UserType("USER")
+
+  object GROUP extends UserType("GROUP")
+
+  val formats: Set[UserType] = Set(SA, USER, GROUP)
+}
+
+class UserTypeDeserializer extends JsonDeserializer[UserType] {
+
+  override def deserialize(jp: JsonParser, ctx: DeserializationContext): UserType = {
+    val value = jp.readValueAs[String](classOf[String])
+    UserType.fromString(value)
+  }
+}

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -411,7 +411,8 @@ class IngestionWorkflow(
                   writeDisposition = writeDisposition,
                   location = task.properties.flatMap(_.get("location")),
                   outputPartition = task.properties.flatMap(_.get("timestamp")),
-                  days = task.properties.flatMap(_.get("days").map(_.toInt))
+                  days = task.properties.flatMap(_.get("days").map(_.toInt)),
+                  rls = task.rls
                 )
               )
             case _ =>

--- a/src/test/resources/expected/yml/business.yml
+++ b/src/test/resources/expected/yml/business.yml
@@ -13,6 +13,11 @@ tasks:
   area: null
   index: null
   properties: null
+  rls:
+    name: "myrls"
+    predicate: "TRUE"
+    grants:
+    - "user:hayssam.saleh@ebiznext.com"
 area: "business"
 format: "parquet"
 coalesce: true

--- a/src/test/scala/com/ebiznext/comet/job/index/bqload/BiqQueryLoadJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/job/index/bqload/BiqQueryLoadJobSpec.scala
@@ -21,6 +21,8 @@ class BiqQueryLoadJobSpec extends TestHelper {
           |                           Big Query Create disposition https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/CreateDisposition
           |  --write_disposition <value>
           |                           Big Query Write disposition https://cloud.google.com/bigquery/docs/reference/auditlogs/rest/Shared.Types/WriteDisposition
+          |  --row_level_security <value>
+          |                           value is in the form name,filter,sa:sa@mail.com,user:user@mail.com,group:group@mail.com
           |""".stripMargin
       rendered.substring(rendered.indexOf("Usage:")).replaceAll("\\s", "") shouldEqual expected
         .replaceAll("\\s", "")

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
@@ -145,7 +145,10 @@ class StorageHandlerSpec extends TestHelper {
         "DOMAIN",
         "ANALYSE",
         WriteMode.OVERWRITE,
-        Some(List("comet_year", "comet_month"))
+        Some(List("comet_year", "comet_month")),
+        rls = Some(
+          RowLevelSecurity("myrls", "TRUE", List("user:hayssam.saleh@ebiznext.com"))
+        )
       )
       val businessJob =
         AutoJobDesc("business1", List(businessTask1), None, Some("parquet"), Some(true))


### PR DESCRIPTION
## Summary
BigQuery will soon introduce a new Row Level Security Feature.
This PR enable us to set the users / groups / service accounts allowed to access tables or subsets of tables by adding the following tags to the YAML files : 
  rls:
    name: "myrls"
    predicate: "TRUE"
    grants:
    - "user:john@doe.com"
    - "group:readers@org.com"
    - "sa:service@serviceaccount.org.com"

This section may appear in the schema definition and is applied at ingestion time or in the AutoTask Definition where it will be applied right after the job has succeeded.

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**


## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



