### PR TITLE
Fixing BQ merge

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -164,11 +164,7 @@ trait IngestionJob extends SparkJob {
                 .option("table", bqTable)
                 .load()
               if (
-                existingBigQueryDF.schema.fields.length == session.read
-                  .parquet(acceptedPath.toString)
-                  .schema
-                  .fields
-                  .length
+                existingBigQueryDF.schema.fields.length == acceptedDfWithscriptFields.schema.fields.length
               )
                 merge(acceptedDfWithscriptFields, existingBigQueryDF, mergeOptions)
               else


### PR DESCRIPTION
## Summary
When merging a source, if a BQ table exists, compare the schema extracted from the BQ table to the current accepted DF instead of reaching for the accepted parquet.
The accepted parquet might not exist for TTL reason and it should not make the ingestion fail.




