### PR TITLE
Handle correctly audit lock

### DIFF
--- a/src/main/scala/com/ebiznext/comet/utils/FileLock.scala
+++ b/src/main/scala/com/ebiznext/comet/utils/FileLock.scala
@@ -108,7 +108,6 @@ class FileLock(path: Path, storageHandler: StorageHandler) extends StrictLogging
             } match {
               case Success(lastModified) =>
                 val currentTimeMillis = System.currentTimeMillis()
-
                 logger.info(s"""
                                |lastModified=$lastModified
                                |System.currentTimeMillis()=${currentTimeMillis}

--- a/src/main/scala/com/ebiznext/comet/utils/FileLock.scala
+++ b/src/main/scala/com/ebiznext/comet/utils/FileLock.scala
@@ -102,12 +102,11 @@ class FileLock(path: Path, storageHandler: StorageHandler) extends StrictLogging
             watch()
             true
           case Failure(e) =>
-            logger.info(s"Audit lock already in use waiting ... ${path.toString} ${e.getMessage}")
+            logger.info(s"Audit lock ${path.toString} already in use waiting ...  ${e.getMessage}")
             Try {
               storageHandler.lastModified(path)
             } match {
-              case Success(lastModified) => // do nothing
-                storageHandler.lastModified(path)
+              case Success(lastModified) =>
                 val currentTimeMillis = System.currentTimeMillis()
 
                 logger.info(s"""
@@ -115,7 +114,7 @@ class FileLock(path: Path, storageHandler: StorageHandler) extends StrictLogging
                                |System.currentTimeMillis()=${currentTimeMillis}
                                |checkinPeriod*4=${checkinPeriod * 4}
                                |refreshPeriod*4=${refreshPeriod * 4}
-          """.stripMargin)
+                               |""".stripMargin)
                 if ((currentTimeMillis - lastModified) > (refreshPeriod * 4)) {
                   storageHandler.delete(path)
                 }


### PR DESCRIPTION
## Summary
The audit lock may be deleted between the time it is detected and the time we access its last modification date.
**Related Issue: #584 **

**PR Type: Bug**

**Status: Ready to review**

**Breaking change? No**

