### PR TITLE
Do not delete BQ table in merge mode but set writemode to overwrite

### DIFF
--- a/src/test/scala/com/ebiznext/comet/schema/handlers/AutoJobHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/AutoJobHandlerSpec.scala
@@ -314,7 +314,7 @@ class AutoJobHandlerSpec extends TestHelper with BeforeAndAfterAll {
       val job = new BigQuerySparkJob(config)
       val conf = job.prepareConf()
 
-      conf.get(BigQueryConfiguration.OUTPUT_TABLE_WRITE_DISPOSITION_KEY) shouldEqual "WRITE_APPEND"
+      conf.get(BigQueryConfiguration.OUTPUT_TABLE_WRITE_DISPOSITION_KEY) shouldEqual "WRITE_TRUNCATE"
       conf.get(
         BigQueryConfiguration.OUTPUT_TABLE_CREATE_DISPOSITION_KEY
       ) shouldEqual "CREATE_IF_NEEDED"


### PR DESCRIPTION
Do not delete BQ table in merge mode but set writemode to overwrite instead.

## Summary

We used to delete BQ table in merge mode but since it is needed to merge with imported dataset it was failing with a Not Found : Table Name exception.
We do not delete it anymore but set writemode to overwrite instead in case of a WRITE_TRUNCATE disposition.