### PR TITLE
Add option to export all tables schema from SQL database at once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ venv
 
 .bsp
 tfm/azure/databricks-tfm/.terraform
+postgresql-42.2.19.jar

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## 0.1.37
+__New feature__:
+- Export all tables in DDL2YML generation
+__Bug Fix__:
+
+
 ## 0.1.36
 __New feature__:
 - Parameterize with Domain & Schema metadata in DDL2YML generation 

--- a/docs/user/concepts/extract/index.rst
+++ b/docs/user/concepts/extract/index.rst
@@ -16,11 +16,12 @@ that describe the tables and columns you are willing to extract using the follow
       catalog: "business" # Optional catalog name in the target database
       schema: "public" # Database schema where tables are located
       tables:
-        - name: "user:
+        - name: "user"
           columns: # optional list of columns, if not present all columns should be exported.
             - id
             - email
-        - name: product
+        - name: product # All columns should be exported
+        - name: "*" # Ignore any other table spec. Just export all tables
       table-types: # One or many of the types below
         - "TABLE"
         - "VIEW"

--- a/scripts/ddl2yml/application.conf
+++ b/scripts/ddl2yml/application.conf
@@ -1,0 +1,11 @@
+connections {
+  airflow-pg-db {
+    format = "jdbc"
+    options {
+      url: "jdbc:postgresql://127.0.0.1:5432/airflow",
+      user: "hayssams",
+      password: "*****",
+      driver: "org.postgresql.Driver"
+    }
+  }
+}

--- a/scripts/ddl2yml/ddl2yml-alltables.yml
+++ b/scripts/ddl2yml/ddl2yml-alltables.yml
@@ -1,0 +1,14 @@
+jdbc-schema:
+  connection: "airflow-pg-db" # Connection name as defined in the connections section of the application.conf file
+  schema: "public" # Database schema where tables are located
+  tables:
+    - name: "*"
+  tableTypes: # One or many of the types below
+    - "TABLE"
+    - "VIEW"
+    - "SYSTEM TABLE"
+    - "GLOBAL TEMPORARY"
+    - "LOCAL TEMPORARY"
+    - "ALIAS"
+    - "SYNONYM"
+#  templateFile: "domain-template.yml" # Metadata to use for the generated YML file.

--- a/scripts/ddl2yml/ddl2yml.sh
+++ b/scripts/ddl2yml/ddl2yml.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+if ls drivers/*.jar 1>/dev/null 2>&1; then
+    echo "JAR in JDBC driver folfer found"
+else
+    echo "Copy JDBC driver in the drivers folder and reference it in the classpath below (--jars argument)"
+    exit 1
+fi
+
+
+export SPARK_DRIVER_MEMORY=1G
+
+export COMET_ROOT=gen
+export COMET_FS=file://
+export COMET_ROOT=gen
+export COMET_METRICS_ACTIVE=true
+export COMET_FS=file://
+export COMET_ASSERTIONS_ACTIVE=true
+export COMET_SINK_TO_FILE=true
+
+
+
+COMET_JAR="comet-spark3_2.12-0.1.36-assembly.jar"
+COMET_OPTIONS="--conf spark.driver.extraJavaOptions=-Dconfig.file=$PWD/application.conf"
+COMET_LIBS="--jars drivers/postgresql-42.2.19.jar"
+COMET_SCRIPT="spark-3.1.1-bin-hadoop2.7/bin/spark-submit $COMET_LIBS $COMET_OPTIONS --class com.ebiznext.comet.schema.generator.DDL2Yml ${COMET_JAR}"
+
+$COMET_SCRIPT --jdbc-mapping ddl2yml-alltables.yml --output-dir output --yml-template domain-template.comet.yml

--- a/scripts/ddl2yml/ddl2yml.yml
+++ b/scripts/ddl2yml/ddl2yml.yml
@@ -1,0 +1,14 @@
+jdbc-schema:
+  connection: "airflow-pg-db" # Connection name as defined in the connections section of the application.conf file
+  schema: "public" # Database schema where tables are located
+  tables:
+    - name: "*" # Takes all tables
+  tableTypes: # One or many of the types below
+    - "TABLE"
+    - "VIEW"
+    - "SYSTEM TABLE"
+    - "GLOBAL TEMPORARY"
+    - "LOCAL TEMPORARY"
+    - "ALIAS"
+    - "SYNONYM"
+#  templateFile: "domain-template.yml" # Metadata to use for the generated YML file.

--- a/scripts/ddl2yml/domain-template.comet.yml
+++ b/scripts/ddl2yml/domain-template.comet.yml
@@ -1,0 +1,32 @@
+load:
+  name: "DOMAIN"
+  directory: "{domain}/{schema}/DOMAIN"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: "/"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+  schemas:
+    - name: "User"
+      metadata:
+        mode: "FILE"
+        format: "DSV"
+        multiline: false
+        array: false
+        withHeader: false
+        separator: ";"
+        quote: "\""
+        escape: "\\"
+        write: "APPEND"
+      pattern: "SCHEMA-.*.dsv"
+      attributes:
+      - name: "id"
+        type: "long"
+        array: false
+        required: true
+        privacy: "NONE"

--- a/scripts/ddl2yml/output/public.yml
+++ b/scripts/ddl2yml/output/public.yml
@@ -1,0 +1,1216 @@
+---
+name: "public"
+directory: "public/DOMAIN"
+metadata:
+  mode: "FILE"
+  format: "DSV"
+  encoding: "UTF-8"
+  multiline: false
+  array: false
+  withHeader: false
+  separator: "/"
+  quote: "\""
+  escape: "\\"
+  write: "APPEND"
+schemas:
+- name: "alembic_version"
+  pattern: "alembic_version.*"
+  attributes:
+  - name: "version_num"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "import_error"
+  pattern: "import_error.*"
+  attributes:
+  - name: "id"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "timestamp"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "filename"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "stacktrace"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "sla_miss"
+  pattern: "sla_miss.*"
+  attributes:
+  - name: "task_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "dag_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "execution_date"
+    type: "timestamp"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "email_sent"
+    type: "boolean"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "timestamp"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "description"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "notification_sent"
+    type: "boolean"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "known_event_type"
+  pattern: "known_event_type.*"
+  attributes:
+  - name: "id"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "know_event_type"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "dag_tag"
+  pattern: "dag_tag.*"
+  attributes:
+  - name: "name"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "dag_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "dag_code"
+  pattern: "dag_code.*"
+  attributes:
+  - name: "fileloc_hash"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "fileloc"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "source_code"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "last_updated"
+    type: "timestamp"
+    array: false
+    required: true
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "users"
+  pattern: "users.*"
+  attributes:
+  - name: "id"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "username"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "email"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "password"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "superuser"
+    type: "boolean"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "known_event"
+  pattern: "known_event.*"
+  attributes:
+  - name: "id"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "label"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "start_date"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "end_date"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "user_id"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "known_event_type_id"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "description"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "job"
+  pattern: "job.*"
+  attributes:
+  - name: "id"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "dag_id"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "state"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "job_type"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "start_date"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "end_date"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "latest_heartbeat"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "executor_class"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "hostname"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "unixname"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "dag_pickle"
+  pattern: "dag_pickle.*"
+  attributes:
+  - name: "id"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "pickle"
+    type: "BINARY"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "created_dttm"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "pickle_hash"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "task_reschedule"
+  pattern: "task_reschedule.*"
+  attributes:
+  - name: "id"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "task_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "dag_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "execution_date"
+    type: "timestamp"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "try_number"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "start_date"
+    type: "timestamp"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "end_date"
+    type: "timestamp"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "duration"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "reschedule_date"
+    type: "timestamp"
+    array: false
+    required: true
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "kube_worker_uuid"
+  pattern: "kube_worker_uuid.*"
+  attributes:
+  - name: "one_row_id"
+    type: "boolean"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "worker_uuid"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "slot_pool"
+  pattern: "slot_pool.*"
+  attributes:
+  - name: "id"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "pool"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "slots"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "description"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "serialized_dag"
+  pattern: "serialized_dag.*"
+  attributes:
+  - name: "dag_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "fileloc"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "fileloc_hash"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "data"
+    type: "OTHER"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "last_updated"
+    type: "timestamp"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "dag_hash"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "rendered_task_instance_fields"
+  pattern: "rendered_task_instance_fields.*"
+  attributes:
+  - name: "dag_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "task_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "execution_date"
+    type: "timestamp"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "rendered_fields"
+    type: "OTHER"
+    array: false
+    required: true
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "variable"
+  pattern: "variable.*"
+  attributes:
+  - name: "id"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "key"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "val"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "is_encrypted"
+    type: "boolean"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "chart"
+  pattern: "chart.*"
+  attributes:
+  - name: "id"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "label"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "conn_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "user_id"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "chart_type"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "sql_layout"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "sql"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "y_log_scale"
+    type: "boolean"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "show_datatable"
+    type: "boolean"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "show_sql"
+    type: "boolean"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "height"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "default_params"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "x_is_date"
+    type: "boolean"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "iteration_no"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "last_modified"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "dag_run"
+  pattern: "dag_run.*"
+  attributes:
+  - name: "id"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "dag_id"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "execution_date"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "state"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "run_id"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "external_trigger"
+    type: "boolean"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "conf"
+    type: "BINARY"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "end_date"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "start_date"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "xcom"
+  pattern: "xcom.*"
+  attributes:
+  - name: "id"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "key"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "value"
+    type: "BINARY"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "timestamp"
+    type: "timestamp"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "execution_date"
+    type: "timestamp"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "task_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "dag_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "dag"
+  pattern: "dag.*"
+  attributes:
+  - name: "dag_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "is_paused"
+    type: "boolean"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "is_subdag"
+    type: "boolean"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "is_active"
+    type: "boolean"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "last_scheduler_run"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "last_pickled"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "last_expired"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "scheduler_lock"
+    type: "boolean"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "pickle_id"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "fileloc"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "owners"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "description"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "default_view"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "schedule_interval"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "root_dag_id"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "connection"
+  pattern: "connection.*"
+  attributes:
+  - name: "id"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "conn_id"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "conn_type"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "host"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "schema"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "login"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "password"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "port"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "extra"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "is_encrypted"
+    type: "boolean"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "is_extra_encrypted"
+    type: "boolean"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "task_instance"
+  pattern: "task_instance.*"
+  attributes:
+  - name: "task_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "dag_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "execution_date"
+    type: "timestamp"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "start_date"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "end_date"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "duration"
+    type: "double"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "state"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "try_number"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "hostname"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "unixname"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "job_id"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "pool"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "queue"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "priority_weight"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "operator"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "queued_dttm"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "pid"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "max_tries"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "executor_config"
+    type: "BINARY"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "pool_slots"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "task_fail"
+  pattern: "task_fail.*"
+  attributes:
+  - name: "id"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "task_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "dag_id"
+    type: "string"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "execution_date"
+    type: "timestamp"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "start_date"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "end_date"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "duration"
+    type: "long"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "kube_resource_version"
+  pattern: "kube_resource_version.*"
+  attributes:
+  - name: "one_row_id"
+    type: "boolean"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "resource_version"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+- name: "log"
+  pattern: "log.*"
+  attributes:
+  - name: "id"
+    type: "long"
+    array: false
+    required: true
+    privacy: "NONE"
+  - name: "dttm"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "dag_id"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "task_id"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "event"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "execution_date"
+    type: "timestamp"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "owner"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  - name: "extra"
+    type: "string"
+    array: false
+    required: false
+    privacy: "NONE"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    encoding: "UTF-8"
+    multiline: false
+    array: false
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+extensions:
+- ".json"
+- ".csv"
+- ".dsv"
+- ".psv"
+ack: ".ack"

--- a/src/main/scala/com/ebiznext/comet/schema/generator/YamlSerializer.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/YamlSerializer.scala
@@ -33,9 +33,8 @@ object YamlSerializer extends LazyLogging {
     mapper.treeToValue(jdbcNode, classOf[JDBCSchema])
   }
 
-  def deserializeDomain(file: File): Domain = {
-    scala.io.Source.fromFile(file.pathAsString)
-    mapper.readValue(file.newInputStream, classOf[Domain])
+  def deserializeDomain(file: File): Try[Domain] = {
+    deserializeDomain(scala.io.Source.fromFile(file.pathAsString).getLines.mkString("\n"))
   }
 
   def serializeToFile(targetFile: File, domain: Domain): Unit =

--- a/src/test/scala/com/ebiznext/comet/schema/generator/DDL2YmlSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/generator/DDL2YmlSpec.scala
@@ -5,6 +5,7 @@ import com.ebiznext.comet.TestHelper
 import com.ebiznext.comet.schema.model.{Domain, Metadata, Mode}
 
 import java.sql.DriverManager
+import scala.util.{Failure, Success}
 
 class DDL2YmlSpec extends TestHelper {
   "DDL2Yml of all tables" should "should generated all the table schemas in a YML file" in {
@@ -31,7 +32,10 @@ class DDL2YmlSpec extends TestHelper {
       val metadata = Metadata(mode = Some(Mode.STREAM), quote = Some("::"))
       val domainTemplate = Domain("CUSTOM_NAME", "/{domain}/{schema}", metadata = Some(metadata))
       DDL2Yml.run(JDBCSchema("test-h2", None, "PUBLIC", Nil), File("/tmp"), Some(domainTemplate))
-      val domain = YamlSerializer.deserializeDomain(File("/tmp", "PUBLIC.yml"))
+      val domain = YamlSerializer.deserializeDomain(File("/tmp", "PUBLIC.yml")) match {
+        case Success(domain) => domain
+        case Failure(e)      => throw e
+      }
       assert(domain.name == "PUBLIC")
       assert(domain.schemas.size == 2)
       assert(domain.metadata.flatMap(_.quote).getOrElse("") == "::")
@@ -79,7 +83,10 @@ class DDL2YmlSpec extends TestHelper {
         File("/tmp"),
         None
       )
-      val domain = YamlSerializer.deserializeDomain(File("/tmp", "PUBLIC.yml"))
+      val domain = YamlSerializer.deserializeDomain(File("/tmp", "PUBLIC.yml")) match {
+        case Success(domain) => domain
+        case Failure(e)      => throw e
+      }
       assert(domain.name == "PUBLIC")
       assert(domain.schemas.size == 1)
       assert(domain.schemas.head.name == "TEST_TABLE1")


### PR DESCRIPTION
## Summary
This PR allows to user to export all tables of a schema at once using the following syntax ` - name: "*"`:

```
    jdbc-schema:
      connection: "test-h2" # Connection name as defined in the connections section of the application.conf file
      catalog: "business" # Optional catalog name in the target database
      schema: "public" # Database schema where tables are located
      tables:
        - name: "user"
          columns: # optional list of columns, if not present all columns should be exported.
            - id
            - email
        - name: product # All columns should be exported
        - name: "*" # Ignore any other table spec. Just export all tables
      table-types: # One or many of the types below
        - "TABLE"
        - "VIEW"
        - "SYSTEM TABLE"
        - "GLOBAL TEMPORARY"
        - "LOCAL TEMPORARY"
        - "ALIAS"
        - "SYNONYM"
      template-file: "/my-templates/domain-template.yml" # Metadata to use for the generated YML file.
```

**PR Type:  Feature**

**Status: Ready to review**

**Breaking change? Yes**
