### PR TITLE
simply privacy in Attribute

### DIFF
--- a/src/main/scala/com/ebiznext/comet/schema/generator/Xls2Yml.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/Xls2Yml.scala
@@ -24,12 +24,17 @@ object Xls2Yml extends LazyLogging {
           .map { attr =>
             if (
               privacy == Nil || privacy.contains(
-                attr.privacy.getOrElse(PrivacyLevel.None).toString
+                attr.privacy.toString
               )
             )
               attr.copy(`type` = "string", required = false, rename = None)
             else
-              attr.copy(`type` = "string", required = false, privacy = None, rename = None)
+              attr.copy(
+                `type` = "string",
+                required = false,
+                privacy = PrivacyLevel.None,
+                rename = None
+              )
           }
       // pre-encryption YML should not contain any partition or sink elements.
       // Write mode is forced to APPEND since encryption output must not overwrite previous results
@@ -63,8 +68,8 @@ object Xls2Yml extends LazyLogging {
      * @return true if the schema is not concerned by the encryption phase
      */
     def noPreEncryptPrivacy(s: Schema): Boolean = {
-      s.attributes.forall(_.privacy.isEmpty) ||
-      (encryptionPrivacyList.nonEmpty && s.attributes.flatMap(_.privacy).distinct.forall { p =>
+      s.attributes.forall(_.privacy.equals(PrivacyLevel.None)) ||
+      (encryptionPrivacyList.nonEmpty && s.attributes.map(_.privacy).distinct.forall { p =>
         !encryptionPrivacyList.contains(p.toString)
       })
     }
@@ -88,10 +93,10 @@ object Xls2Yml extends LazyLogging {
         val attributes = schema.attributes.map { attr =>
           if (
             encryptionPrivacyList == Nil || encryptionPrivacyList.contains(
-              attr.privacy.getOrElse(PrivacyLevel.None).toString
+              attr.privacy.toString
             )
           )
-            attr.copy(privacy = None)
+            attr.copy(privacy = PrivacyLevel.None)
           else
             attr
         }

--- a/src/main/scala/com/ebiznext/comet/schema/generator/XlsReader.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/XlsReader.scala
@@ -337,7 +337,7 @@ class XlsReader(path: String) {
                     semType,
                     array = None,
                     required,
-                    privacy,
+                    privacy.getOrElse(PrivacyLevel.None),
                     comment = commentOpt,
                     rename = renameOpt,
                     metricType = metricType,

--- a/src/main/scala/com/ebiznext/comet/schema/model/Attribute.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Attribute.scala
@@ -52,7 +52,7 @@ case class Attribute(
   `type`: String = "string",
   array: Option[Boolean] = None,
   required: Boolean = true,
-  privacy: Option[PrivacyLevel] = None,
+  privacy: PrivacyLevel = PrivacyLevel.None,
   comment: Option[String] = None,
   rename: Option[String] = None,
   metricType: Option[MetricType] = None,
@@ -231,7 +231,7 @@ case class Attribute(
   @JsonIgnore
   def getFinalName(): String = rename.getOrElse(name)
 
-  def getPrivacy(): PrivacyLevel = this.privacy.getOrElse(PrivacyLevel.None)
+  def getPrivacy(): PrivacyLevel = this.privacy
 
   def isArray(): Boolean = this.array.getOrElse(false)
 

--- a/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
@@ -26,6 +26,7 @@ import com.ebiznext.comet.utils.conversion.BigQueryUtils._
 import com.ebiznext.comet.schema.handlers.SchemaHandler
 import com.ebiznext.comet.utils.TextSubstitutionEngine
 import com.google.cloud.bigquery.Field
+import net.minidev.json.annotate.JsonIgnore
 import org.apache.spark.sql.types._
 
 import scala.collection.mutable
@@ -72,6 +73,7 @@ case class Schema(
   rls: Option[List[RowLevelSecurity]] = None
 ) {
 
+  @JsonIgnore
   lazy val attributesWithoutScript: List[Attribute] = attributes.filter(_.script.isEmpty)
 
   /** @return Are the parittions columns defined in the metadata valid column names

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -179,7 +179,7 @@ class IngestionWorkflow(
       val filteredResolved = if (settings.comet.privacyOnly) {
         val (withPrivacy, noPrivacy) =
           resolved.partition(
-            _._1.exists(_.attributes.forall(_.privacy.exists(!PrivacyLevel.None.equals(_))))
+            _._1.exists(_.attributes.map(_.privacy).exists(!PrivacyLevel.None.equals(_)))
           )
         // files for schemas without any privacy attributes are moved directly to accepted area
         noPrivacy.foreach {

--- a/src/test/scala/com/ebiznext/comet/JdbcChecks.scala
+++ b/src/test/scala/com/ebiznext/comet/JdbcChecks.scala
@@ -61,7 +61,11 @@ trait JdbcChecks {
     val jdbcOptions = settings.comet.connections(jdbcName)
     val engine = settings.comet.jdbcEngines(jdbcOptions.engine)
 
-    val conn = DriverManager.getConnection(jdbcOptions.options("url"), jdbcOptions.options("user"), jdbcOptions.options("password"))
+    val conn = DriverManager.getConnection(
+      jdbcOptions.options("url"),
+      jdbcOptions.options("user"),
+      jdbcOptions.options("password")
+    )
     try {
       val lacksTheTable =
         /* lacks the table, and not https://www.ikea.com/us/en/p/lack-side-table-white-30449908/ */
@@ -81,7 +85,9 @@ trait JdbcChecks {
 
         val fetched: Vector[T] = {
           val rs =
-            stmt.executeQuery(s"select ${columns.mkString(", ")} from ${referenceDatasetName}".stripMargin)
+            stmt.executeQuery(
+              s"select ${columns.mkString(", ")} from ${referenceDatasetName}".stripMargin
+            )
 
           @tailrec
           def pull(base: Vector[T]): Vector[T] = {

--- a/src/test/scala/com/ebiznext/comet/job/connections/ConnectionJobsSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/job/connections/ConnectionJobsSpec.scala
@@ -20,7 +20,7 @@ class ConnectionJobsSpec extends TestHelper {
         ("Sam", "Hal", 20),
         ("Martin", "Odersky", 30)
       ).toDF("firstname", "lastname", "age")
-      val usersOptions = settings.comet.connections(connection).options  + ("dbtable" -> "users")
+      val usersOptions = settings.comet.connections(connection).options + ("dbtable" -> "users")
       usersDF.write.format("jdbc").options(usersOptions).mode(SaveMode.Overwrite).save()
 
       val businessTask1 = AutoTaskDesc(
@@ -41,7 +41,6 @@ class ConnectionJobsSpec extends TestHelper {
           views = Some(Map("user_View" -> s"jdbc:$connection:select * from users"))
         )
 
-
       val schemaHandler = new SchemaHandler(metadataStorageHandler)
 
       val businessJobDef = mapper
@@ -55,7 +54,7 @@ class ConnectionJobsSpec extends TestHelper {
 
       workflow.autoJob(TransformConfig("user", Map("age" -> "10")))
 
-      val userOutOptions = settings.comet.connections(connection).options  + ("dbtable" -> "userout")
+      val userOutOptions = settings.comet.connections(connection).options + ("dbtable" -> "userout")
       sparkSession.read.format("jdbc").options(userOutOptions).load.collect() should have size 1
     }
   }

--- a/src/test/scala/com/ebiznext/comet/schema/generator/SchemaGenSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/generator/SchemaGenSpec.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import com.ebiznext.comet.TestHelper
 import com.ebiznext.comet.config.DatasetArea
-import com.ebiznext.comet.schema.model.{BigQuerySink, Domain, Format, PrivacyLevel}
+import com.ebiznext.comet.schema.model.{BigQuerySink, Domain, Format}
 
 class SchemaGenSpec extends TestHelper {
   new WithSettings() {
@@ -97,7 +97,7 @@ class SchemaGenSpec extends TestHelper {
     private def validCount(domain: Domain, algo: String, count: Int) =
       domain.schemas
         .flatMap(_.attributes)
-        .filter(_.privacy.getOrElse(PrivacyLevel.None).toString == algo) should have length count
+        .filter(_.privacy.toString == algo) should have length count
 
     "SHA1 & HIDE privacy policies" should "be applied in the pre-encrypt step " in {
       domainOpt shouldBe defined

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
@@ -65,21 +65,21 @@ class StorageHandlerSpec extends TestHelper {
                 "string",
                 Some(false),
                 false,
-                Some(PrivacyLevel.None)
+                PrivacyLevel.None
               ),
               Attribute(
                 "lastname",
                 "string",
                 Some(false),
                 false,
-                Some(PrivacyLevel("SHA1"))
+                PrivacyLevel("SHA1")
               ),
               Attribute(
                 "age",
                 "age",
                 Some(false),
                 false,
-                Some(PrivacyLevel("HIDE"))
+                PrivacyLevel("HIDE")
               )
             ),
             Some(Metadata(withHeader = Some(true))),

--- a/src/test/scala/com/ebiznext/comet/schema/model/SchemaSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/model/SchemaSpec.scala
@@ -41,8 +41,8 @@ class SchemaSpec extends TestHelper {
         "invalid-type", // should raise error non existent type
         Some(true),
         true,
-        Some(
-          PrivacyLevel("MD5")
+        PrivacyLevel(
+          "MD5"
         ) // Should raise an error. Privacy cannot be applied on types other than string
       )
 
@@ -55,8 +55,8 @@ class SchemaSpec extends TestHelper {
         "long",
         Some(true),
         true,
-        Some(
-          PrivacyLevel("ApproxLong(20)")
+        PrivacyLevel(
+          "ApproxLong(20)"
         ) // Should raise an error. Privacy cannot be applied on types other than stringsettings = settings
       )
       attr.checkValidity(schemaHandler) shouldBe Right(true)
@@ -68,14 +68,14 @@ class SchemaSpec extends TestHelper {
         "long",
         Some(true),
         true,
-        Some(
-          PrivacyLevel("ApproxLong(20)")
+        PrivacyLevel(
+          "ApproxLong(20)"
         ), // Should raise an error. Privacy cannot be applied on types other than string
         attributes = Some(List[Attribute]())
       )
       val expectedErrors = List(
-        "Attribute Attribute(attr,long,Some(true),true,Some(ApproxLong(20)),None,None,None,Some(List()),None,None,None) : Simple attributes cannot have sub-attributes",
-        "Attribute Attribute(attr,long,Some(true),true,Some(ApproxLong(20)),None,None,None,Some(List()),None,None,None) : when present, attributes list cannot be empty."
+        "Attribute Attribute(attr,long,Some(true),true,ApproxLong(20),None,None,None,Some(List()),None,None,None) : Simple attributes cannot have sub-attributes",
+        "Attribute Attribute(attr,long,Some(true),true,ApproxLong(20),None,None,None,Some(List()),None,None,None) : when present, attributes list cannot be empty."
       )
 
       attr.checkValidity(schemaHandler) shouldBe Left(expectedErrors)


### PR DESCRIPTION
## Summary
Simplify the `PrivacyLevel` modeling in `Attribute`. No need to have an `Option[]` for `Attribute.privacy `since the absence of privacy level can be expressed by `PrivacyLevel.None`


**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
Replace `privacy: Option[PrivacyLevel] = None`
by `privacy: PrivacyLevel = PrivacyLevel.None`

### How has this been tested?
Existing unit tests

### Other changes
Add a `@JsonIgnore` annotation for a val in Schema to avoid having it in the output of serialization. 


## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.



