### PR TITLE
Consider cells with whitespaces only as blank cells

### DIFF
--- a/src/main/scala/com/ebiznext/comet/schema/generator/XlsReader.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/XlsReader.scala
@@ -34,8 +34,9 @@ class XlsReader(path: String) {
         .flatMap(formatter.formatCellValue)
       val directoryOpt = Option(row.getCell(1, Row.MissingCellPolicy.RETURN_BLANK_AS_NULL))
         .flatMap(formatter.formatCellValue)
+      // Here for ack, we do not want to get None returned for an empty cell since None would give us a ".ack" as default later on
       val ack = Option(row.getCell(2, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK))
-        .flatMap(formatter.formatCellValue)
+        .flatMap(formatter.formatCellValue).orElse(Some(""))
       val comment = Option(row.getCell(3, Row.MissingCellPolicy.RETURN_BLANK_AS_NULL))
         .flatMap(formatter.formatCellValue)
       (nameOpt, directoryOpt) match {


### PR DESCRIPTION
## Summary
When parsing Excel cells, consider cells with only whitespaces as blank to avoid human mistakes.