### PR TITLE
Sinking to a file is now a first class citizen

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,5 +1,6 @@
 updates.ignore = [
   { groupId = "com.fasterxml.jackson.module", artifactId = "jackson-module-scala" },
   { groupId = "com.fasterxml.jackson.dataformat", artifactId = "jackson-dataformat-yaml" },
+  { groupId = "org.apache.poi", artifactId = "poi-ooxml" },
   { groupId = "com.fasterxml.jackson.core" }
 ]

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,7 +4,7 @@
 __New feature__:
 - Use the same variable for Lock timeout
 - Improve logging when locking file fails
-
+- File sink while still the default is now controlled by the sink tag in the YAML file. The option sink-to-file is removed and used for testing purpose only.
 ## 0.2.0
 __New feature__:
 - Export all tables in DDL2YML generation

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@ __New feature__:
 - Use the same variable for Lock timeout
 - Improve logging when locking file fails
 - File sink while still the default is now controlled by the sink tag in the YAML file. The option sink-to-file is removed and used for testing purpose only.
+
 ## 0.2.0
 __New feature__:
 - Export all tables in DDL2YML generation

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -121,7 +121,7 @@ object Versions {
   val bq = "1.120.0"
   val hadoop = "3.3.0"
   val h2 = "1.4.200" // Test only
-  val poi = "5.0.0"
+  val poi = "4.1.2"
   val scalate = "1.9.6"
   val akkaHttp = "10.1.14"
 //  val akkaStream = "2.6.12"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -72,7 +72,7 @@ grouped = ${?COMET_GROUPED}
 load-strategy-class = "com.ebiznext.comet.job.load.IngestionTimeStrategy"
 load-strategy-class = ${?COMET_LOAD_STRATEGY}
 
-sink-to-file = true
+sink-to-file = false
 sink-to-file = ${?COMET_SINK_TO_FILE}
 
 # Save Format in CSV with coalesce(1)

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -94,7 +94,8 @@ trait IngestionJob extends SparkJob {
     val start = Timestamp.from(Instant.now())
     IngestionUtil.sinkRejected(session, rejectedRDD, domainName, schemaName, now) match {
       case Success((rejectedDF, rejectedPath)) =>
-        if (settings.comet.sinkToFile)
+        // We sink to a file when running unit tests
+        if (settings.comet.sinkToFile) {
           sinkToFile(
             rejectedDF,
             rejectedPath,
@@ -103,6 +104,20 @@ trait IngestionJob extends SparkJob {
             merge = false,
             settings.comet.defaultRejectedWriteFormat
           )
+        } else {
+          settings.comet.audit.sink match {
+            case _: NoneSink | FsSink(_, _) =>
+              sinkToFile(
+                rejectedDF,
+                rejectedPath,
+                WriteMode.APPEND,
+                StorageArea.rejected,
+                merge = false,
+                settings.comet.defaultRejectedWriteFormat
+              )
+            case _ => // do nothing
+          }
+        }
         val end = Timestamp.from(Instant.now())
         val log = AuditLog(
           session.sparkContext.applicationId,
@@ -255,7 +270,7 @@ trait IngestionJob extends SparkJob {
     }
     logger.info("Final Dataframe Schema")
     finalMergedDf.printSchema()
-    val savedDataset =
+    val savedInFileDataset =
       if (settings.comet.sinkToFile)
         sinkToFile(
           finalMergedDf,
@@ -267,6 +282,22 @@ trait IngestionJob extends SparkJob {
         )
       else
         finalMergedDf
+
+    val sinkType = metadata.getSink().map(_.`type`)
+    val savedDataset = sinkType.getOrElse(SinkType.None) match {
+      case SinkType.FS | SinkType.None if !settings.comet.sinkToFile =>
+        // TODO do this inside the sink function below
+        sinkToFile(
+          finalMergedDf,
+          acceptedPath,
+          writeMode,
+          StorageArea.accepted,
+          schema.merge.isDefined,
+          settings.comet.defaultWriteFormat
+        )
+      case _ =>
+        savedInFileDataset
+    }
     logger.info("Saved Dataset Schema")
     savedDataset.printSchema()
     sink(finalMergedDf) match {
@@ -397,8 +428,9 @@ trait IngestionJob extends SparkJob {
                 throw e
             }
           }
-        case SinkType.None =>
-          // ignore
+        case SinkType.None | SinkType.FS =>
+          // Done in the caller
+          // TODO do it here instead
           logger.trace("not producing an index, as requested (no sink or sink at None explicitly)")
       }
     }
@@ -432,7 +464,7 @@ trait IngestionJob extends SparkJob {
           if (writeMode.toSaveMode == SaveMode.Overwrite)
             session.sql(s"drop table if exists $hiveDB.$tableName")
         } match {
-          case Success(dataframe) => ;
+          case Success(_) => ;
           case Failure(e) =>
             logger.warn("Ignore error when hdfs files not found")
             Utils.logException(logger, e)
@@ -885,7 +917,7 @@ object IngestionUtil {
       .createDataFrame(
         rejectedTypedRDD.toDF().rdd,
         StructType(
-          rejectedCols.map { case (attrName, sqlType, sparkType) =>
+          rejectedCols.map { case (attrName, _, sparkType) =>
             StructField(attrName, sparkType, nullable = false)
           }
         )
@@ -928,6 +960,8 @@ object IngestionUtil {
           // TODO Sink Rejected Log to ES
           throw new Exception("Sinking Audit log to Elasticsearch not yet supported")
         case _: NoneSink | FsSink(_, _) =>
+          // We save in the caller
+          // TODO rewrite this one
           Success(())
       }
     res match {

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -336,6 +336,7 @@ trait IngestionJob extends SparkJob {
           Step.SINK_ACCEPTED.toString
         )
         SparkAuditLogWriter.append(session, log)
+        throw exception
     }
     (savedDataset, acceptedPath)
   }

--- a/src/test/resources/application-test.conf
+++ b/src/test/resources/application-test.conf
@@ -12,6 +12,8 @@ archive = true
 
 file-system = "file://"
 
+sink-to-file=true
+
 hive = false
 
 grouped = true


### PR DESCRIPTION
## Summary
Historically, file sink was the only option and thus was treated a little bit differently than other sinks.

File sink while still the default is now controlled by the sink tag in the YAML file. The option sink-to-file is removed and used for testing purpose only.



**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**

