### PR TITLE
Fix : Support time (HHmmss) patterns for timestamp type

### DIFF
--- a/src/test/scala/com/ebiznext/comet/schema/model/TimestampTypeSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/model/TimestampTypeSpec.scala
@@ -288,5 +288,12 @@ class TimestampTypeSpec extends TestHelper {
         timestamp.fromString("2017-SEP-04", "yyyy-MMM-dd", "UTC+2")
       }
     }
+
+    "Time only pattern at UTC timezone with zone arg set to UTC" should "return a valid timestamp" in {
+      val input = "220157"
+      val expected = Timestamp.from(Instant.parse("1970-01-01T22:01:57.00Z"))
+      val actual = timestamp.fromString(input, "HHmmss", "UTC")
+      expected shouldEqual actual
+    }
   }
 }


### PR DESCRIPTION
## Summary
Since the implementation of standard date time patterns, columns specifying a time pattern without a date, which were valid with the previous implementation, became not parseable. Since then, some dataset could not be ingested.
This is a fix for that issue.

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**

## Description
### Solution
Parse the time patterns (eg. HHmmss) with the old API, based on SimpleDateFormat.

### How has this been tested?
* Unit tests
* Data ingestion

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



