### PR TITLE
A loading mode for applying Privacy levels

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -30,6 +30,9 @@ analyze = ${?COMET_ANALYZE}
 csv-output = false
 csv-output = ${?COMET_CSV_OUTPUT}
 
+only-privacy = false
+only-privacy = ${?COMET_ONLY_PRIVACY}
+
 default-write-format = parquet
 default-write-format = ${?COMET_DEFAULT_WRITE_FORMAT}
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -30,8 +30,8 @@ analyze = ${?COMET_ANALYZE}
 csv-output = false
 csv-output = ${?COMET_CSV_OUTPUT}
 
-only-privacy = false
-only-privacy = ${?COMET_ONLY_PRIVACY}
+privacy-only = false
+privacy-only = ${?COMET_PRIVACY_ONLY}
 
 default-write-format = parquet
 default-write-format = ${?COMET_DEFAULT_WRITE_FORMAT}

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -184,7 +184,7 @@ object Settings extends StrictLogging {
     lock: Lock,
     defaultWriteFormat: String,
     csvOutput: Boolean,
-    onlyPrivacy: Boolean,
+    privacyOnly: Boolean,
     launcher: String,
     chewerPrefix: String,
     rowValidatorClass: String,

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -184,6 +184,7 @@ object Settings extends StrictLogging {
     lock: Lock,
     defaultWriteFormat: String,
     csvOutput: Boolean,
+    onlyPrivacy: Boolean,
     launcher: String,
     chewerPrefix: String,
     rowValidatorClass: String,

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -197,9 +197,9 @@ class IngestionWorkflow(
 
       // We group files with the same schema to ingest them together in a single step.
       val groupedResolved: Map[Schema, Iterable[Path]] = filteredResolved.map {
-          case (Some(schema), path) => (schema, path)
-          case (None, _)            => throw new Exception("Should never happen")
-        } groupBy (_._1) mapValues (it => it.map(_._2))
+        case (Some(schema), path) => (schema, path)
+        case (None, _)            => throw new Exception("Should never happen")
+      } groupBy (_._1) mapValues (it => it.map(_._2))
 
       groupedResolved.map { case (schema, pendingPaths) =>
         logger.info(s"""Ingest resolved file : ${pendingPaths

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -176,7 +176,7 @@ class IngestionWorkflow(
         storageHandler.move(path, targetPath)
       }
 
-      val filteredResolved = if (settings.comet.onlyPrivacy) {
+      val filteredResolved = if (settings.comet.privacyOnly) {
         val (withPrivacy, noPrivacy) =
           resolved.partition(
             _._1.exists(_.attributes.forall(_.privacy.exists(!PrivacyLevel.None.equals(_))))


### PR DESCRIPTION
## Summary
This pull request introduces _PRIVACY_ONLY_ loading mode which can be used to apply **Privacy Level** on the **Schemas** of a given **Domain**. Only the input data of Schemas that have attributes with Privacy Level are concerned by this step. Input data for the Schemas in the same Domain without any Privacy Level can be moved directly to the accepted zone.

**PR Type: Feature**

**Status: Ready To Review**

**Breaking change? Yes**
Impact on already generated yml files. The post-encrypt yml for a Schema without any privacy level in a Domain that contains privacy levels is to be regenerated.

## Description
### Solution
- During the ingestion phase, identify the schemas without any defined privacy level and move their corresponding data files from pending to accepted zone.
- Update the post-encrypt generation for the schemas without an applied privacy level in the encryption phase

### How has this been tested?
- Existing unit tests
- A local ingestion 

## Contributor checklist:
- [x] My code follows the code style of this project.



