### PR TITLE
Validate on load implementation

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -7,7 +7,7 @@ metadata-file-system = ${?COMET_METADATA_FS}
 validate-on-load = false
 validate-on-load = ${?COMET_VALIDATE_ON_LOAD}
 
-  root = "/tmp"
+root = "/tmp"
 root = ${?COMET_ROOT}
 
 datasets = ${root}"/datasets"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -4,8 +4,10 @@ file-system = ${?COMET_FS}
 metadata-file-system = ${file-system}
 metadata-file-system = ${?COMET_METADATA_FS}
 
+validate-on-load = false
+validate-on-load = ${?COMET_VALIDATE_ON_LOAD}
 
-root = "/tmp"
+  root = "/tmp"
 root = ${?COMET_ROOT}
 
 datasets = ${root}"/datasets"

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -243,6 +243,7 @@ object Settings extends StrictLogging {
     datasets: String,
     metadata: String,
     metrics: Metrics,
+    validateOnLoad: Boolean,
     audit: Audit,
     archive: Boolean,
     sinkToFile: Boolean,

--- a/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/handlers/SchemaHandler.scala
@@ -206,7 +206,8 @@ class SchemaHandler(storage: StorageHandler)(implicit settings: Settings) extend
         logger.error(
           s"There is one or more invalid Yaml files in your domains folder:${err.getMessage}"
         )
-        throw err
+        if (settings.comet.validateOnLoad)
+          throw err
       case Success(_) => // ignore
     }
 
@@ -314,7 +315,8 @@ class SchemaHandler(storage: StorageHandler)(implicit settings: Settings) extend
         logger.error(
           s"There is one or more invalid Yaml files in your jobs folder:${err.getMessage}"
         )
-        throw err
+        if (settings.comet.validateOnLoad)
+          throw err
       case Success(_) => // do nothing
     }
 


### PR DESCRIPTION
## Summary
we add a new command comet validate that exit the program with an error and print error only when any other command is run. In your DAG you would need to put a extra task that run comet validate first.

We add  an extra option COMET_VALIDATE_ON_LOAD, if set would stop the process or else simply print error message.


**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**

