### PR TITLE
Fix Big Query Sink with scripted fields issue

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -146,18 +146,21 @@ trait IngestionJob extends SparkJob {
                                         }
                                       } else acceptedDF).drop(Settings.cometInputFileNameColumn)
 
-    logger.info("Accepted Dataframe schema right after adding computed columns")
-    acceptedDfWithScriptFields.printSchema()
-    acceptedDfWithScriptFields.show(10)
+    logger.whenDebugEnabled {
+      logger.debug("Accepted Dataframe schema right after adding computed columns")
+      acceptedDfWithScriptFields.printSchema()
+    }
 
     val withScriptFieldsDF =
       session.createDataFrame(
         acceptedDfWithScriptFields.rdd,
         schema.sparkTypeWithRenamedFields(schemaHandler)
       )
-    logger.info("Accepted Dataframe schema before optional merge")
-    withScriptFieldsDF.printSchema()
-    withScriptFieldsDF.show(10)
+
+    logger.whenDebugEnabled {
+      logger.debug("Accepted Dataframe schema before optional merge")
+      withScriptFieldsDF.printSchema()
+    }
 
     val mergedDF = schema.merge
       .map { mergeOptions =>

--- a/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
@@ -31,7 +31,7 @@ import org.apache.spark.sql.types._
 import scala.collection.mutable
 
 /**
-  * How dataset are merge
+  * How dataset are merged
   *
   * @param key    list of attributes to join existing with incoming dataset. Use renamed columns here.
   * @param delete Optional valid sql condition on the incoming dataset. Use renamed column here.
@@ -105,8 +105,22 @@ case class Schema(
     *
     * @return Spark Catalyst Schema
     */
-  def sparkTypeRenamed(schemaHandler: SchemaHandler): StructType = {
-    val fields = attributes.map { attr =>
+  def sparkTypeWithRenamedFields(schemaHandler: SchemaHandler): StructType =
+    sparkSchemaWithCondition(schemaHandler, _ => true)
+
+  /**
+    * This Schema as a Spark Catalyst Schema, without scripted fields
+    *
+    * @return Spark Catalyst Schema
+    */
+  def sparkSchemaWithoutScriptedFields(schemaHandler: SchemaHandler): StructType =
+    sparkSchemaWithCondition(schemaHandler, _.script.isEmpty)
+
+  private def sparkSchemaWithCondition(
+    schemaHandler: SchemaHandler,
+    p: Attribute => Boolean
+  ): StructType = {
+    val fields = attributes filter p map { attr =>
       StructField(attr.rename.getOrElse(attr.name), attr.sparkType(schemaHandler), !attr.required)
     }
     StructType(fields)
@@ -220,8 +234,8 @@ case class Schema(
     val tse = TextSubstitutionEngine(
       "PROPERTIES" -> properties,
       "ATTRIBUTES" -> attrs,
-      "DOMAIN" -> domainName.toLowerCase,
-      "SCHEMA" -> name.toLowerCase
+      "DOMAIN"     -> domainName.toLowerCase,
+      "SCHEMA"     -> name.toLowerCase
     )
 
     tse.apply(template.getOrElse {

--- a/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
@@ -100,6 +100,18 @@ case class Schema(
     StructType(fields)
   }
 
+  /**
+    * This Schema as a Spark Catalyst Schema, with renamed attributes
+    *
+    * @return Spark Catalyst Schema
+    */
+  def sparkTypeRenamed(schemaHandler: SchemaHandler): StructType = {
+    val fields = attributes.map { attr =>
+      StructField(attr.rename.getOrElse(attr.name), attr.sparkType(schemaHandler), !attr.required)
+    }
+    StructType(fields)
+  }
+
   import com.google.cloud.bigquery.{Schema => BQSchema}
 
   def bqSchema(schemaHandler: SchemaHandler): BQSchema = {

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/JsonIngestionJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/JsonIngestionJobSpec.scala
@@ -56,6 +56,10 @@ abstract class JsonIngestionJobSpecBase(variant: String) extends TestHelper with
           "/sample/json/complex.json"
         )
 
+        val schemaHandler = new SchemaHandler(settings.storageHandler)
+        val schema = schemaHandler.getSchema("json", "sample_json").get
+        val sparkSchema = schema.sparkSchemaWithoutScriptedFields(schemaHandler)
+
         // Accepted should have the same data as input
         val resultDf = sparkSession.read
           .parquet(
@@ -63,6 +67,7 @@ abstract class JsonIngestionJobSpecBase(variant: String) extends TestHelper with
           )
 
         val expectedDf = sparkSession.read
+          .schema(sparkSchema)
           .json(
             getClass.getResource(s"/sample/${datasetDomainName}/complex.json").toURI.getPath
           )

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/JsonIngestionJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/JsonIngestionJobSpec.scala
@@ -66,8 +66,8 @@ abstract class JsonIngestionJobSpecBase(variant: String) extends TestHelper with
           .json(
             getClass.getResource(s"/sample/${datasetDomainName}/complex.json").toURI.getPath
           )
-          .withColumn("source_file_name", regexp_extract(input_file_name, ".+\\/(.+)$", 1))
           .withColumn("email_domain", regexp_extract(col("email"), ".+@(.+)", 1))
+          .withColumn("source_file_name", regexp_extract(input_file_name, ".+\\/(.+)$", 1))
 
         resultDf
           .except(


### PR DESCRIPTION
## Summary
At ingestion time, we have no control over the attribute `required` of the scripted fields, resulting in a schema incompatibility when sinking in Big Query, which causes the failure of the sink.
After fixing the 'required' issue of the computed (scripted) fields, it appears that data ingested from a json source does not follow the declared yaml schema columns order, which may cause issues when sinking in big query. This is fixed by forcing the schema at ingestion time for json sources

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
* Create spark schema at runtime from the yaml file
* Apply this schema to the dataframes (from parquet, bq or json)

### How has this been tested?
* unit tests
* integration tests
* ingestions on GCP with big query sinks

### Other changes
Apply the declared yaml schema in json ingestion

### Remaining Todos

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



