### PR TITLE
remove ordering condition on positions

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTaskJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTaskJob.scala
@@ -47,18 +47,18 @@ import scala.util.{Failure, Success, Try}
   * @param sqlParameters : Sql Parameters to pass to SQL statements
   */
 class AutoTaskJob(
-                   override val name: String,
-                   defaultArea: Option[StorageArea],
-                   format: scala.Option[String],
-                   coalesce: Boolean,
-                   udf: scala.Option[String],
-                   views: scala.Option[Map[String, String]],
-                   engine: Engine,
-                   task: AutoTaskDesc,
-                   storageHandler: StorageHandler,
-                   sqlParameters: Map[String, String]
-                 )(implicit val settings: Settings)
-  extends SparkJob {
+  override val name: String,
+  defaultArea: Option[StorageArea],
+  format: scala.Option[String],
+  coalesce: Boolean,
+  udf: scala.Option[String],
+  views: scala.Option[Map[String, String]],
+  engine: Engine,
+  task: AutoTaskDesc,
+  storageHandler: StorageHandler,
+  sqlParameters: Map[String, String]
+)(implicit val settings: Settings)
+    extends SparkJob {
 
   override def run(): Try[JobResult] = {
     engine match {
@@ -196,7 +196,8 @@ class AutoTaskJob(
         case BQ =>
           val TablePathWithFilter = "(.*)\\.comet_filter\\((.*)\\)".r
           val TablePathWithSelect = "(.*)\\.comet_select\\((.*)\\)".r
-          val TablePathWithFilterAndSelect = "(.*)\\.comet_select\\((.*)\\)\\.comet_filter\\((.*)\\)".r
+          val TablePathWithFilterAndSelect =
+            "(.*)\\.comet_select\\((.*)\\)\\.comet_filter\\((.*)\\)".r
           path match {
             case TablePathWithFilterAndSelect(tablePath, select, filter) =>
               val filterFormat = filter.richFormat(sqlParameters)

--- a/src/main/scala/com/ebiznext/comet/schema/model/Position.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Position.scala
@@ -24,6 +24,5 @@ package com.ebiznext.comet.schema.model
   *
   * @param first : First char position
   * @param last   : last char position
-  * @param trim : trim left / right / both / none
   */
 case class Position(first: Int, last: Int)

--- a/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
@@ -181,25 +181,6 @@ case class Schema(
     for (errors <- duplicates(attributes.map(_.name), duplicateErrorMessage).left) {
       errorList ++= errors
     }
-    val format = this.mergedMetadata(domainMetaData).format
-    format match {
-      case Some(Format.POSITION) =>
-        val attrsAsArray = attributesWithoutScript.toArray
-        for (i <- 0 until attrsAsArray.length - 1) {
-          val pos1 = attrsAsArray(i).position
-          val pos2 = attrsAsArray(i + 1).position
-          (pos1, pos2) match {
-            case (Some(pos1), Some(pos2)) =>
-              if (pos1.last >= pos2.first) {
-                errorList += s"Positions should be ordered : ${pos1.last} > ${pos2.first}"
-              }
-            case (_, _) =>
-              errorList += s"All attributes should have their position defined"
-
-          }
-        }
-      case _ =>
-    }
 
     if (errorList.nonEmpty)
       Left(errorList.toList)

--- a/src/test/scala/com/ebiznext/comet/utils/UtilsSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/utils/UtilsSpec.scala
@@ -77,7 +77,7 @@ class UtilsSpec extends TestHelper {
       standardResult shouldEqual standardView
       customResult shouldEqual (standardView, filter)
       filterSelectResult shouldEqual (standardView, select, filter)
-      selectResult shouldEqual(standardView, select)
+      selectResult shouldEqual (standardView, select)
     }
   }
 


### PR DESCRIPTION
## Summary
Gives more flexibility in defining a Position Format Schema by removing the obligation of having the `Position.first` of attributes in a strictly increasing order

**PR Type:  Feature**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
cf. Summary

### How has this been tested?
No regression in existing unit tests

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.



