### PR TITLE
Feature/multifile schema

### DIFF
--- a/src/main/scala/com/ebiznext/comet/schema/generator/DDL2Yml.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/DDL2Yml.scala
@@ -255,6 +255,7 @@ object DDL2Yml extends LazyLogging {
         jdbcSchema.schema,
         incomingDir,
         domainTemplate.flatMap(_.metadata),
+        None,
         cometSchema.toList,
         None,
         domainTemplate.flatMap(_.extensions),

--- a/src/main/scala/com/ebiznext/comet/schema/generator/YamlSerializer.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/generator/YamlSerializer.scala
@@ -2,7 +2,7 @@ package com.ebiznext.comet.schema.generator
 
 import better.files.File
 import com.ebiznext.comet.config.Settings
-import com.ebiznext.comet.schema.model.{AutoJobDesc, Domain}
+import com.ebiznext.comet.schema.model.{AutoJobDesc, Domain, Schemas}
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
@@ -55,6 +55,16 @@ object YamlSerializer extends LazyLogging {
   def serializeToFile(targetFile: File, domain: Domain): Unit = {
     case class Load(load: Domain)
     mapper.writeValue(targetFile.toJava, Load(domain))
+  }
+
+  def deserializeSchemas(content: String, path: String): Schemas = {
+    Try {
+      mapper.readValue(content, classOf[Schemas])
+    } match {
+      case Success(value) => value
+      case Failure(exception) =>
+        throw new Exception(s"Invalid Schema file: $path(${exception.getMessage})")
+    }
   }
 
   def deserializeDomain(content: String, path: String): Try[Domain] = {

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/InferSchemaHandler.scala
@@ -143,7 +143,7 @@ object InferSchemaHandler {
     schemas: List[Schema] = Nil
   ): Domain = {
 
-    Domain(name, directory, metadata, schemas)
+    Domain(name, directory, metadata, None, schemas)
   }
 
   /** *

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
@@ -33,6 +33,8 @@ import org.apache.hadoop.fs.Path
 import scala.util.{Failure, Success, Try}
 import com.ebiznext.comet.utils.Formatter._
 
+import java.util.regex.Pattern
+
 /** Handles access to datasets metadata,  eq. domains / types / schemas.
   *
   * @param storage : Underlying filesystem manager
@@ -161,9 +163,36 @@ class SchemaHandler(storage: StorageHandler)(implicit settings: Settings) extend
   @throws[Exception]
   lazy val domains: List[Domain] = {
     val (validDomainsFile, invalidDomainsFiles) = storage
-      .list(DatasetArea.domains, ".yml", recursive = true)
+      .list(
+        DatasetArea.domains,
+        extension = ".yml",
+        recursive = true,
+        exclude = Some(Pattern.compile("_.*"))
+      )
       .map { path =>
-        YamlSerializer.deserializeDomain(storage.read(path).richFormat(activeEnv), path.toString)
+        val domain =
+          YamlSerializer.deserializeDomain(storage.read(path).richFormat(activeEnv), path.toString)
+        domain match {
+          case Success(domain) =>
+            val folder = path.getParent()
+            val schemaRefs = domain.schemaRefs
+              .getOrElse(Nil)
+              .map { ref =>
+                if (!ref.startsWith("_"))
+                  throw new Exception(
+                    s"reference to a schema should start with '_' in domain ${domain.name} in $path for schema ref $ref"
+                  )
+                val schemaPath = new Path(folder, ref)
+                YamlSerializer.deserializeSchemas(
+                  storage.read(schemaPath).richFormat(activeEnv),
+                  schemaPath.toString
+                )
+              }
+              .flatMap(_.schemas)
+            Success(domain.copy(schemas = domain.schemas ::: schemaRefs))
+          case Failure(e) =>
+            Failure(e)
+        }
       }
       .partition(_.isSuccess)
 

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
@@ -182,7 +182,9 @@ class SchemaHandler(storage: StorageHandler)(implicit settings: Settings) extend
                   throw new Exception(
                     s"reference to a schema should start with '_' in domain ${domain.name} in $path for schema ref $ref"
                   )
-                val schemaPath = new Path(folder, ref)
+                val refFullName =
+                  if (ref.endsWith(".yml") || ref.endsWith(".yaml")) ref else ref + ".comet.yml"
+                val schemaPath = new Path(folder, refFullName)
                 YamlSerializer.deserializeSchemas(
                   storage.read(schemaPath).richFormat(activeEnv),
                   schemaPath.toString

--- a/src/main/scala/com/ebiznext/comet/schema/model/Domain.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Domain.scala
@@ -59,6 +59,7 @@ case class Domain(
   name: String,
   directory: String,
   metadata: Option[Metadata] = None,
+  schemaRefs: Option[List[String]] = None,
   schemas: List[Schema] = Nil,
   comment: Option[String] = None,
   extensions: Option[List[String]] = None,

--- a/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Schema.scala
@@ -362,3 +362,5 @@ object Schema {
   }
 
 }
+
+case class Schemas(schemas: List[Schema])

--- a/src/test/resources/sample/schema-refs/WITH_REF.comet.yml
+++ b/src/test/resources/sample/schema-refs/WITH_REF.comet.yml
@@ -1,0 +1,43 @@
+---
+load:
+  name: "WITH_REF"
+  directory: "__COMET_TEST_ROOT__/DOMAIN"
+  metadata:
+    mode: "FILE"
+    format: "DSV"
+    withHeader: false
+    separator: ";"
+    quote: "\""
+    escape: "\\"
+    write: "APPEND"
+    partition:
+      attributes:
+        - comet_year
+        - comet_month
+        - comet_day
+    sink:
+      type: ES
+  schemaRefs:
+    - _users.comet.yml
+    - _players
+  schemas:
+    - name: "employee"
+      pattern: "employee.*.csv"
+      attributes:
+        - name: "name"
+          type: "string"
+          privacy: "None"
+          required: false
+        - name: "age"
+          type: "int"
+          privacy: "None"
+          required: false
+      postsql:
+        - "Select name from COMET_TABLE"
+      metadata:
+        mode: "FILE"
+        format: "DSV"
+        withHeader: false
+        separator: ","
+        partition:
+          attributes: []

--- a/src/test/resources/sample/schema-refs/_players.comet.yml
+++ b/src/test/resources/sample/schema-refs/_players.comet.yml
@@ -1,0 +1,54 @@
+schemas:
+  - name: "Players"
+    pattern: "Players.*.csv"
+    attributes:
+      - name: "PK"
+        type: "string"
+        array: false
+        required: true
+        privacy: "NONE"
+        metricType: "NONE"
+      - name: "firstName"
+        type: "string"
+        array: false
+        required: true
+        privacy: "NONE"
+        metricType: "NONE"
+      - name: "lastName"
+        type: "string"
+        array: false
+        required: true
+        privacy: "NONE"
+        metricType: "NONE"
+      - name: "DOB"
+        type: "date"
+        array: false
+        required: true
+        privacy: "NONE"
+      - name: "YEAR"
+        type: "string"
+        array: false
+        required: false
+        privacy: "NONE"
+      - name: "MONTH"
+        type: "string"
+        array: false
+        required: false
+        privacy: "NONE"
+    metadata:
+      mode: "FILE"
+      format: "DSV"
+      encoding: "UTF-8"
+      multiline: false
+      withHeader: false
+      separator: ","
+      quote: "\""
+      escape: "\\"
+      write: "OVERWRITE"
+      partition:
+        attributes:
+          - "YEAR"
+          - "MONTH"
+    merge:
+      key:
+        - "PK"

--- a/src/test/resources/sample/schema-refs/_users.comet.yml
+++ b/src/test/resources/sample/schema-refs/_users.comet.yml
@@ -1,0 +1,33 @@
+schemas:
+  - name: "User"
+    pattern: "SCHEMA-.*.dsv"
+    attributes:
+      - name: "first name"
+        rename: "firstname"
+        type: "string"
+        required: false
+        privacy: "NONE"
+      - name: "last name"
+        rename: "lastname"
+        type: "string"
+        required: false
+        privacy: "MD5"
+      - name: "age"
+        rename: "age"
+        type: "int"
+        metricType: "discrete"
+        required: false
+        privacy: "NONE"
+      - name: "ok"
+        type: "boolean"
+        required: false
+        privacy: "NONE"
+        default: true
+    metadata:
+      mode: "FILE"
+      format: "DSV"
+      withHeader: true
+      separator: ";"
+      quote: "\""
+      escape: "\\"
+      write: "APPEND"

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/SchemaHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/SchemaHandlerSpec.scala
@@ -648,6 +648,36 @@ class SchemaHandlerSpec extends TestHelper {
       }
 
     }
+    "Schema with external refs" should "produce import external refs into domain" in {
+      new SpecTrait(
+        domainOrJobFilename = "DOMAIN.comet.yml",
+        sourceDomainOrJobPathname = s"/sample/schema-refs/WITH_REF.comet.yml",
+        datasetDomainName = "WITH_REF",
+        sourceDatasetPathName = "/sample/Players.csv"
+      ) {
+        cleanMetadata
+        cleanDatasets
+
+        withSettings.deliverTestFile(
+          "/sample/schema-refs/_players.comet.yml",
+          new Path(domainMetadataRootPath, "_players.comet.yml")
+        )
+
+        withSettings.deliverTestFile(
+          "/sample/schema-refs/_users.comet.yml",
+          new Path(domainMetadataRootPath, "_users.comet.yml")
+        )
+        val schemaHandler = new SchemaHandler(settings.storageHandler)
+        schemaHandler
+          .getDomain("WITH_REF")
+          .map(_.schemas.map(_.name))
+          .get should contain theSameElementsAs List(
+          "User",
+          "Players",
+          "employee"
+        )
+      }
+    }
 
   }
 }

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
@@ -55,6 +55,7 @@ class StorageHandlerSpec extends TestHelper {
             None
           )
         ),
+        None,
         List(
           Schema(
             "User",


### PR DESCRIPTION
## Summary
Domains support now the schema ref syntax as described below:---
```
load:
  name: "WITH_REF"
  directory: "__COMET_TEST_ROOT__/DOMAIN"
  metadata:
    mode: "FILE"
    format: "DSV"
    withHeader: false
    separator: ";"
    quote: "\""
    escape: "\\"
    write: "APPEND"
    partition:
      attributes:
        - comet_year
        - comet_month
        - comet_day
    sink:
      type: ES
  schemaRefs:
    - _users.comet.yml
    - _players
  schemas:
   ...
```


Note that the file extension is optional in the schemaRefs section. It will be automatically added before loading.

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**

