### PR TITLE
Using a main arg to get delta columns instead of timestamp schema field

### DIFF
--- a/src/main/scala/com/ebiznext/comet/database/extractor/ExtractScriptGenConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/database/extractor/ExtractScriptGenConfig.scala
@@ -6,7 +6,8 @@ import scopt.{OParser, RenderingMode}
 case class ExtractScriptGenConfig(
   domain: String = "",
   scriptTemplateFile: File = File("."),
-  scriptOutputDir: File = File(".")
+  scriptOutputDir: File = File("."),
+  deltaColumn: Option[String] = None
 )
 
 object ExtractScriptGenConfig {
@@ -66,7 +67,11 @@ object ExtractScriptGenConfig {
         .validate(exists("Script output folder"))
         .action((x, c) => c.copy(scriptOutputDir = File(x)))
         .required()
-        .text("Scripts output folder")
+        .text("Scripts output folder"),
+      opt[String]("deltaColumn")
+        .action((x, c) => c.copy(deltaColumn = Some(x)))
+        .optional()
+        .text("The date column used to determine new rows to export")
     )
   }
   val usage: String = OParser.usage(parser, RenderingMode.TwoColumns)

--- a/src/main/scala/com/ebiznext/comet/database/extractor/TemplateParams.scala
+++ b/src/main/scala/com/ebiznext/comet/database/extractor/TemplateParams.scala
@@ -66,9 +66,10 @@ object TemplateParams {
     */
   def fromDomain(
     domain: Domain,
-    scriptsOutputFolder: File
+    scriptsOutputFolder: File,
+    deltaColumn: Option[String]
   ): List[TemplateParams] =
-    domain.schemas.map(fromSchema(_, scriptsOutputFolder))
+    domain.schemas.map(fromSchema(_, scriptsOutputFolder, deltaColumn))
 
   /**
     * Generate scripts template parameters, extracting the tables and the columns described in the schema
@@ -77,7 +78,8 @@ object TemplateParams {
     */
   def fromSchema(
     schema: Schema,
-    scriptsOutputFolder: File
+    scriptsOutputFolder: File,
+    deltaColumn: Option[String]
   ): TemplateParams = {
     val scriptOutputFileName = s"EXTRACT_${schema.name}.sql"
     // exportFileBase is the csv file name base such as EXPORT_L58MA_CLIENT_DELTA_...
@@ -89,7 +91,7 @@ object TemplateParams {
       tableToExport = schema.name,
       columnsToExport = schema.attributes.map(_.name),
       fullExport = isFullExport,
-      deltaColumn = if (!isFullExport) schema.merge.flatMap(_.timestamp) else None,
+      deltaColumn = if (!isFullExport) deltaColumn else None,
       dsvDelimiter = schema.metadata.flatMap(_.separator).getOrElse(","),
       exportOutputFileBase = exportFileBase,
       scriptOutputFile = scriptsOutputFolder / scriptOutputFileName

--- a/src/test/scala/com/ebiznext/comet/database/extractor/TemplateParamsSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/database/extractor/TemplateParamsSpec.scala
@@ -31,7 +31,11 @@ class TemplateParamsSpec extends AnyFlatSpec with Matchers {
       exportOutputFileBase = "output_file",
       scriptOutputFile = scriptOutputFolder / "EXTRACT_table1.sql"
     )
-    TemplateParams.fromSchema(schema, scriptOutputFolder) shouldBe expectedTemplateParams
+    TemplateParams.fromSchema(
+      schema,
+      scriptOutputFolder,
+      Some("updateCol")
+    ) shouldBe expectedTemplateParams
   }
 
   it should "generate the correct TemplateParams for an other Schema" in {
@@ -55,6 +59,6 @@ class TemplateParamsSpec extends AnyFlatSpec with Matchers {
       exportOutputFileBase = "output_file",
       scriptOutputFile = scriptOutputFolder / "EXTRACT_table1.sql"
     )
-    TemplateParams.fromSchema(schema, scriptOutputFolder) shouldBe expectedTemplateParams
+    TemplateParams.fromSchema(schema, scriptOutputFolder, None) shouldBe expectedTemplateParams
   }
 }


### PR DESCRIPTION
## Summary

Using a main argument to provide the column used in databases tables to identify rows to be exported in delta export mode instead of timestamp field of the schema (which use is to be used as a merge option and should not be used that way).

**PR Type: Bug Fix**

**Status: Ready to review**