### PR TITLE
Bugfix/poi version + date parsing

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -126,7 +126,7 @@ object Versions {
   val bq = "1.120.0"
   val hadoop = "3.3.0"
   val h2 = "1.4.200" // Test only
-  val poi = "5.0.0"
+  val poi = "4.1.2"
   val scalate = "1.9.6"
   val akkaHttp = "10.1.13"
 //  val akkaStream = "2.6.12"

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -527,15 +527,17 @@ trait IngestionJob extends SparkJob {
       session.emptyDataFrame
     }
     if (csvOutput() && area != StorageArea.rejected) {
-      val csvPath = storageHandler
+      val paths = storageHandler
         .list(targetPath, ".csv", LocalDateTime.MIN)
         .filterNot(path => schema.pattern.matcher(path.getName).matches())
-        .head
-      val finalCsvPath = new Path(
-        targetPath,
-        path.head.getName
-      )
-      storageHandler.move(csvPath, finalCsvPath)
+      if (path.nonEmpty) {
+        val csvPath = path.head
+        val finalCsvPath = new Path(
+          targetPath,
+          path.head.getName
+        )
+        storageHandler.move(csvPath, finalCsvPath)
+      }
     }
     resultDataFrame
   }

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
@@ -136,7 +136,7 @@ class SchemaHandler(storage: StorageHandler)(implicit settings: Settings) extend
           val domainNode =
             if (loadNode.isNull() || loadNode.isMissingNode) {
               logger.warn(
-                s"Defining a domain outsiide a load node is now deprecated. Please updaet definition $path"
+                s"Defining a domain outside a load node is now deprecated. Please update definition $path"
               )
               rootNode
             } else

--- a/src/main/scala/com/ebiznext/comet/schema/model/PrimitiveType.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/PrimitiveType.scala
@@ -284,9 +284,13 @@ object PrimitiveType {
         null
       else {
         val formatter = DateTimeFormatter.ofPattern(pattern)
-        val date = LocalDate.parse(str, formatter)
-        java.sql.Date.valueOf(date)
-
+        Try {
+          val date = LocalDate.parse(str, formatter)
+          java.sql.Date.valueOf(date)
+        } match {
+          case Success(value) => value
+          case Failure(_)     => java.sql.Date.valueOf(YearMonth.parse(str, formatter).atDay(1))
+        }
       }
     }
 

--- a/src/test/scala/com/ebiznext/comet/schema/model/DateTypeSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/model/DateTypeSpec.scala
@@ -34,5 +34,24 @@ class DateTypeSpec extends TestHelper {
       )
       result shouldBe expected
     }
+    "Parsing a valid Year-Month pattern" should "return a date with the first day of the month" in {
+      val expected = java.sql.Date.valueOf("2009-12-01")
+      date.fromString(
+        "2009.12",
+        "yyyy.MM"
+      ) shouldBe expected
+
+      date.fromString(
+        "12-2009",
+        "MM-yyyy"
+      ) shouldBe expected
+
+      assertThrows[DateTimeParseException] {
+        date.fromString(
+          "12-20090",
+          "MM-yyyy"
+        )
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Downgrade poi version to 4.1.2. Version 5.0.0 seems to cause a regression when using comet as a dependency. 
- Manage the parsing of dates with a pattern of year and month (e.g. yyyyMM) to a date with the first day of the month
- Minor correction when saving a csv output while the dataframe is empty

**PR Type: Bug Fix**

**Status:Ready to review**

**Breaking change?No**


## How has this been tested?
Local testing

