### PR TITLE
Spark-BigQuery-Connector supports overwrite data of a single date partition 

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
@@ -81,7 +81,7 @@ class AutoTask(
             session.read.parquet(fullPath)
           case BQ =>
             session.read
-              .format("bigquery")
+              .format("com.google.cloud.spark.bigquery")
               .load(path)
               .cache()
           case _ =>

--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
@@ -65,13 +65,6 @@ class AutoTask(
           .asInstanceOf[UdfRegistration]
       udfInstance.register(session)
     }
-    task.properties.foreach { properties =>
-      properties.map {
-        case (k, v) if k.startsWith("spark.") =>
-          session.conf.set(k.substring("spark.".length), v)
-        case _ => // do nothing
-      }
-    }
     views.getOrElse(Map()).foreach {
       case (key, value) =>
         val sepIndex = value.indexOf(":")

--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTask.scala
@@ -88,9 +88,8 @@ class AutoTask(
             session.read.parquet(fullPath)
           case BQ =>
             session.read
-              .format("com.google.cloud.spark.bigquery")
-              .option("table", path)
-              .load()
+              .format("bigquery")
+              .load(path)
               .cache()
           case _ =>
             ???


### PR DESCRIPTION
## Summary
The aim of this PR is to use spark-bigquery-connector feature to overwrite data of a single date partition instead of, managing it by comet.
Since we have updated our spark-bigquery-connector jar to 0.17.0, we can take advantage of this new feature : 

******************************************
https://github.com/GoogleCloudDataproc/spark-bigquery-connector/releases/tag/0.17.0
******************************************

**Related Issue: https://github.com/GoogleCloudDataproc/spark-bigquery-connector/issues/103**

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



