### PR TITLE
[Feature] Change default Data Format for reading from BigQuery

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTaskJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTaskJob.scala
@@ -223,6 +223,7 @@ class AutoTaskJob(
               logger
                 .info(s"We are loading the Table with columns: $select and filters: $filterFormat")
               session.read
+                .option("readDataFormat", "AVRO")
                 .format("com.google.cloud.spark.bigquery")
                 .option("table", tablePath)
                 .option("filter", filterFormat)
@@ -233,6 +234,7 @@ class AutoTaskJob(
               val filterFormat = filter.richFormat(sqlParameters)
               logger.info(s"We are loading the Table with filters: $filterFormat")
               session.read
+                .option("readDataFormat", "AVRO")
                 .format("com.google.cloud.spark.bigquery")
                 .option("table", tablePath)
                 .option("filter", filterFormat)
@@ -241,6 +243,7 @@ class AutoTaskJob(
             case TablePathWithSelect(tablePath, select) =>
               logger.info(s"We are loading the Table with columns: $select")
               session.read
+                .option("readDataFormat", "AVRO")
                 .format("com.google.cloud.spark.bigquery")
                 .option("table", tablePath)
                 .load()
@@ -248,6 +251,7 @@ class AutoTaskJob(
                 .cache()
             case _ =>
               session.read
+                .option("readDataFormat", "AVRO")
                 .format("com.google.cloud.spark.bigquery")
                 .option("table", path)
                 .load()


### PR DESCRIPTION
## Summary
Spark BigQuery Connector uses ARROW Data Format for reading from BigQuery (https://arrow.apache.org/).
Therefore, unsupported Arrow filters are not pushed down and results are filtered later by Spark. (Currently Arrow does not support disjunction across columns).
So, we should use AVRO as Data Format for reading BigQuery Tables.

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



