### PR TITLE
Spark when saving to csv ignore leading and trailing spaces.

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/convert/Parquet2CSV.scala
+++ b/src/main/scala/com/ebiznext/comet/job/convert/Parquet2CSV.scala
@@ -55,6 +55,8 @@ class Parquet2CSV(config: Parquet2CSVConfig, val storageHandler: StorageHandler)
             .mode(config.writeMode.getOrElse(WriteMode.ERROR_IF_EXISTS).toSaveMode)
           config.options
             .foldLeft(writer)((w, kv) => w.option(kv._1, kv._2))
+            .option("ignoreLeadingWhiteSpace", false)
+            .option("ignoreTrailingWhiteSpace", false)
             .csv(csvPath.toString)
           if (config.partitions == 1) {
             val files = storageHandler.list(csvPath, "csv")

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -424,6 +424,8 @@ trait IngestionJob extends SparkJob {
           targetDatasetWriter
             .mode(saveMode)
             .format("csv")
+            .option("ignoreLeadingWhiteSpace", false)
+            .option("ignoreTrailingWhiteSpace", false)
             .option("header", metadata.withHeader.getOrElse(false))
             .option("delimiter", metadata.separator.getOrElse("µ"))
             .option("path", targetPath.toString)


### PR DESCRIPTION

## Summary
Spark when saving to csv ignore leading and trailing spaces.
We ask not to trim string explicitly

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**

