### PR TITLE
Bugfix: script fields with Position Format

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/ingest/DsvIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/DsvIngestionJob.scala
@@ -128,7 +128,7 @@ class DsvIngestionJob(
              if there are more in the CSV file
            */
 
-          val attributesWithoutscript = schema.attributes.filter(!_.script.isDefined)
+          val attributesWithoutscript = schema.attributesWithoutScript
           val compare =
             attributesWithoutscript.length.compareTo(df.columns.length)
           if (compare == 0) {
@@ -178,7 +178,7 @@ class DsvIngestionJob(
   def ingest(dataset: DataFrame): (RDD[_], RDD[_]) = {
 
     val attributesWithoutscript: Seq[Attribute] =
-      schema.attributes.filter(!_.script.isDefined) :+ Attribute(
+      schema.attributesWithoutScript :+ Attribute(
         name = Settings.cometInputFileNameColumn
       )
 

--- a/src/main/scala/com/ebiznext/comet/job/ingest/PositionIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/PositionIngestionJob.scala
@@ -90,11 +90,12 @@ class PositionIngestionJob(
     */
   override def ingest(input: DataFrame): (RDD[_], RDD[_]) = {
 
-    val dataset: DataFrame = PositionIngestionUtil.prepare(session, input, schema.attributes)
+    val attributesWithoutScript = schema.attributes.filter(_.script.isEmpty)
+    val dataset: DataFrame = PositionIngestionUtil.prepare(session, input, attributesWithoutScript)
 
     def reorderAttributes(): List[Attribute] = {
       val attributesMap =
-        this.schema.attributes.map(attr => (attr.name, attr)).toMap
+        attributesWithoutScript.map(attr => (attr.name, attr)).toMap
       dataset.columns.map(colName => attributesMap(colName)).toList
     }
 

--- a/src/main/scala/com/ebiznext/comet/job/ingest/PositionIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/PositionIngestionJob.scala
@@ -90,12 +90,12 @@ class PositionIngestionJob(
     */
   override def ingest(input: DataFrame): (RDD[_], RDD[_]) = {
 
-    val attributesWithoutScript = schema.attributes.filter(_.script.isEmpty)
-    val dataset: DataFrame = PositionIngestionUtil.prepare(session, input, attributesWithoutScript)
+    val dataset: DataFrame =
+      PositionIngestionUtil.prepare(session, input, schema.attributesWithoutScript)
 
     def reorderAttributes(): List[Attribute] = {
       val attributesMap =
-        attributesWithoutScript.map(attr => (attr.name, attr)).toMap
+        schema.attributesWithoutScript.map(attr => (attr.name, attr)).toMap
       dataset.columns.map(colName => attributesMap(colName)).toList
     }
 

--- a/src/main/scala/com/ebiznext/comet/schema/generator/Xls2Yml.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/Xls2Yml.scala
@@ -31,8 +31,10 @@ object Xls2Yml extends LazyLogging {
             else
               attr.copy(`type` = "string", required = false, privacy = None, rename = None)
           }
+      // pre-encryption YML should not contain any partition or sink elements.
+      // Write mode is forced to APPEND since encryption output must not overwrite previous results
       val newMetaData: Option[Metadata] = s.metadata.map { m =>
-        m.copy(partition = None, sink = None)
+        m.copy(partition = None, sink = None, write = Some(WriteMode.APPEND))
       }
       s.copy(attributes = newAttributes)
         .copy(metadata = newMetaData)

--- a/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
@@ -72,6 +72,8 @@ case class Schema(
   rls: Option[List[RowLevelSecurity]] = None
 ) {
 
+  lazy val attributesWithoutScript: List[Attribute] = attributes.filter(_.script.isEmpty)
+
   /** @return Are the parittions columns defined in the metadata valid column names
     */
   def validatePartitionColumns(): Boolean = {
@@ -182,7 +184,7 @@ case class Schema(
     val format = this.mergedMetadata(domainMetaData).format
     format match {
       case Some(Format.POSITION) =>
-        val attrsAsArray = attributes.toArray
+        val attrsAsArray = attributesWithoutScript.toArray
         for (i <- 0 until attrsAsArray.length - 1) {
           val pos1 = attrsAsArray(i).position
           val pos2 = attrsAsArray(i + 1).position

--- a/src/test/resources/sample/position/position.yml
+++ b/src/test/resources/sample/position/position.yml
@@ -85,3 +85,13 @@ schemas:
         position:
           first: 48
           last: 57
+      - name: "calculatedCode"
+        type: "string"
+        script: concat(code0,'-',code1,'-',bancode,'-')
+        array: false
+        required: true
+        privacy: "NONE"
+        metricType: "NONE"
+        position:
+          first: 0
+          last: 0

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/PositionIngestionJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/PositionIngestionJobSpec.scala
@@ -64,6 +64,7 @@ class PositionIngestionJobSpec extends TestHelper {
         sparkSession.read
           .text(getClass.getResource(s"/sample/${datasetDomainName}/XPOSTBL").toURI.getPath)
           .count()
+        acceptedDf.schema.fields.map(_.name).contains("calculatedCode") shouldBe true
       }
 
     }


### PR DESCRIPTION
## Summary
Correction to a problem encountered upon the ingestion of a Position format schema that has script fields.

**PR Type: Bug Fix**

**Status: Ready To Review**

**Breaking change? No**

## Description
### Solution
In `PositionIngestionJob`, loading input data is now done with a schema that does not contain the script fields. This behavior was already implemented in `DsvIngestionJob`

### How has this been tested?
Updating existing unit tests to cover the case of ingesting Position schema with a script field. 

### Other changes
- refactoring of the extraction of attributes without script fields into a `lazy val` in `Schema`
- minor correction in the generation of pre-encryption yml

### Deploy Notes
Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, new environment variables, ...


## Contributor checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



