### PR TITLE
[Feature] Use Parquet as a Default Format for BigQuery intermediate format

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -410,7 +410,7 @@ internal {
   cache-storage-level = "MEMORY_AND_DISK"
   cache-storage-level = ${?COMET_INTERNAL_CACHE_STORAGE_LEVEL}
   # Parquet is the default format : https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-parquet
-  # other values incllude orc & avro. When using avro, spark-avro dependency should be included at runtime.
+  # other values include orc & avro. When using avro, spark-avro dependency should be included at runtime.
   # If you want to use orc or avro format, you should be aware of this
   # For orc format (All fields in the detected schema are NULLABLE) : https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-orc
   # For avro format : https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -409,8 +409,12 @@ internal {
   # See https://spark.apache.org/docs/latest/api/java/index.html?org/apache/spark/storage/StorageLevel.html
   cache-storage-level = "MEMORY_AND_DISK"
   cache-storage-level = ${?COMET_INTERNAL_CACHE_STORAGE_LEVEL}
-  # other values incllude parquet & avro. When using avro, spark-avro dependency should be included
-  intermediate-bigquery-format = "orc"
+  # Parquet is the default format : https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-parquet
+  # other values incllude orc & avro. When using avro, spark-avro dependency should be included at runtime.
+  # If you want to use orc or avro format, you should be aware of this
+  # For orc format (All fields in the detected schema are NULLABLE) : https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-orc
+  # For avro format : https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro
+  intermediate-bigquery-format = "parquet"
 }
 
 http {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -415,6 +415,7 @@ internal {
   # For orc format (All fields in the detected schema are NULLABLE) : https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-orc
   # For avro format : https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro
   intermediate-bigquery-format = "parquet"
+  intermediate-bigquery-format = ${?COMET_INTERMEDIATE_BQ_FORMAT}
 }
 
 http {


### PR DESCRIPTION
## Summary
We will use parquet as a default format for BigQuery intermediate format.
Other values include orc & avro.
In order to use the Avro format, the spark-avro package must be added at runtime.
If you want to use orc or avro format, you should be aware of this:

- For orc format (All fields in the detected schema are NULLABLE) : https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-orc

- For avro format : https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



