### PR TITLE
Timestamped csv

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -31,7 +31,7 @@ timestamped-csv = false
 timestamped-csv = ${?COMET_TIMESTAMPED_CSV}
 
 default-write-format = parquet
-default-write-format = ${COMET_DEFAULT_WRITE_FORMAT}
+default-write-format = ${?COMET_DEFAULT_WRITE_FORMAT}
 
 merge-force-distinct = false
 merge-force-distinct = ${?COMET_MERGE_FORCE_DISTINCT}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -26,9 +26,12 @@ grouped = ${?COMET_GROUPED}
 analyze = true
 analyze = ${?COMET_ANALYZE}
 
-# deprecated
-write-format = parquet
-write-format = ${?COMET_WRITE_FORMAT}
+# Save Format in CSV with coalesce(1) using timestamp
+timestamped-csv = false
+timestamped-csv = ${?COMET_TIMESTAMPED_CSV}
+
+default-write-format = parquet
+default-write-format = ${COMET_DEFAULT_WRITE_FORMAT}
 
 merge-force-distinct = false
 merge-force-distinct = ${?COMET_MERGE_FORCE_DISTINCT}

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -46,6 +46,7 @@ import org.slf4j.MDC
 import scala.concurrent.duration.FiniteDuration
 
 object Settings extends StrictLogging {
+
   private def loggerForCompanionInstances: Logger = logger
 
   /**
@@ -216,7 +217,7 @@ object Settings extends StrictLogging {
     * @param metrics        : Absolute path, location where all computed metrics are stored
     * @param audit          : Absolute path, location where all log are stored
     * @param archive        : Should we backup the ingested datasets ? true by default
-    * @param writeFormat    : Choose between parquet, orc ... Default is parquet
+    * @param defaultWriteFormat    : Choose between parquet, orc ... Default is parquet
     * @param launcher       : Cron Job Manager : simple (useful for testing) or airflow ? simple by default
     * @param analyze        : Should we create basics Hive statistics on the generated dataset ? true by default
     * @param hive           : Should we create a Hive Table ? true by default
@@ -232,7 +233,8 @@ object Settings extends StrictLogging {
     audit: Audit,
     archive: Boolean,
     lock: Lock,
-    writeFormat: String,
+    defaultWriteFormat: String,
+    timestampedCsv: Boolean,
     launcher: String,
     chewerPrefix: String,
     rowValidatorClass: String,

--- a/src/main/scala/com/ebiznext/comet/job/ingest/AuditLog.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/AuditLog.scala
@@ -104,7 +104,7 @@ object SparkAuditLogWriter {
       val auditPath = new Path(settings.comet.audit.path, s"ingestion-log")
       Seq(log).toDF.write
         .mode(SaveMode.Append)
-        .format(settings.comet.writeFormat)
+        .format(settings.comet.defaultWriteFormat)
         .option("path", auditPath.toString)
         .save()
     }

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -85,7 +85,7 @@ trait IngestionJob extends SparkJob {
       .map(_ => WriteMode.OVERWRITE)
       .getOrElse(metadata.getWriteMode())
 
-  private def timestamedCsv(): Boolean =
+  private def timestampedCsv(): Boolean =
     settings.comet.timestampedCsv && !settings.comet.grouped && metadata.partition.isEmpty
 
   /**
@@ -148,7 +148,7 @@ trait IngestionJob extends SparkJob {
     val savedDataset =
       saveRows(mergedDF, acceptedPath, writeMode, StorageArea.accepted, schema.merge.isDefined)
 
-    if (timestamedCsv()) {
+    if (timestampedCsv()) {
       val formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
       val now = LocalDateTime.now().format(formatter)
       val csvPath = storageHandler.list(acceptedPath, ".csv", LocalDateTime.MIN).head
@@ -336,7 +336,7 @@ trait IngestionJob extends SparkJob {
 
       val nbPartitions = metadata.getSamplingStrategy() match {
         case 0.0 => // default partitioning
-          if (timestamedCsv())
+          if (timestampedCsv())
             1
           else
             dataset.rdd.getNumPartitions
@@ -401,7 +401,7 @@ trait IngestionJob extends SparkJob {
       } else
         (partitionedDFWriter, dataset)
       val finalTargetDatasetWriter =
-        if (timestamedCsv())
+        if (timestampedCsv())
           targetDatasetWriter
             .mode(saveMode)
             .format("csv")

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -405,6 +405,8 @@ trait IngestionJob extends SparkJob {
           targetDatasetWriter
             .mode(saveMode)
             .format("csv")
+            .option("header", metadata.withHeader.getOrElse(false))
+            .option("delimiter", metadata.separator.getOrElse("µ"))
             .option("path", targetPath.toString)
         else
           targetDatasetWriter

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -1,13 +1,15 @@
 package com.ebiznext.comet.job.ingest
 
 import java.sql.Timestamp
-import java.time.Instant
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, LocalDateTime}
 
 import com.ebiznext.comet.config.Settings.IndexSinkSettings
 import com.ebiznext.comet.config.{DatasetArea, Settings, StorageArea}
 import com.ebiznext.comet.job.index.bqload.{BigQueryLoadConfig, BigQueryLoadJob}
 import com.ebiznext.comet.job.index.esload.{ESLoadConfig, ESLoadJob}
 import com.ebiznext.comet.job.index.jdbcload.{JdbcLoadConfig, JdbcLoadJob}
+import com.ebiznext.comet.job.ingest.ImprovedDataFrameContext._
 import com.ebiznext.comet.job.metrics.MetricsJob
 import com.ebiznext.comet.schema.handlers.{SchemaHandler, StorageHandler}
 import com.ebiznext.comet.schema.model.Rejection.{ColInfo, ColResult}
@@ -22,7 +24,6 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.expressions.Window
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.{StringType, StructField, StructType, TimestampType}
-import com.ebiznext.comet.job.ingest.ImprovedDataFrameContext._
 
 import scala.language.existentials
 import scala.util.{Failure, Success, Try}
@@ -143,6 +144,17 @@ trait IngestionJob extends SparkJob {
 
     val savedDataset =
       saveRows(mergedDF, acceptedPath, writeMode, StorageArea.accepted, schema.merge.isDefined)
+
+    if (settings.comet.timestampedCsv && metadata.partition.isEmpty) {
+      val formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+      val now = LocalDateTime.now().format(formatter)
+      val csvPath = storageHandler.list(acceptedPath, ".csv", LocalDateTime.MIN).head
+      val finalCsvPath = new Path(
+        acceptedPath,
+        s"${acceptedPath.getName()}-${now}.csv"
+      )
+      storageHandler.move(csvPath, finalCsvPath)
+    }
 
     if (settings.comet.metrics.active) {
       new MetricsJob(this.domain, this.schema, Stage.GLOBAL, storageHandler, schemaHandler)
@@ -321,7 +333,10 @@ trait IngestionJob extends SparkJob {
 
       val nbPartitions = metadata.getSamplingStrategy() match {
         case 0.0 => // default partitioning
-          dataset.rdd.getNumPartitions
+          if (settings.comet.timestampedCsv && metadata.partition.isEmpty)
+            1
+          else
+            dataset.rdd.getNumPartitions
         case fraction if fraction > 0.0 && fraction < 1.0 =>
           // Use sample to determine partitioning
           val count = dataset.count()
@@ -338,7 +353,7 @@ trait IngestionJob extends SparkJob {
           val sampledDataset = dataset.sample(false, minFraction)
           partitionedDatasetWriter(sampledDataset, metadata.getPartitionAttributes())
             .mode(SaveMode.ErrorIfExists)
-            .format(settings.comet.writeFormat)
+            .format(settings.comet.defaultWriteFormat)
             .option("path", tmpPath.toString)
             .save()
           val consumed = storageHandler.spaceConsumed(tmpPath) / fraction
@@ -368,7 +383,7 @@ trait IngestionJob extends SparkJob {
         logger.info(s"Saving Dataset to merge location $mergePath")
         partitionedDFWriter
           .mode(SaveMode.Overwrite)
-          .format(settings.comet.writeFormat)
+          .format(settings.comet.defaultWriteFormat)
           .option("path", mergePath)
           .save()
         logger.info(s"reading Dataset from merge location $mergePath")
@@ -382,10 +397,18 @@ trait IngestionJob extends SparkJob {
         )
       } else
         (partitionedDFWriter, dataset)
-      val finalTargetDatasetWriter = targetDatasetWriter
-        .mode(saveMode)
-        .format(settings.comet.writeFormat)
-        .option("path", targetPath.toString)
+      val finalTargetDatasetWriter =
+        if (settings.comet.timestampedCsv && metadata.partition.isEmpty)
+          targetDatasetWriter
+            .mode(saveMode)
+            .format("csv")
+            .option("path", targetPath.toString)
+        else
+          targetDatasetWriter
+            .mode(saveMode)
+            .format(settings.comet.defaultWriteFormat)
+            .option("path", targetPath.toString)
+
       logger.info(s"Saving Dataset to final location $targetPath")
       if (settings.comet.hive) {
         finalTargetDatasetWriter.saveAsTable(fullTableName)

--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
@@ -109,7 +109,7 @@ class AutoTask(
 
       val finalDataset = partitionedDF
         .mode(task.write.toSaveMode)
-        .format(format.getOrElse(settings.comet.writeFormat))
+        .format(format.getOrElse(settings.comet.defaultWriteFormat))
         .option("path", targetPath.toString)
 
       if (settings.comet.hive) {


### PR DESCRIPTION
## Summary
Sometimes we want to ingest a file and save it in a single CSV file. This should never happen except at the preencrypt phase before the file is sent for ingestion.
We achieve this by setting the timestamped-csv property to true in the reference.conf or by using the COMET_TIMESTAMPED_CSV env var.
This feature requires partitioning and grouped ingestion to be disabled "grouped = ${?COMET_GROUPED}" otherwise it is ignored.


**PR Type: Feature**

**Status: Ready to review**

**Breaking change? Yes**
