### PR TITLE
bugfix : no need to update bq table schema

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -102,7 +102,7 @@ object Dependencies {
     "com.google.cloud" % "google-cloud-bigquery" % Versions.bq exclude ("javax.jms", "jms") exclude ("com.sun.jdmk", "jmxtools") exclude ("com.sun.jmx", "jmxri") excludeAll (jacksonExclusions: _*),
     // see https://github.com/GoogleCloudDataproc/spark-bigquery-connector/issues/36
     // Add the jar file to spark dependencies
-    "com.google.cloud.spark" %% "spark-bigquery-with-dependencies" % "0.18.1" % "provided" excludeAll (jacksonExclusions: _*)
+    "com.google.cloud.spark" %% "spark-bigquery-with-dependencies" % "0.20.0" % "provided" excludeAll (jacksonExclusions: _*)
   )
 
   val esHadoop = Seq(

--- a/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQuerySparkJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/index/bqload/BigQuerySparkJob.scala
@@ -189,12 +189,6 @@ class BigQuerySparkJob(
             .option("table", bqTable)
             .option("intermediateFormat", intermediateFormat)
           cliConfig.options.foldLeft(finalDF)((w, kv) => w.option(kv._1, kv._2)).save()
-          if (
-            writeDisposition == "WRITE_TRUNCATE" && !tableDefinition.getSchema.getFields.isEmpty
-          ) {
-            logger.info(s"updating BQ schema with ${tableDefinition.getSchema.getFields.toString}")
-            table.toBuilder.setDefinition(tableDefinition).build().update()
-          }
       }
 
       val stdTableDefinitionAfter =


### PR DESCRIPTION
## Summary
The version 0.20.0 of spark-bigquery connector fixed an issue (https://github.com/GoogleCloudDataproc/spark-bigquery-connector/issues/190) that led to losing column descriptions in BigQuery tables. No need to do an explicit update of the table schema after sinking in Overwrite mode. This explicit update is also the origin of a bug when modifying the schema of an autojob.

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
update version of spark-bigquery-connector

### How has this been tested?
Ingestion tests on GCP 

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] I have updated the Release notes.



