### PR TITLE
Optonal sink to file

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## 0.1.26
+__New feature__:
+- Optionally sink to file using property sink-to-file = ${?COMET_SINK_TO_FILE}
+
+__Bugfix__:
+- Sink name was ignored and always considered as None
 ## 0.1.23
 
 __New feature__:

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -23,7 +23,7 @@ env = ${?COMET_ENV}
 sink-to-file = true
 sink-to-file = ${?COMET_SINK_TO_FILE}
 
-  assertions {
+assertions {
   active = false
   active = ${?COMET_ASSERTIONS_ACTIVE}
   path = ${root}"/assertions/{domain}"
@@ -140,7 +140,7 @@ metrics {
   sink {
     type = "NoneSink" # can be BigQuerySink or JdbcSink or NoneSink or EsSink
     type = ${?COMET_METRICS_SINK_TYPE}
-    name = "metrics" // serves as dataset name for BigQuery or Elasticsearch index name
+    name = "metrics" # serves as dataset name for BigQuery or Elasticsearch index name
 
     ## BigQuery options
     # location = "EU"

--- a/src/main/scala/com/ebiznext/comet/job/ingest/AuditLog.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/AuditLog.scala
@@ -125,7 +125,7 @@ object SparkAuditLogWriter {
       .toDF(auditCols.map(_._1): _*)
 
     settings.comet.audit.sink match {
-      case JdbcSink(connectionName, partitions, batchSize) =>
+      case JdbcSink(_, connectionName, partitions, batchSize) =>
         val jdbcConfig = ConnectionLoadConfig.fromComet(
           connectionName,
           settings.comet,
@@ -151,9 +151,9 @@ object SparkAuditLogWriter {
         )
         new BigQuerySparkJob(bqConfig, Some(bigqueryAuditSchema())).run()
 
-      case EsSink(id, timestamp) =>
+      case _: EsSink =>
         ???
-      case NoneSink() =>
+      case _: NoneSink =>
       // this is a NOP
     }
   }

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -644,7 +644,7 @@ trait IngestionJob extends SparkJob {
         ) {
           val bqTable = s"${domain.name}.${schema.name}"
           (mergeOptions.queryFilter, metadata.sink) match {
-            case (Some(query), Some(BigQuerySink(_, Some(_), _, _, _))) =>
+            case (Some(query), Some(BigQuerySink(_, _, Some(_), _, _, _))) =>
               val queryArgs = query.richFormat(options)
               if (queryArgs.contains("latest")) {
                 val partitions =
@@ -765,7 +765,7 @@ object IngestionUtil {
           )
           new BigQuerySparkJob(bqConfig, Some(bigqueryRejectedSchema())).run()
 
-        case JdbcSink(jdbcName, partitions, batchSize) =>
+        case JdbcSink(_, jdbcName, partitions, batchSize) =>
           val jdbcConfig = ConnectionLoadConfig.fromComet(
             jdbcName,
             settings.comet,
@@ -777,9 +777,9 @@ object IngestionUtil {
 
           new ConnectionLoadJob(jdbcConfig).run()
 
-        case EsSink(_, _) =>
+        case _: EsSink =>
           ???
-        case NoneSink() =>
+        case _: NoneSink =>
           Success(())
       }
     res match {

--- a/src/main/scala/com/ebiznext/comet/job/metrics/AssertionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/metrics/AssertionJob.scala
@@ -116,7 +116,7 @@ class AssertionJob(
         .withColumn("cometStage", lit(Stage.UNIT.value))
 
       val assertionsResult =
-        if (engine == Engine.SPARK) {
+        if (engine == Engine.SPARK && settings.comet.sinkToFile) {
           val savePath: Path = DatasetArea.assertions(domainName, schemaName)
           val lockedPath = lockPath(settings.comet.assertions.path)
           val waitTimeMillis = settings.comet.lock.metricsTimeout

--- a/src/main/scala/com/ebiznext/comet/schema/model/Sink.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Sink.scala
@@ -90,7 +90,9 @@ class SinkTypeDeserializer extends JsonDeserializer[SinkType] {
     new JsonSubTypes.Type(value = classOf[JdbcSink], name = "JDBC")
   )
 )
-sealed abstract class Sink(val `type`: SinkType, val name: Option[String] = None)
+sealed abstract class Sink(val `type`: SinkType) {
+  def name: Option[String]
+}
 
 /** When the sink *type* field is set to BQ, the options below should be provided.
   * @param location : Database location (EU, US, ...)
@@ -101,6 +103,7 @@ sealed abstract class Sink(val `type`: SinkType, val name: Option[String] = None
   */
 @JsonTypeName("BQ")
 final case class BigQuerySink(
+  override val name: Option[String] = None,
   location: Option[String] = None,
   timestamp: Option[String] = None,
   clustering: Option[Seq[String]] = None,
@@ -114,11 +117,14 @@ final case class BigQuerySink(
   * @param timestamp: Timestamp field format as expeted by Elasticsearch ("{beginTs|yyyy.MM.dd}" for example).
   */
 @JsonTypeName("ES")
-final case class EsSink(id: Option[String] = None, timestamp: Option[String] = None)
-    extends Sink(SinkType.ES)
+final case class EsSink(
+  override val name: Option[String] = None,
+  id: Option[String] = None,
+  timestamp: Option[String] = None
+) extends Sink(SinkType.ES)
 
 @JsonTypeName("None")
-final case class NoneSink() extends Sink(SinkType.None)
+final case class NoneSink(override val name: Option[String] = None) extends Sink(SinkType.None)
 
 /** When the sink *type* field is set to JDBC, the options below should be provided.
   * @param connection: Connection String
@@ -127,6 +133,7 @@ final case class NoneSink() extends Sink(SinkType.None)
   */
 @JsonTypeName("JDBC")
 final case class JdbcSink(
+  override val name: Option[String] = None,
   connection: String,
   partitions: Option[Int] = None,
   batchsize: Option[Int] = None

--- a/src/main/scala/com/ebiznext/comet/utils/SinkUtils.scala
+++ b/src/main/scala/com/ebiznext/comet/utils/SinkUtils.scala
@@ -14,7 +14,7 @@ class SinkUtils(implicit settings: Settings) extends StrictLogging {
 
   def sink(sinkType: Sink, dataframe: DataFrame, table: String): Try[Unit] = {
     sinkType match {
-      case NoneSink() =>
+      case _: NoneSink =>
         Success(())
 
       case sink: BigQuerySink =>
@@ -22,7 +22,7 @@ class SinkUtils(implicit settings: Settings) extends StrictLogging {
           sinkToBigQuery(dataframe, sink.name.getOrElse(table), table)
         }
 
-      case JdbcSink(jdbcConnection, partitions, batchSize) =>
+      case JdbcSink(_, jdbcConnection, partitions, batchSize) =>
         Try {
           val jdbcConfig = ConnectionLoadConfig.fromComet(
             jdbcConnection,
@@ -34,7 +34,7 @@ class SinkUtils(implicit settings: Settings) extends StrictLogging {
           )
           sinkToJdbc(jdbcConfig)
         }
-      case EsSink(id, timestamp) =>
+      case _: EsSink =>
         ???
     }
   }


### PR DESCRIPTION
## Summary
It is now possible not to sink to a parquet file and sink the dataframe directly to the target database (ES / BQ / JDBC / ...)
This PR is a fist step toward supporting multiple sinks at once

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**

