### PR TITLE
privacy performance

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,7 @@
 ## 0.1.35
 __New feature__:
 - Auto compile with scala 2.11 for Spark 2 and with scala 2.12 for Spark 3. [#457]
+- Performance optimization when using Privacy Rules. 
 
 __Bug Fix__:
 - Make Jackson lib provided. [#457]

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -527,11 +527,11 @@ trait IngestionJob extends SparkJob {
       session.emptyDataFrame
     }
     if (csvOutput() && area != StorageArea.rejected) {
-      val paths = storageHandler
+      val outputList = storageHandler
         .list(targetPath, ".csv", LocalDateTime.MIN)
         .filterNot(path => schema.pattern.matcher(path.getName).matches())
-      if (path.nonEmpty) {
-        val csvPath = path.head
+      if (outputList.nonEmpty) {
+        val csvPath = outputList.head
         val finalCsvPath = new Path(
           targetPath,
           path.head.getName

--- a/src/main/scala/com/ebiznext/comet/schema/generator/XlsReader.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/XlsReader.scala
@@ -282,7 +282,7 @@ class XlsReader(input: Input) {
             val privacy =
               Option(row.getCell(headerMap("_privacy"), Row.MissingCellPolicy.RETURN_BLANK_AS_NULL))
                 .flatMap(formatter.formatCellValue)
-                .map(PrivacyLevel.ForSettings(settings).fromString)
+                .map(value => settings.allPrivacyLevels(value.toUpperCase())._2)
             val metricType =
               Option(row.getCell(headerMap("_metric"), Row.MissingCellPolicy.RETURN_BLANK_AS_NULL))
                 .flatMap(formatter.formatCellValue)


### PR DESCRIPTION
## Summary
Build the list of defined Privacy rules once (per executor) for better performance

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**


## Description

### How has this been tested?
Ingestion time with +20 privacy rules on a 500 Mb file drops from 40 min to 3 min 

### Other changes
bug fix for a regression due to misused variables after refactoring

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] I have updated the Release notes.



