### PR TITLE
Add Comet Data Pipeline Json Schema

### DIFF
--- a/src/main/resources/schema/comet.json
+++ b/src/main/resources/schema/comet.json
@@ -1,0 +1,430 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Comet Data Pipeline",
+  "description": "JSOn Schema for Comet Data Pipeline",
+  "definitions": {
+    "WriteMode": {
+      "type": "string",
+      "oneOf": [
+        {
+          "const": "OVERWRITE",
+          "description": ""
+        },
+        {
+          "const": "APPEND",
+          "description": ""
+        },
+        {
+          "const": "ERROR_IF_EXISTS",
+          "description": ""
+        },
+        {
+          "const": "IGNORE",
+          "description": ""
+        }
+      ]
+    },
+    "UserType": {
+      "type": "string",
+      "oneOf": [
+        {
+          "const": "SA",
+          "description": ""
+        },
+        {
+          "const": "USER",
+          "description": ""
+        },
+        {
+          "const": "GROUP",
+          "description": ""
+        }
+      ]
+    },
+    "Trim": {
+      "type": "string",
+      "oneOf": [
+        {
+          "const": "LEFT",
+          "description": ""
+        },
+        {
+          "const": "RIGHT",
+          "description": ""
+        },
+        {
+          "const": "BOTH",
+          "description": ""
+        },
+        {
+          "const": "NONE",
+          "description": ""
+        }
+      ]
+    },
+    "Sink": {
+      "type": "string",
+      "oneOf": [
+        {
+          "const": "NONE",
+          "description": ""
+        },
+        {
+          "const": "JBDC",
+          "description": ""
+        },
+        {
+          "const": "BQ",
+          "description": ""
+        },
+        {
+          "const": "ES",
+          "description": ""
+        },
+        {
+          "const": "FS",
+          "description": ""
+        }
+      ]
+    },
+    "Mode": {
+      "type": "string",
+      "oneOf": [
+        {
+          "const": "FILE",
+          "description": ""
+        },
+        {
+          "const": "STREAM",
+          "description": ""
+        },
+        {
+          "const": "FILE_AND_STREAM",
+          "description": ""
+        }
+      ]
+    },
+    "Partition": {
+      "type": "object",
+      "properties": {
+        "sampling": {
+          "type": "number"
+        },
+        "attributes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": []
+    },
+    "Position": {
+      "type": "object",
+      "properties": {
+        "first": {
+          "type": "number"
+        },
+        "last": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "first",
+        "last"
+      ]
+    },
+    "RowLevelSecurity": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "predicate": {
+          "type": "string"
+        },
+        "grants": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "MergeOptions": {
+      "type": "object",
+      "properties": {
+        "key": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "delete": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string"
+        },
+        "queryFilter": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "first",
+        "last"
+      ]
+    },
+    "Format": {
+      "type": "string",
+      "oneOf": [
+        {
+          "const": "DSV",
+          "description": ""
+        },
+        {
+          "const": "POSITION",
+          "description": ""
+        },
+        {
+          "const": "JSON",
+          "description": ""
+        },
+        {
+          "const": "ARRAY_JSON",
+          "description": ""
+        },
+        {
+          "const": "SIMPLE_JSON",
+          "description": ""
+        },
+        {
+          "const": "XML",
+          "description": ""
+        }
+      ]
+    },
+    "MapString": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "Metadata": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "$ref": "#/definitions/Mode"
+        },
+        "format": {
+          "$ref": "#/definitions/Format"
+        },
+        "encoding": {
+          "type": "string"
+        },
+        "multiline": {
+          "type": "boolean"
+        },
+        "array": {
+          "type": "boolean"
+        },
+        "withHeader": {
+          "type": "boolean"
+        },
+        "separator": {
+          "type": "string"
+        },
+        "quote": {
+          "type": "string"
+        },
+        "escape": {
+          "type": "string"
+        },
+        "write": {
+          "$ref": "#/definitions/WriteMode"
+        },
+        "partition": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Partition"
+          },
+        },
+        "sink": {
+          "$ref": "#/definitions/Sink"
+        },
+        "ignore": {
+          "type": "string"
+        },
+        "clustering": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "$ref": "#/definitions/MapString"
+        }
+      }
+    },
+    "Schema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "attributes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "metadata": {
+          "$ref": "#/definitions/Metadata"
+        },
+        "merge": {
+          "$ref": "#/definitions/MergeOptions"
+        },
+        "comment": {
+          "type": "string"
+        },
+        "presql": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "postsql": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/RowLevelSecurity"
+          }
+        }
+      }
+    },
+    "Attribute": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Attribute name as defined in the source dataset and as received in the file"
+        },
+        "type": {
+          "type": "string",
+          "description": "Is it an array ?"
+        },
+        "array": {
+          "type": "boolean",
+          "description": "semantic type of the attribute"
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Should this attribute always be present in the source"
+        },
+        "privacy": {
+          "type": "string",
+          "description": "Should this attribute be applied a privacy transformation at ingestion time"
+        },
+        "comment": {
+          "type": "string",
+          "description": "free text for attribute description"
+        },
+        "rename": {
+          "type": "string",
+          "description": "If present, the attribute is renamed with this name"
+        },
+        "metricType": {
+          "type": "string",
+          "description": "If present, what kind of stat should be computed for this field"
+        },
+        "attributes": {
+          "type": "array",
+          "description": "List of sub-attributes (valid for JSON and XML files only)",
+          "items": {
+            "$ref": "#/definitions/Attribute"
+          }
+        },
+        "position": {
+          "$ref": "#/definitions/Position"
+        },
+        "default": {
+          "type": "string",
+          "description": "Default value for this attribute when it is not present."
+        },
+        "tags": {
+          "type": "array",
+          "description": "Tags associated with this attribute",
+          "items": {
+            "type": "string"
+          }
+        },
+        "trim": {
+          "$ref": "#/definitions/Trim"
+        },
+        "script": {
+          "type": "string",
+          "description": "Scripted field : SQL request on renamed column"
+        }
+      },
+      "required": [
+        "name",
+        "type"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Domain name. Make sure you use a name that may be used as a folder name on the target storage.\n                   - When using HDFS or Cloud Storage,  files once ingested are stored in a sub-directory named after the domain name.\n                   - When used with BigQuery, files are ingested and sorted in tables under a dataset named after the domain name."
+    },
+    "directory": {
+      "description": "Folder on the local filesystem where incoming files are stored.\n                     Typically, this folder will be scanned periodically to move the dataset to the cluster for ingestion.\n                     Files located in this folder are moved to the pending folder for ingestion by the \"import\" command.",
+      "type": "string"
+    },
+    "metadata": {
+      "$ref": "#/definitions/Metadata"
+    },
+    "schemas": {
+      "type": "array",
+      "description": "List of schemas for each dataset in this domain.\nA domain ususally contains multiple schemas. Each schema defining how the contents of the input file should be parsed.\nSee Schema for more details.",
+      "items": {
+        "$ref": "#/definitions/Schema"
+      }
+    },
+    "comment": {
+      "description": "Domain Description (free text)",
+      "type": "string"
+    },
+    "extensions": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "recognized filename extensions. json, csv, dsv, psv are recognized by default.\nOnly files with these extensions will be moved to the pending folder."
+    },
+    "ack": {
+      "description": "Ack extension used for each file. \".ack\" if not specified.\nFiles are moved to the pending folder only once a file with the same name as the source file and with this extension is present.\nTo move a file without requiring an ack file to be present, set explicitly this property to the empty string value \"\".",
+      "type": "string"
+    }
+  },
+  "required": [
+    "name",
+    "directory",
+    "schemas"
+  ]
+}


### PR DESCRIPTION
## Summary
This allows to use VS Code and Intellij YAML Validation out of the bow once this PR is accepted on Schema Store https://github.com/SchemaStore/schemastore/pull/1389

This requires to rename all YAML files with the suffix .comet.yaml or .comet.yml
**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**


### How has this been tested?
Tested on SchemaStore
