### PR TITLE
[FEATURE] MERGE with Partial Matching Partitions

### DIFF
--- a/.bsp/sbt.json
+++ b/.bsp/sbt.json
@@ -1,1 +1,0 @@
-{"name":"sbt","version":"1.4.4","bspVersion":"2.0.0-M5","languages":["scala"],"argv":["/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/bin/java","-Xms100m","-Xmx100m","-classpath","/usr/local/Cellar/sbt/1.1.1/libexec/bin/sbt-launch.jar","xsbt.boot.Boot","-bsp"]}

--- a/.bsp/sbt.json
+++ b/.bsp/sbt.json
@@ -1,0 +1,1 @@
+{"name":"sbt","version":"1.4.4","bspVersion":"2.0.0-M5","languages":["scala"],"argv":["/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home/jre/bin/java","-Xms100m","-Xmx100m","-classpath","/usr/local/Cellar/sbt/1.1.1/libexec/bin/sbt-launch.jar","xsbt.boot.Boot","-bsp"]}

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ src/main/resources/application.conf
 
 #Python
 venv
+
+.bsp

--- a/docs/user/cli/load.rst
+++ b/docs/user/cli/load.rst
@@ -33,3 +33,8 @@ Options
     *Required*. list of comma separated paths
 
 
+.. option:: --options: <value>
+
+    *Optional*. arguments to be used as substitutions
+
+

--- a/docs/user/cli/watch.rst
+++ b/docs/user/cli/watch.rst
@@ -28,3 +28,8 @@ Options
     *Optional*. Domains not to watch
 
 
+.. option:: --options: k1=v1,k2=v2...
+
+    *Optional*. Watch arguments to be used as substitutions
+
+

--- a/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQuerySparkJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQuerySparkJob.scala
@@ -26,10 +26,10 @@ import org.apache.spark.storage.StorageLevel
 import scala.util.Try
 
 class BigQuerySparkJob(
-                        override val cliConfig: BigQueryLoadConfig,
-                        maybeSchema: Option[BQSchema] = None
-                      )(implicit val settings: Settings)
-  extends SparkJob
+  override val cliConfig: BigQueryLoadConfig,
+  maybeSchema: Option[BQSchema] = None
+)(implicit val settings: Settings)
+    extends SparkJob
     with BigQueryJobBase {
 
   override def name: String = s"bqload-${cliConfig.outputDataset}-${cliConfig.outputTable}"
@@ -250,10 +250,10 @@ case class TableMetadata(table: Option[Table], biqueryClient: BigQuery)
 object BigQuerySparkJob {
 
   def getTable(
-                session: SparkSession,
-                datasetName: String,
-                tableName: String
-              ): TableMetadata = {
+    session: SparkSession,
+    datasetName: String,
+    tableName: String
+  ): TableMetadata = {
     val conf = session.sparkContext.hadoopConfiguration
     val projectId: String =
       Option(conf.get("fs.gs.project.id")).getOrElse(ServiceOptions.getDefaultProjectId)

--- a/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQuerySparkJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQuerySparkJob.scala
@@ -26,10 +26,10 @@ import org.apache.spark.storage.StorageLevel
 import scala.util.Try
 
 class BigQuerySparkJob(
-  override val cliConfig: BigQueryLoadConfig,
-  maybeSchema: Option[BQSchema] = None
-)(implicit val settings: Settings)
-    extends SparkJob
+                        override val cliConfig: BigQueryLoadConfig,
+                        maybeSchema: Option[BQSchema] = None
+                      )(implicit val settings: Settings)
+  extends SparkJob
     with BigQueryJobBase {
 
   override def name: String = s"bqload-${cliConfig.outputDataset}-${cliConfig.outputTable}"
@@ -205,24 +205,24 @@ class BigQuerySparkJob(
         */
 
       //      prepareRLS().foreach { rlsStatement =>
-//        logger.info(s"Applying security $rlsStatement")
-//        try {
-//          Option(runJob(rlsStatement, cliConfig.getLocation())) match {
-//            case None =>
-//              throw new RuntimeException("Job no longer exists")
-//            case Some(job) if job.getStatus.getExecutionErrors() != null =>
-//              throw new RuntimeException(
-//                job.getStatus.getExecutionErrors().asScala.reverse.mkString(",")
-//              )
-//            case Some(job) =>
-//              logger.info(s"Job with id ${job} on Statement $rlsStatement succeeded")
-//          }
-//
-//        } catch {
-//          case e: Exception =>
-//            e.printStackTrace()
-//        }
-//      }
+      //        logger.info(s"Applying security $rlsStatement")
+      //        try {
+      //          Option(runJob(rlsStatement, cliConfig.getLocation())) match {
+      //            case None =>
+      //              throw new RuntimeException("Job no longer exists")
+      //            case Some(job) if job.getStatus.getExecutionErrors() != null =>
+      //              throw new RuntimeException(
+      //                job.getStatus.getExecutionErrors().asScala.reverse.mkString(",")
+      //              )
+      //            case Some(job) =>
+      //              logger.info(s"Job with id ${job} on Statement $rlsStatement succeeded")
+      //          }
+      //
+      //        } catch {
+      //          case e: Exception =>
+      //            e.printStackTrace()
+      //        }
+      //      }
       SparkJobResult(None)
     }
   }
@@ -245,18 +245,20 @@ class BigQuerySparkJob(
 
 }
 
+case class TableMetadata(table: Option[Table], biqueryClient: BigQuery)
+
 object BigQuerySparkJob {
 
   def getTable(
-    session: SparkSession,
-    datasetName: String,
-    tableName: String
-  ): Option[Table] = {
+                session: SparkSession,
+                datasetName: String,
+                tableName: String
+              ): TableMetadata = {
     val conf = session.sparkContext.hadoopConfiguration
     val projectId: String =
       Option(conf.get("fs.gs.project.id")).getOrElse(ServiceOptions.getDefaultProjectId)
     val bigquery: BigQuery = BigQueryOptions.getDefaultInstance().getService()
     val tableId = TableId.of(projectId, datasetName, tableName)
-    Option(bigquery.getTable(tableId))
+    TableMetadata(Option(bigquery.getTable(tableId)), bigquery)
   }
 }

--- a/src/main/scala/com/ebiznext/comet/job/ingest/DsvIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/DsvIngestionJob.scala
@@ -43,6 +43,7 @@ import scala.util.{Failure, Success, Try}
   * @param types          : List of globally defined types
   * @param path           : Input dataset path
   * @param storageHandler : Storage Handler
+  * @param options : Parameters to pass as input (k1=v1,k2=v2,k3=v3)
   */
 class DsvIngestionJob(
   val domain: Domain,
@@ -50,7 +51,8 @@ class DsvIngestionJob(
   val types: List[Type],
   val path: List[Path],
   val storageHandler: StorageHandler,
-  val schemaHandler: SchemaHandler
+  val schemaHandler: SchemaHandler,
+  val options: Map[String, String]
 )(implicit val settings: Settings)
     extends IngestionJob {
 

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -199,6 +199,10 @@ trait IngestionJob extends SparkJob {
         .run()
         .get
     }
+   /*
+    * Avoid to sink to bq since it is already done above during the merge with BigQuery
+   */
+   //TODO Improve code structure
     if (metadata.getSink().map(_.`type`).getOrElse(SinkType.None) != SinkType.BQ) {
       sink(savedDataset)
     }

--- a/src/main/scala/com/ebiznext/comet/job/ingest/JsonIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/JsonIngestionJob.scala
@@ -46,7 +46,8 @@ class JsonIngestionJob(
   val types: List[Type],
   val path: List[Path],
   val storageHandler: StorageHandler,
-  val schemaHandler: SchemaHandler
+  val schemaHandler: SchemaHandler,
+  val options: Map[String, String]
 )(implicit val settings: Settings)
     extends IngestionJob {
 

--- a/src/main/scala/com/ebiznext/comet/job/ingest/LoadConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/LoadConfig.scala
@@ -31,7 +31,8 @@ import scopt.OParser
 case class LoadConfig(
   domain: String = "",
   schema: String = "",
-  paths: List[Path] = Nil
+  paths: List[Path] = Nil,
+  options: Map[String, String] = Map.empty
 )
 
 object LoadConfig extends CliConfig[LoadConfig] {
@@ -54,7 +55,11 @@ object LoadConfig extends CliConfig[LoadConfig] {
       arg[String]("paths")
         .required()
         .action((x, c) => c.copy(paths = x.split(',').map(new Path(_)).toList))
-        .text("list of comma separated paths")
+        .text("list of comma separated paths"),
+      arg[Map[String, String]]("options")
+        .optional()
+        .action((x, c) => c.copy(options = x))
+        .text("arguments to be used as substitutions")
     )
   }
 

--- a/src/main/scala/com/ebiznext/comet/job/ingest/PositionIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/PositionIngestionJob.scala
@@ -46,9 +46,10 @@ class PositionIngestionJob(
   types: List[Type],
   path: List[Path],
   storageHandler: StorageHandler,
-  schemaHandler: SchemaHandler
+  schemaHandler: SchemaHandler,
+  options: Map[String, String]
 )(implicit settings: Settings)
-    extends DsvIngestionJob(domain, schema, types, path, storageHandler, schemaHandler) {
+    extends DsvIngestionJob(domain, schema, types, path, storageHandler, schemaHandler, options) {
 
   /** Load dataset using spark csv reader and all metadata. Does not infer schema.
     * columns not defined in the schema are dropped fro the dataset (require datsets with a header)

--- a/src/main/scala/com/ebiznext/comet/job/ingest/SimpleJsonIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/SimpleJsonIngestionJob.scala
@@ -45,9 +45,10 @@ class SimpleJsonIngestionJob(
   types: List[Type],
   path: List[Path],
   storageHandler: StorageHandler,
-  schemaHandler: SchemaHandler
+  schemaHandler: SchemaHandler,
+  options: Map[String, String]
 )(implicit settings: Settings)
-    extends DsvIngestionJob(domain, schema, types, path, storageHandler, schemaHandler) {
+    extends DsvIngestionJob(domain, schema, types, path, storageHandler, schemaHandler, options) {
 
   override def loadDataSet(): Try[DataFrame] = {
     try {

--- a/src/main/scala/com/ebiznext/comet/job/ingest/XmlIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/XmlIngestionJob.scala
@@ -46,7 +46,8 @@ class XmlIngestionJob(
   val types: List[Type],
   val path: List[Path],
   val storageHandler: StorageHandler,
-  val schemaHandler: SchemaHandler
+  val schemaHandler: SchemaHandler,
+  val options: Map[String, String]
 )(implicit val settings: Settings)
     extends IngestionJob {
 

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/LaunchHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/LaunchHandler.scala
@@ -48,10 +48,16 @@ trait LaunchHandler {
     * @param path   : absolute path where the source dataset  (JSON / CSV / ...) is located
     * @return success / failure
     */
-  def ingest(workflow: IngestionWorkflow, domain: Domain, schema: Schema, path: Path)(implicit
+  def ingest(
+    workflow: IngestionWorkflow,
+    domain: Domain,
+    schema: Schema,
+    path: Path,
+    options: Map[String, String]
+  )(implicit
     settings: Settings
   ): Boolean =
-    ingest(workflow, domain, schema, path :: Nil)
+    ingest(workflow, domain, schema, path :: Nil, options)
 
   /** Submit to the cron manager multiple files for ingestion.
     * All the files should have the schema schema and belong to the same domain.
@@ -65,7 +71,8 @@ trait LaunchHandler {
     workflow: IngestionWorkflow,
     domain: Domain,
     schema: Schema,
-    paths: List[Path]
+    paths: List[Path],
+    options: Map[String, String]
   )(implicit settings: Settings): Boolean
 
   /** Index into elasticsearch
@@ -109,10 +116,11 @@ class SimpleLauncher extends LaunchHandler with StrictLogging {
     workflow: IngestionWorkflow,
     domain: Domain,
     schema: Schema,
-    paths: List[Path]
+    paths: List[Path],
+    options: Map[String, String]
   )(implicit settings: Settings): Boolean = {
     logger.info(s"Launch Ingestion: ${domain.name} ${schema.name} $paths ")
-    workflow.ingest(LoadConfig(domain.name, schema.name, paths))
+    workflow.ingest(LoadConfig(domain.name, schema.name, paths, options))
   }
 
   /** Index into elasticsearch
@@ -198,7 +206,8 @@ class AirflowLauncher extends LaunchHandler with StrictLogging {
     workflow: IngestionWorkflow,
     domain: Domain,
     schema: Schema,
-    paths: List[Path]
+    paths: List[Path],
+    options: Map[String, String]
   )(implicit settings: Settings): Boolean = {
     val endpoint = settings.comet.airflow.endpoint
     val ingest = settings.comet.airflow.ingest

--- a/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
@@ -40,7 +40,8 @@ import scala.collection.mutable
 case class MergeOptions(
   key: List[String],
   delete: Option[String] = None,
-  timestamp: Option[String] = None
+  timestamp: Option[String] = None,
+  queryFilter: Option[String] = None
 )
 
 /** Dataset Schema

--- a/src/main/scala/com/ebiznext/comet/workflow/WatchConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/WatchConfig.scala
@@ -3,7 +3,11 @@ package com.ebiznext.comet.workflow
 import com.ebiznext.comet.utils.CliConfig
 import scopt.OParser
 
-case class WatchConfig(includes: Seq[String] = Seq.empty, excludes: Seq[String] = Seq.empty)
+case class WatchConfig(
+  includes: Seq[String] = Seq.empty,
+  excludes: Seq[String] = Seq.empty,
+  options: Map[String, String] = Map.empty
+)
 
 object WatchConfig extends CliConfig[WatchConfig] {
 
@@ -23,7 +27,12 @@ object WatchConfig extends CliConfig[WatchConfig] {
         .valueName("domain1,domain2...")
         .optional()
         .action((x, c) => c.copy(excludes = x))
-        .text("Domains not to watch")
+        .text("Domains not to watch"),
+      opt[Map[String, String]]("options")
+        .valueName("k1=v1,k2=v2...")
+        .optional()
+        .action((x, c) => c.copy(options = x))
+        .text("Watch arguments to be used as substitutions")
     )
   }
 

--- a/src/test/scala/com/ebiznext/comet/job/ingest/IngestJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/job/ingest/IngestJobSpec.scala
@@ -8,13 +8,13 @@ class IngestJobSpec extends TestHelper {
       val rendered = LoadConfig.usage()
       val expected =
         """
-          |Usage: comet load | ingest domain schema paths
+          |Usage: comet load | ingest domain schema paths [options]
           |
           |  domain  Domain name
           |  schema  Schema name
           |  paths   list of comma separated paths
+          |  options arguments to be used as substitutions
           |""".stripMargin
-      println(rendered)
       rendered.substring(rendered.indexOf("Usage:")).replaceAll("\\s", "") shouldEqual expected
         .replaceAll("\\s", "")
     }


### PR DESCRIPTION
## Summary

Add the possibility to merge a part of a BigQuery Table, rather than all the Table.
We should, add a filter in MERGE metadata options, in order to apply the MERGE, only on a part of the table.

For example, if we want, to merge, from the last partition in the Table, we should only read the last parititon,
and apply the MERGE statement.

**Related Issue: #388**

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? Maybe**


## Description
### Solution
To apply the merge only on a part of a table:

**In case of a REINIT of a specific partition in the Table (partition of January for example) , we want to read only the specific partition (January) from the Table, and apply the merge, we have to add a query filter in the yaml schema like this:**

```
merge:
    key:
    - "email"
    queryFilter: "processing_date = PARSE_DATE('%d-%m-%Y',{{merge_date}})"
```
And passe the merge_date as an environment variable.

**In case of a Snapshot Table, we only want to read the last partition, and apply the merge, so we have to add a query filter in the yaml schema like this:**

```
  merge:
    key:
    - "email"
    queryFilter: "processing_date = latest"
```

### Other changes
Describe any other additional work done:
I added the possibility to add environment variables in the **watch** process.
I also fix, the BigQuery sink, instead of reading parquets files and sink to BigQuery,
we will read The Dataframe generated after the merge action, and then, sink this Dataframe to BigQuery.
We keep, of course, the process, of generating parquet files at the end of the merge.

### Deploy Notes

Import some files to Ingesting folder with : 

```
gcloud dataproc jobs submit spark \
  --region europe-west1 \
  --cluster=cluster-b653  \
  --jars=gs://comet_artifacts_amines/comet-spark3_2.12-0.1.22-SNAPSHOT-assembly.jar \
  --properties=^#^spark.hadoop.fs.defaultFS=gs://datastore-amines#spark.sql.sources.partitionOverwriteMode=DYNAMIC#spark.jars.packages=com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:0.17.3#spark.driver.extraJavaOptions="-DCOMET_FS=gs://datastore-amines -DCOMET_METRICS_ACTIVE=true -DCOMET_METRICS_INDEX_TYPE=BigQuery" \
  --bucket=datastore-amines \
  --class=com.ebiznext.comet.job.Main \
  -- import
```

Start ingestion with : 

```
gcloud dataproc jobs submit spark \
  --region europe-west1 \
  --cluster=cluster-b653  \
  --jars=gs://comet_artifacts_amines/comet-spark3_2.12-0.1.22-SNAPSHOT-assembly.jar \
  --properties=^#^spark.hadoop.fs.defaultFS=gs://datastore-amines#spark.sql.sources.partitionOverwriteMode=DYNAMIC#spark.jars.packages=com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:0.17.3#spark.driver.extraJavaOptions="-DCOMET_FS=gs://datastore-amines -DCOMET_METRICS_ACTIVE=true -DCOMET_METRICS_INDEX_TYPE=BigQuery" \
  --bucket=datastore-amines \
  --class=com.ebiznext.comet.job.Main \
  -- watch --options date_event="'03-12-2020'",merge_date="'02-12-2020'"
```

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



