### PR TITLE
Log success and errors during sink at load and transform steps.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,7 +15,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.3.2")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.2")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 
 addSbtPlugin("com.lightbend" % "sbt-google-cloud-storage" % "0.0.10")
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -228,7 +228,8 @@ jdbc-engines {
                               countRejected BIGINT not NULL,
                               timestamp TIMESTAMP not NULL,
                               duration INTEGER not NULL,
-                              message VARCHAR(255) not NULL
+                              message VARCHAR(255) not NULL,
+                              step VARCHAR(255) not NULL
                              )
     """
       },
@@ -314,7 +315,8 @@ jdbc-engines {
                               countRejected BIGINT not NULL,
                               timestamp TIMESTAMP not NULL,
                               duration INTEGER not NULL,
-                              message VARCHAR(255) not NULL
+                              message VARCHAR(255) not NULL,
+                              step VARCHAR(255) not NULL
                              )
     """
       },

--- a/src/main/scala/com/ebiznext/comet/job/ingest/AuditLog.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/AuditLog.scala
@@ -41,10 +41,10 @@ object Step {
 
   def fromString(value: String): Step = {
     value.toUpperCase() match {
-      case "LOAD"      => Step.LOAD
-      case "SINK_ACCEPTED"      => Step.SINK_ACCEPTED
-      case "SINK_REJECTED"      => Step.SINK_REJECTED
-      case "TRANSFORM" => Step.TRANSFORM
+      case "LOAD"          => Step.LOAD
+      case "SINK_ACCEPTED" => Step.SINK_ACCEPTED
+      case "SINK_REJECTED" => Step.SINK_REJECTED
+      case "TRANSFORM"     => Step.TRANSFORM
     }
   }
 

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -283,7 +283,6 @@ trait IngestionJob extends SparkJob {
     (savedDataset, acceptedPath)
   }
 
-
   private[this] def sink(mergedDF: DataFrame): Try[Unit] = {
     Try {
       val sinkType = metadata.getSink().map(_.`type`)

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -263,6 +263,7 @@ trait IngestionJob extends SparkJob {
         )
         SparkAuditLogWriter.append(session, log)
       case Failure(exception) =>
+        Utils.logException(logger, exception)
         val end = Timestamp.from(Instant.now())
         val log = AuditLog(
           session.sparkContext.applicationId,
@@ -323,7 +324,8 @@ trait IngestionJob extends SparkJob {
           val res = new BigQuerySparkJob(config, Some(schema.bqSchema(schemaHandler))).run()
           res match {
             case Success(_) => ;
-            case Failure(e) => logger.error("BQLoad Failed", e)
+            case Failure(e) =>
+              throw e
           }
 
         case SinkType.KAFKA =>
@@ -359,7 +361,8 @@ trait IngestionJob extends SparkJob {
             val res = new ConnectionLoadJob(jdbcConfig).run()
             res match {
               case Success(_) => ;
-              case Failure(e) => logger.error("JDBCLoad Failed", e)
+              case Failure(e) =>
+                throw e
             }
           }
         case SinkType.None =>

--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTaskJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTaskJob.scala
@@ -21,7 +21,11 @@
 package com.ebiznext.comet.job.transform
 
 import com.ebiznext.comet.config.{Settings, StorageArea}
-import com.ebiznext.comet.job.index.bqload.{BigQueryJobResult, BigQueryLoadConfig, BigQueryNativeJob}
+import com.ebiznext.comet.job.index.bqload.{
+  BigQueryJobResult,
+  BigQueryLoadConfig,
+  BigQueryNativeJob
+}
 import com.ebiznext.comet.job.ingest.{AuditLog, SparkAuditLogWriter, Step}
 import com.ebiznext.comet.job.metrics.AssertionJob
 import com.ebiznext.comet.schema.handlers.{SchemaHandler, StorageHandler}

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -535,9 +535,8 @@ class IngestionWorkflow(
                     case Failure(e) => logger.error("JDBCLoad Failed", e)
                   }
                 case _ =>
-                  // TODO Sinking not supported
-                  logger.error(s"Sinking from Spark to $sink not yet supported.")
-                  false
+                  logger.warn("Sink is not activated for this job")
+                  true
               }
             case Failure(exception) =>
               exception.printStackTrace()

--- a/src/test/scala/com/ebiznext/comet/JdbcChecks.scala
+++ b/src/test/scala/com/ebiznext/comet/JdbcChecks.scala
@@ -200,7 +200,7 @@ trait JdbcChecks {
       "audit",
       "jobid" :: "paths" :: "domain" :: "schema" :: "success" ::
       "count" :: "countAccepted" :: "countRejected" :: "timestamp" ::
-      "duration" :: "message" :: Nil,
+      "duration" :: "message" :: "step" :: Nil,
       values.to[Vector]
     ) { rs =>
       val item = AuditLog(
@@ -214,7 +214,8 @@ trait JdbcChecks {
         rs.getInt("countRejected"),
         rs.getTimestamp("timestamp"),
         rs.getInt("duration"),
-        rs.getString("message")
+        rs.getString("message"),
+        rs.getString("step")
       )
 
       item.timestamp.after(TestStart) should be(true)

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/JsonIngestionJobSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/JsonIngestionJobSpec.scala
@@ -148,7 +148,8 @@ class JsonIngestionJobSpecNoIndexJdbcMetricsJdbcAuditSpec
       countRejected = 0,
       timestamp = TestStart,
       duration = 1 /* fake */,
-      message = "success"
+      message = "success",
+      Step.LOAD.toString
     ) :: Nil
 
   override def expectedRejectRecords(implicit settings: Settings): List[RejectedRecord] =


### PR DESCRIPTION
## Summary
An audit log record is generated when sinking datasets. 
**Related Issue: #IssueId**

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? Yes**
If using JDBC Sinks, the schema must be updated and a "step" column added too the audit table.

