### PR TITLE
Minor changes on BigQuery Autojob

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
@@ -81,7 +81,7 @@ class AutoTask(
             session.read.parquet(fullPath)
           case BQ =>
             session.read
-              .format("bigquery")
+              .format("com.google.cloud.spark.bigquery")
               .load(path)
               .cache()
           case _ =>

--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
@@ -65,13 +65,6 @@ class AutoTask(
           .asInstanceOf[UdfRegistration]
       udfInstance.register(session)
     }
-    task.properties.foreach { properties =>
-      properties.map {
-        case (k, v) if k.startsWith("spark.") =>
-          session.conf.set(k.substring("spark.".length), v)
-        case _ => // do nothing
-      }
-    }
     views.getOrElse(Map()).foreach {
       case (key, value) =>
         val sepIndex = value.indexOf(":")

--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
@@ -88,9 +88,8 @@ class AutoTask(
             session.read.parquet(fullPath)
           case BQ =>
             session.read
-              .format("com.google.cloud.spark.bigquery")
-              .option("table", path)
-              .load()
+              .format("bigquery")
+              .load(path)
               .cache()
           case _ =>
             ???


### PR DESCRIPTION
## Summary

- We must no longer use the "table" option when reading a table from BigQuery, because this option has been deprecated and will be removed in a future version.

- Spark properties should be invoked from Task Dag Run instead of Autojob yaml file.


**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



