### PR TITLE
Enable the user to use his own row validator.

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -42,6 +42,9 @@ metadata-file-system = ${?COMET_METADATA_FS}
 chewer-prefix = "comet.chewer"
 chewer-prefix = ${?COMET_CHEWER_PREFIX}
 
+row-validator-class = "com.ebiznext.comet.job.ingest.DsvIngestionUtil"
+row-validator-class = ${?COMET_ROW_VALIDATOR_CLASS}
+
 lock {
   path = ${root}"/locks"
   path = ${?COMET_LOCK_PATH}

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -235,6 +235,7 @@ object Settings extends StrictLogging {
     writeFormat: String,
     launcher: String,
     chewerPrefix: String,
+    rowValidatorClass: String,
     analyze: Boolean,
     hive: Boolean,
     grouped: Boolean,

--- a/src/main/scala/com/ebiznext/comet/job/ingest/PositionIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/PositionIngestionJob.scala
@@ -101,7 +101,7 @@ class PositionIngestionJob(
 
     val (orderedTypes, orderedSparkTypes) = reorderTypes()
 
-    val (rejectedRDD, acceptedRDD) = DsvIngestionUtil.validate(
+    val (rejectedRDD, acceptedRDD) = rowValidator().validate(
       session,
       dataset,
       orderedAttributes,


### PR DESCRIPTION
## Summary
Sometimes, we need to use specific validator or accept the data without validation, all we want is typing.
This PR allows the user to customise his validator for DSV, POSITION and SIMPLE_JSON input files.
We will need to add something similar for hierarchical documents (aka JSON & XML)

The validator may be customised through the property row-validator-class or the COMET_ROW_VALIDATOR_CLASS environment variable.

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**

