### PR TITLE
[FEATURE] - Ingest a subset of schemas from a Domain

### DIFF
--- a/docs/user/cli/watch.rst
+++ b/docs/user/cli/watch.rst
@@ -28,6 +28,11 @@ Options
     *Optional*. Domains not to watch
 
 
+.. option:: --schema: schema1
+
+    *Optional*. Schema to watch
+
+
 .. option:: --options: k1=v1,k2=v2...
 
     *Optional*. Watch arguments to be used as substitutions

--- a/docs/user/cli/watch.rst
+++ b/docs/user/cli/watch.rst
@@ -28,9 +28,9 @@ Options
     *Optional*. Domains not to watch
 
 
-.. option:: --schema: schema1
+.. option:: --schemas: schema1,schema2,schema3...
 
-    *Optional*. Schema to watch
+    *Optional*. Schemas to watch
 
 
 .. option:: --options: k1=v1,k2=v2...

--- a/src/main/java/com/ebiznext/comet/utils/repackaged/BigQuerySchemaConverters.java
+++ b/src/main/java/com/ebiznext/comet/utils/repackaged/BigQuerySchemaConverters.java
@@ -261,7 +261,9 @@ public class BigQuerySchemaConverters {
     protected static Field createBigQueryColumn(StructField sparkField, int depth) {
         DataType sparkType = sparkField.dataType();
         String fieldName = sparkField.name();
+        System.out.println("field name +++++ " + fieldName);
         Field.Mode fieldMode = (sparkField.nullable()) ? Field.Mode.NULLABLE : Field.Mode.REQUIRED;
+        System.out.println("field mode ++++++ " + fieldMode.name());
         String description;
         FieldList subFields = null;
         LegacySQLTypeName fieldType;

--- a/src/main/java/com/ebiznext/comet/utils/repackaged/BigQuerySchemaConverters.java
+++ b/src/main/java/com/ebiznext/comet/utils/repackaged/BigQuerySchemaConverters.java
@@ -261,9 +261,7 @@ public class BigQuerySchemaConverters {
     protected static Field createBigQueryColumn(StructField sparkField, int depth) {
         DataType sparkType = sparkField.dataType();
         String fieldName = sparkField.name();
-        System.out.println("field name +++++ " + fieldName);
         Field.Mode fieldMode = (sparkField.nullable()) ? Field.Mode.NULLABLE : Field.Mode.REQUIRED;
-        System.out.println("field mode ++++++ " + fieldMode.name());
         String description;
         FieldList subFields = null;
         LegacySQLTypeName fieldType;

--- a/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQuerySparkJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQuerySparkJob.scala
@@ -159,7 +159,8 @@ class BigQuerySparkJob(
         s"BigQuery Saving to  ${table.getTableId} containing ${stdTableDefinition.getNumRows} rows"
       )
 
-      val intermediateFormat = settings.comet.internal.map(_.intermediateBigqueryFormat).getOrElse("orc")
+      val intermediateFormat =
+        settings.comet.internal.map(_.intermediateBigqueryFormat).getOrElse("orc")
       (cliConfig.writeDisposition, cliConfig.outputPartition) match {
         case ("WRITE_TRUNCATE", Some(partition)) =>
           logger.info(s"overwriting partition ${partition} in The BQ Table $bqTable")
@@ -182,7 +183,7 @@ class BigQuerySparkJob(
               .format("com.google.cloud.spark.bigquery")
               .option("datePartition", partitionStr)
               .option("table", bqTable)
-              .option("intermediateFormat", intermediateFormat)
+              .option("intermediateFormat", "orc")
               .save()
           )
         case _ =>
@@ -191,7 +192,7 @@ class BigQuerySparkJob(
             .mode(SaveMode.Append)
             .format("com.google.cloud.spark.bigquery")
             .option("table", bqTable)
-            .option("intermediateFormat", intermediateFormat)
+            .option("intermediateFormat", "orc")
             .save()
       }
 

--- a/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQuerySparkJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQuerySparkJob.scala
@@ -183,7 +183,7 @@ class BigQuerySparkJob(
               .format("com.google.cloud.spark.bigquery")
               .option("datePartition", partitionStr)
               .option("table", bqTable)
-              .option("intermediateFormat", "orc")
+              .option("intermediateFormat", intermediateFormat)
               .save()
           )
         case _ =>
@@ -192,7 +192,7 @@ class BigQuerySparkJob(
             .mode(SaveMode.Append)
             .format("com.google.cloud.spark.bigquery")
             .option("table", bqTable)
-            .option("intermediateFormat", "orc")
+            .option("intermediateFormat", intermediateFormat)
             .save()
       }
 

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -168,7 +168,7 @@ class IngestionWorkflow(
 
     val result = includedDomains.flatMap { domain =>
       logger.info(s"Watch Domain: ${domain.name}")
-      val (resolved, unresolved) = pending(domain.name, config.schema)
+      val (resolved, unresolved) = pending(domain.name, config.schemas.toList)
       unresolved.foreach { case (_, path) =>
         val targetPath =
           new Path(DatasetArea.unresolved(domain.name), path.getName)
@@ -236,7 +236,7 @@ class IngestionWorkflow(
     */
   private def pending(
     domainName: String,
-    schemaName: Option[String]
+    schemasName: List[String]
   ): (Iterable[(Option[Schema], Path)], Iterable[(Option[Schema], Path)]) = {
     val pendingArea = DatasetArea.pending(domainName)
     logger.info(s"List files in $pendingArea")
@@ -244,45 +244,33 @@ class IngestionWorkflow(
     logger.info(s"Found ${files.mkString(",")}")
     val domain = schemaHandler.getDomain(domainName)
 
-    schemaName match {
-      case Some(name) =>
-        logger.info(
-          s"We will only check files that match the schema name: $name for the Domain: $domainName"
-        )
-        val schemas = for {
-          dom <- domain.toList
-          schema <- files.filter(x => predicate(dom, name, x)).map { file =>
-            (dom.findSchema(file.getName), file)
-          }
-        } yield {
-          logger.info(
-            s"Found Schema ${schema._1.map(_.name).getOrElse("None")} for file ${schema._2}"
-          )
-          schema
-        }
-        schemas.partition(_._1.isDefined)
-      case _ =>
-        logger.info(s"We will check all the files for the Domain: $domainName")
-        val schemas = for {
-          dom <- domain.toList
-          schema <- files.map { file =>
-            (dom.findSchema(file.getName), file)
-
-          }
-        } yield {
-          logger.info(
-            s"Found Schema ${schema._1.map(_.name).getOrElse("None")} for file ${schema._2}"
-          )
-          schema
-        }
-        schemas.partition(_._1.isDefined)
+    val schemas = for {
+      dom <- domain.toList
+      schema <- files.filter(f => predicate(dom, schemasName, f)).map { file =>
+        (dom.findSchema(file.getName), file)
+      }
+    } yield {
+      logger.info(
+        s"Found Schema ${schema._1.map(_.name).getOrElse("None")} for file ${schema._2}"
+      )
+      schema
     }
-
+    schemas.partition(_._1.isDefined)
   }
 
-  private[this] def predicate(domain: Domain, schemaName: String, file: Path): Boolean = {
-    val schema = domain.schemas.find(_.name.equals(schemaName))
-    schema.exists(_.pattern.matcher(file.getName).matches())
+  private[this] def predicate(domain: Domain, schemasName: List[String], file: Path): Boolean = {
+    schemasName.exists { schemaName =>
+      val schema = domain.schemas.find(_.name.equals(schemaName))
+      val exist = schema.exists(_.pattern.matcher(file.getName).matches())
+      if (exist) {
+        logger.info(
+          s"We will only watch files that match the schemas name: $schemasName for the Domain: ${domain.name}"
+        )
+      } else {
+        logger.info(s"We will watch all the files for the Domain: ${domain.name}")
+      }
+      exist
+    }
   }
 
   /** Ingest the file (called by the cron manager at ingestion time for a specific dataset

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -242,12 +242,12 @@ class IngestionWorkflow(
     logger.info(s"List files in $pendingArea")
     val files = storageHandler.list(pendingArea)
     logger.info(s"Found ${files.mkString(",")}")
-    val domain = schemaHandler.getDomain(domainName)
+    val domain = schemaHandler.getDomain(domainName).toList
 
     val schemas = for {
-      dom <- domain.toList
-      schema <- files.filter(f => predicate(dom, schemasName, f)).map { file =>
-        (dom.findSchema(file.getName), file)
+      domain <- domain
+      schema <- files.filter(f => predicate(domain, schemasName, f)).map { file =>
+        (domain.findSchema(file.getName), file)
       }
     } yield {
       logger.info(

--- a/src/main/scala/com/ebiznext/comet/workflow/WatchConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/WatchConfig.scala
@@ -6,6 +6,7 @@ import scopt.OParser
 case class WatchConfig(
   includes: Seq[String] = Seq.empty,
   excludes: Seq[String] = Seq.empty,
+  schema: Option[String] = None,
   options: Map[String, String] = Map.empty
 )
 
@@ -28,6 +29,11 @@ object WatchConfig extends CliConfig[WatchConfig] {
         .optional()
         .action((x, c) => c.copy(excludes = x))
         .text("Domains not to watch"),
+      opt[String]("schema")
+        .valueName("schema1")
+        .optional()
+        .action((x, c) => c.copy(schema = Some(x)))
+        .text("Schema to watch"),
       opt[Map[String, String]]("options")
         .valueName("k1=v1,k2=v2...")
         .optional()

--- a/src/main/scala/com/ebiznext/comet/workflow/WatchConfig.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/WatchConfig.scala
@@ -6,7 +6,7 @@ import scopt.OParser
 case class WatchConfig(
   includes: Seq[String] = Seq.empty,
   excludes: Seq[String] = Seq.empty,
-  schema: Option[String] = None,
+  schemas: Seq[String] = Seq.empty,
   options: Map[String, String] = Map.empty
 )
 
@@ -29,11 +29,11 @@ object WatchConfig extends CliConfig[WatchConfig] {
         .optional()
         .action((x, c) => c.copy(excludes = x))
         .text("Domains not to watch"),
-      opt[String]("schema")
-        .valueName("schema1")
+      opt[Seq[String]]("schemas")
+        .valueName("schema1,schema2,schema3...")
         .optional()
-        .action((x, c) => c.copy(schema = Some(x)))
-        .text("Schema to watch"),
+        .action((x, c) => c.copy(schemas = x))
+        .text("Schemas to watch"),
       opt[Map[String, String]]("options")
         .valueName("k1=v1,k2=v2...")
         .optional()


### PR DESCRIPTION
## Summary
The purpose of this feature is to ingest a subset of schemas from a Domain.
If we have for example, a domain : DOM1 with schemas : schemas1,schemas2,schemas3
and we want to ingest, only files that belong to : schemas2,schemas3
we could pass an [-options] = schemas2,schemas3 to the watch process.

**Related Issue: #389**

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**
Import the files from incoming Area to pending Area with : 

```
gcloud dataproc jobs submit spark \
  --region europe-west1 \
  --cluster=cluster-0fcf  \
  --jars=gs://comet_artifacts_amines/comet-spark3_2.12-0.1.22-SNAPSHOT-assembly.jar \
  --properties=^#^spark.hadoop.fs.defaultFS=gs://datastore-amines#spark.sql.sources.partitionOverwriteMode=DYNAMIC#spark.jars.packages=com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:0.17.3#spark.driver.extraJavaOptions="-DCOMET_FS=gs://datastore-amines -DCOMET_METRICS_ACTIVE=true -DCOMET_METRICS_INDEX_TYPE=BigQuery" \
  --bucket=datastore-amines \
  --class=com.ebiznext.comet.job.Main \
  -- import
```

Ingest only files that belong to the schemas : person,identity 

```
gcloud dataproc jobs submit spark \
  --region europe-west1 \
  --cluster=cluster-0fcf  \
  --jars=gs://comet_artifacts_amines/comet-spark3_2.12-0.1.22-SNAPSHOT-assembly.jar \
  --properties=^#^spark.hadoop.fs.defaultFS=gs://datastore-amines#spark.sql.sources.partitionOverwriteMode=DYNAMIC#spark.jars.packages=com.google.cloud.spark:spark-bigquery-with-dependencies_2.12:0.17.3#spark.driver.extraJavaOptions="-DCOMET_FS=gs://datastore-amines -DCOMET_METRICS_ACTIVE=true -DCOMET_METRICS_INDEX_TYPE=BigQuery" \
  --bucket=datastore-amines \
  --class=com.ebiznext.comet.job.Main \
  -- watch --include amine_forbidden_to_view_touch --schemas person,identity --options date_event="'03-12-2020'"
```

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



