### PR TITLE
UDF through reference.conf

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -39,6 +39,8 @@ merge-force-distinct = ${?COMET_MERGE_FORCE_DISTINCT}
 file-system = "file://"
 file-system = ${?COMET_FS}
 
+udfs = ${?COMET_UDFS}
+
 metadata-file-system = ${file-system}
 metadata-file-system = ${?COMET_METADATA_FS}
 

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -207,7 +207,8 @@ object Settings extends StrictLogging {
     privacy: Privacy,
     fileSystem: Option[String],
     metadataFileSystem: Option[String],
-    internal: Option[Internal]
+    internal: Option[Internal],
+    udfs: Option[String]
   ) extends Serializable {
 
     @JsonIgnore


### PR DESCRIPTION
## Summary
Allow the user to define UDFs at the reference.conf level through the "udfs" key as a comma separated list of UDFRegistration classes. See com.ebiznext.comet.udf.TestUdf

This key may also be defined through the COMET_UDFS environment variable.

UDFs defined here are available in all ingestion / Auto Jobs throughout the project. 
**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**
