### PR TITLE
Do not compute colMap before it is used.

### DIFF
--- a/src/main/scala/com/ebiznext/comet/job/ingest/DsvIngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/DsvIngestionJob.scala
@@ -292,7 +292,7 @@ object DsvIngestionUtil extends DsvValidator {
               (Option(colValue).map(_.toString), colAttribute)
             }
           val rowCols = rowValues.zip(types)
-          val colMap = rowValues.map(__ => (__._2.name, __._1)).toMap
+          lazy val colMap = rowValues.map(__ => (__._2.name, __._1)).toMap
           val validNumberOfColumns = attributes.length <= rowCols.length
           if (!validNumberOfColumns) {
             RowResult(

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -889,7 +889,7 @@ object IngestionUtil {
     colRawValue: Option[String],
     colAttribute: Attribute,
     tpe: Type,
-    colMap: Map[String, Option[String]]
+    colMap: => Map[String, Option[String]]
   )(
     implicit /* TODO: make me explicit. Avoid rebuilding the PrivacyLevel(settings) at each invocation? */ settings: Settings
   ): ColResult = {

--- a/src/main/scala/com/ebiznext/comet/privacy/PrivacyEngine.scala
+++ b/src/main/scala/com/ebiznext/comet/privacy/PrivacyEngine.scala
@@ -3,7 +3,7 @@ package com.ebiznext.comet.privacy
 import scala.util.Random
 
 /** Several encryption methods used in privacy management
- */
+  */
 object PrivacyEngine {
 
   def algo(alg: String, data: String): String = {
@@ -158,7 +158,11 @@ object RandomDouble extends NumericRandomPrivacy {
 
   def genUnbounded(): Double = rnd.nextDouble()
 
-  override def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String = {
+  override def crypt(
+    s: String,
+    colMap: => Map[String, Option[String]],
+    params: List[Any]
+  ): String = {
     crypt(params).toString
   }
 }
@@ -203,7 +207,11 @@ object ApproxDouble extends ApproxDouble {}
 
 object ApproxLong extends ApproxDouble {
 
-  override def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String = {
+  override def crypt(
+    s: String,
+    colMap: => Map[String, Option[String]],
+    params: List[Any]
+  ): String = {
     assert(params.length == 1)
     crypt(s.toDouble, params.head.asInstanceOf[Int]).toLong.toString
   }
@@ -222,12 +230,12 @@ object Mask extends PrivacyEngine {
   }
 
   def crypt(
-             s: String,
-             maskingChar: Char,
-             numberOfChars: Int,
-             leftSide: Int,
-             rightSide: Int
-           ): String = {
+    s: String,
+    maskingChar: Char,
+    numberOfChars: Int,
+    leftSide: Int,
+    rightSide: Int
+  ): String = {
     s match {
       case input if input.length <= leftSide =>
         "%s%s".format(input, maskingChar.toString * numberOfChars)

--- a/src/main/scala/com/ebiznext/comet/privacy/PrivacyEngine.scala
+++ b/src/main/scala/com/ebiznext/comet/privacy/PrivacyEngine.scala
@@ -48,36 +48,36 @@ object PrivacyEngine {
 }
 
 trait PrivacyEngine {
-  def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String
+  def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String
 }
 
 object Md5 extends PrivacyEngine {
 
-  def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String =
+  def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String =
     PrivacyEngine.algo("MD5", s)
 }
 
 object Sha1 extends PrivacyEngine {
 
-  def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String =
+  def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String =
     PrivacyEngine.algo("SHA-1", s)
 }
 
 object Sha256 extends PrivacyEngine {
 
-  def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String =
+  def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String =
     PrivacyEngine.algo("SHA-256", s)
 }
 
 object Sha512 extends PrivacyEngine {
 
-  def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String =
+  def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String =
     PrivacyEngine.algo("SHA-512", s)
 }
 
 object Hide extends PrivacyEngine {
 
-  def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String = {
+  def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String = {
     if (params.isEmpty)
       ""
     else {
@@ -90,19 +90,19 @@ object Hide extends PrivacyEngine {
 }
 
 object No extends PrivacyEngine {
-  def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String = s
+  def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String = s
 }
 
 object Initials extends PrivacyEngine {
 
-  def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String = {
+  def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String = {
     s.split("\\s+").map(_.substring(0, 1)).mkString("", ".", ".")
   }
 }
 
 object Email extends PrivacyEngine {
 
-  def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String = {
+  def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String = {
     assert(params.length == 1)
     val split = s.split('@')
     PrivacyEngine.algo(params.head.toString, split(0)) + "@" + split(1)
@@ -112,7 +112,7 @@ object Email extends PrivacyEngine {
 trait IP extends PrivacyEngine {
   def separator: Char
 
-  def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String = {
+  def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String = {
     assert(params.length == 1)
     crypt(s, params.head.asInstanceOf[Int])
   }
@@ -154,7 +154,7 @@ object RandomDouble extends NumericRandomPrivacy {
   val rnd = new Random()
   def genUnbounded(): Double = rnd.nextDouble()
 
-  override def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String = {
+  override def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String = {
     crypt(params).toString
   }
 }
@@ -163,7 +163,7 @@ object RandomLong extends NumericRandomPrivacy {
   val rnd = new Random()
   override def genUnbounded(): Double = rnd.nextLong().toDouble
 
-  override def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String =
+  override def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String =
     (crypt(params) % Long.MaxValue).toLong.toString
 }
 
@@ -171,14 +171,14 @@ object RandomInt extends NumericRandomPrivacy {
   val rnd = new Random()
   override def genUnbounded(): Double = rnd.nextInt().toDouble
 
-  override def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String =
+  override def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String =
     (crypt(params) % Int.MaxValue).toInt.toString
 }
 
 class ApproxDouble extends PrivacyEngine {
   val rnd = new Random()
 
-  def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String = {
+  def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String = {
     assert(params.length == 1)
     crypt(s.toDouble, params.head.asInstanceOf[Int]).toString
   }
@@ -197,7 +197,7 @@ object ApproxDouble extends ApproxDouble {}
 
 object ApproxLong extends ApproxDouble {
 
-  override def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String = {
+  override def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String = {
     assert(params.length == 1)
     crypt(s.toDouble, params.head.asInstanceOf[Int]).toLong.toString
   }
@@ -206,7 +206,7 @@ object ApproxLong extends ApproxDouble {
 
 object Mask extends PrivacyEngine {
 
-  def crypt(s: String, colMap: Map[String, Option[String]], params: List[Any]): String = {
+  def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String = {
     assert(params.length == 4)
     val maskingChar = params(0).asInstanceOf[Char]
     val numberOfChars = params(1).asInstanceOf[Int]

--- a/src/main/scala/com/ebiznext/comet/privacy/PrivacyEngine.scala
+++ b/src/main/scala/com/ebiznext/comet/privacy/PrivacyEngine.scala
@@ -3,7 +3,7 @@ package com.ebiznext.comet.privacy
 import scala.util.Random
 
 /** Several encryption methods used in privacy management
-  */
+ */
 object PrivacyEngine {
 
   def algo(alg: String, data: String): String = {
@@ -32,6 +32,7 @@ object PrivacyEngine {
         else
           param.toInt
       }
+
     val hasParam = maskingAlgo.indexOf('(')
     if (hasParam > 0) {
       assert(maskingAlgo.indexOf(')') > hasParam)
@@ -133,7 +134,9 @@ object IPv6 extends IP {
 
 trait NumericRandomPrivacy extends PrivacyEngine {
   val rnd: Random
+
   final def gen(low: Double, up: Double): Double = low + (up - low) * rnd.nextDouble()
+
   def genUnbounded(): Double
 
   final def crypt(params: List[Any]): Double = {
@@ -152,6 +155,7 @@ trait NumericRandomPrivacy extends PrivacyEngine {
 
 object RandomDouble extends NumericRandomPrivacy {
   val rnd = new Random()
+
   def genUnbounded(): Double = rnd.nextDouble()
 
   override def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String = {
@@ -161,6 +165,7 @@ object RandomDouble extends NumericRandomPrivacy {
 
 object RandomLong extends NumericRandomPrivacy {
   val rnd = new Random()
+
   override def genUnbounded(): Double = rnd.nextLong().toDouble
 
   override def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String =
@@ -169,6 +174,7 @@ object RandomLong extends NumericRandomPrivacy {
 
 object RandomInt extends NumericRandomPrivacy {
   val rnd = new Random()
+
   override def genUnbounded(): Double = rnd.nextInt().toDouble
 
   override def crypt(s: String, colMap: => Map[String, Option[String]], params: List[Any]): String =
@@ -216,12 +222,12 @@ object Mask extends PrivacyEngine {
   }
 
   def crypt(
-    s: String,
-    maskingChar: Char,
-    numberOfChars: Int,
-    leftSide: Int,
-    rightSide: Int
-  ): String = {
+             s: String,
+             maskingChar: Char,
+             numberOfChars: Int,
+             leftSide: Int,
+             rightSide: Int
+           ): String = {
     s match {
       case input if input.length <= leftSide =>
         "%s%s".format(input, maskingChar.toString * numberOfChars)

--- a/src/test/scala/com/ebiznext/comet/privacy/PrivacyEngineSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/privacy/PrivacyEngineSpec.scala
@@ -105,7 +105,7 @@ class PrivacyEngineSpec extends TestHelper {
       object ConditionalHide extends PrivacyEngine {
         override def crypt(
           s: String,
-          colMap: Map[String, Option[String]],
+          colMap: => Map[String, Option[String]],
           params: List[Any]
         ): String = {
           if (colMap.isDefinedAt("col1")) s else ""


### PR DESCRIPTION
## Summary
The objective is to delay the computation of the column map until it is used in a privacy Algo.
Almost all privacy Algo do not use it. We change the function signature to a call by name 

**Related Issue: #IssueId**

**PR Type: Feature**

**Status:Ready to review**

**Breaking change? Yes**
Existing privacy subclass should now change the colMap argument to a call by name argument.
