### PR TITLE
Support Query pushdown

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@ __New feature__:
 - Support XML Schema inference
 - Support the ability to reject the whole file on error
 - Improve error reporting
+- Support engine on task SQL (query pushdown to BigQuery)
 
 __Bug Fix__:
 - Loading empty files when the schema contains script fields

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,8 @@ __New feature__:
 - Support the ability to reject the whole file on error
 - Improve error reporting
 - Support engine on task SQL (query pushdown to BigQuery)
+- Added env var to control BigQuery materialization on pushdown queries COMET_SPARK_BIGQUERY_MATERIALIZATION_PROJECT, COMET_SPARK_BIGQUERY_MATERIALIZATION_DATASET (default to materalization)
+- Added env var to control BigQuery read data format COMET_SPARK_BIGQUERY_READ_DATA_FORMAT (default to AVRO)
 
 __Bug Fix__:
 - Loading empty files when the schema contains script fields

--- a/project/Definition.scala
+++ b/project/Definition.scala
@@ -30,16 +30,21 @@ trait Definition {
 
   /** Creates a library module
     *
-    * @param name the name of the module, will be used as the module's root folder name
-    * @return the module's `Project`
+    * @param name
+    *   the name of the module, will be used as the module's root folder name
+    * @return
+    *   the module's `Project`
     */
   def library(name: String): Project = library(name, file(name))
 
   /** Creates a library sub project
     *
-    * @param name the name of the project
-    * @param src  the module's root folder
-    * @return the module's `Project`
+    * @param name
+    *   the name of the project
+    * @param src
+    *   the module's root folder
+    * @return
+    *   the module's `Project`
     */
   def library(name: String, src: File): Project =
     sbt

--- a/src/main/resources/reference-spark.conf
+++ b/src/main/resources/reference-spark.conf
@@ -13,6 +13,13 @@ spark {
   #  sql.catalogImplementation="in-memory"
   sql.legacy.parquet.datetimeRebaseModeInWrite = "CORRECTED"
   sql.streaming.checkpointLocation = "/tmp"
-  viewsEnabled = "true"
+
+  datasource.bigquery {
+    viewsEnabled = "true"
+    # materializationProject
+    # materializationDataset
+    # materializationExpirationTimeInMinutes (DEFAULT_MATERIALIZATION_EXPRIRATION_TIME_IN_MINUTES = 24 * 60)
+    readDataFormat = "AVRO"
+  }
 }
 

--- a/src/main/resources/reference-spark.conf
+++ b/src/main/resources/reference-spark.conf
@@ -16,10 +16,12 @@ spark {
 
   datasource.bigquery {
     viewsEnabled = "true"
-    # materializationProject
-    # materializationDataset
+    materializationProject = ${?COMET_SPARK_BIGQUERY_MATERIALIZATION_PROJECT}
+    materializationDataset = "materialization"
+    materializationDataset = ${?COMET_SPARK_BIGQUERY_MATERIALIZATION_DATASET}
     # materializationExpirationTimeInMinutes (DEFAULT_MATERIALIZATION_EXPRIRATION_TIME_IN_MINUTES = 24 * 60)
     readDataFormat = "AVRO"
+    readDataFormat = ${?COMET_SPARK_BIGQUERY_READ_DATA_FORMAT}
   }
 }
 

--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTaskJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTaskJob.scala
@@ -29,7 +29,6 @@ import com.ebiznext.comet.job.index.bqload.{
 import com.ebiznext.comet.job.ingest.{AuditLog, SparkAuditLogWriter, Step}
 import com.ebiznext.comet.job.metrics.AssertionJob
 import com.ebiznext.comet.schema.handlers.{SchemaHandler, StorageHandler}
-import com.ebiznext.comet.schema.model.Engine.SPARK
 import com.ebiznext.comet.schema.model._
 import com.ebiznext.comet.utils.Formatter._
 import com.ebiznext.comet.utils.{JobResult, SparkJob, SparkJobResult, Utils}

--- a/src/main/scala/com/ebiznext/comet/job/transform/AutoTaskJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/transform/AutoTaskJob.scala
@@ -236,7 +236,7 @@ case class AutoTaskJob(
       val (preSql, sqlWithParameters, postSql) = buildQuerySpark()
 
       preSql.foreach(req => session.sql(req))
-      logger.info(s"running sql request $sqlWithParameters wusing ${task.engine}")
+      logger.info(s"running sql request $sqlWithParameters using ${task.engine}")
 
       val dataframe =
         task.engine.getOrElse(Engine.SPARK) match {
@@ -249,6 +249,7 @@ case class AutoTaskJob(
           case Engine.JDBC =>
             logger.warn("JDBC Engine not supported on job task. Running query using Spark Engine")
             session.sql(sqlWithParameters)
+          case _ => throw new Exception("should never happen")
         }
 
       val targetPath = task.getTargetPath(defaultArea)

--- a/src/main/scala/com/ebiznext/comet/schema/model/AutoJobDesc.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/AutoJobDesc.scala
@@ -60,7 +60,8 @@ case class AutoTaskDesc(
   area: Option[StorageArea] = None,
   sink: Option[Sink] = None,
   rls: Option[List[RowLevelSecurity]] = None,
-  assertions: Option[Map[String, String]] = None
+  assertions: Option[Map[String, String]] = None,
+  engine: Option[Engine] = None
 ) {
 
   @JsonIgnore

--- a/src/main/scala/com/ebiznext/comet/schema/model/Views.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Views.scala
@@ -1,6 +1,6 @@
 package com.ebiznext.comet.schema.model
 
-/** Thisi tag appears in files and allow import of views and assertions definitions into the current
+/** This tag appears in files and allow import of views and assertions definitions into the current
   * files.
   * @param assertions
   *   : List of assertion definitions to include


### PR DESCRIPTION
## Summary
Using the task.engine YAML tag we are now able to push the entire query to BigQuery.
Previously we were able to push the entire job including the sink action to the backend.
This feature allow us to keep spark doing the sinking while delegating the query execution to the backend engine. This is useful when we want use dynamic parititioning currently not supported by some backend like BigQuery

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**



