### PR TITLE
Bug fix/load landing without extension

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,7 @@ __Bug Fix__:
 - Remove duplicates on incoming when existingDF does not exist or is empty
 - Parse Sink options correctly 
 - Handle extreme cases where audit lock raise an exception on creation
+- Handle files without extension in the landing zone
 
 # 0.2.4 / 0.2.5
 __Bug Fix__:

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -81,71 +81,68 @@ class IngestionWorkflow(
     logger.info("LoadLanding")
     domains.foreach { domain =>
       val storageHandler = settings.storageHandler
-      val inputDir = new Path(domain.directory)
+      val inputDir =
+        storageHandler.fs.resolvePath(new Path(domain.directory)) // restore scheme if missing
       if (storageHandler.exists(inputDir)) {
         logger.info(s"Scanning $inputDir")
         storageHandler.list(inputDir, domain.getAck(), recursive = false).foreach { path =>
-          val ackFile = path
-          val fileStr = ackFile.toString
-          val prefixStr =
-            if (domain.getAck().isEmpty) fileStr.substring(0, fileStr.lastIndexOf('.'))
-            else fileStr.stripSuffix(domain.getAck())
-          val tmpDir = new Path(prefixStr)
-          val rawFormats =
-            if (domain.getAck().isEmpty) List(ackFile)
-            else
-              domain.getExtensions().map(ext => new Path(prefixStr + ext))
-          val existRawFile = rawFormats.find(file => storageHandler.exists(file))
-          logger.info(s"Found ack file $ackFile")
-          val zipExtensions = List(".tgz", ".gz", ".zip")
-          val isZip = zipExtensions.exists(ext => path.toString.endsWith(ext))
-          if (domain.getAck().nonEmpty)
-            storageHandler.delete(ackFile)
-          if (!isZip && existRawFile.isDefined) {
-            existRawFile.foreach { file =>
-              logger.info(s"Found raw file $existRawFile")
-              storageHandler.mkdirs(tmpDir)
-              val tmpFile = new Path(tmpDir, file.getName)
-              storageHandler.move(file, tmpFile)
-            }
-          } else if (storageHandler.fs.getScheme == "file") {
-            storageHandler.mkdirs(tmpDir)
-            val tgz = new Path(prefixStr + ".tgz")
-            val gz = new Path(prefixStr + ".gz")
-            val zip = new Path(prefixStr + ".zip")
-            val tmpFile = Path.getPathWithoutSchemeAndAuthority(tmpDir).toString
-            if (storageHandler.exists(gz)) {
-              logger.info(s"Found compressed file $gz")
+          val (filesToLoad, tmpDir) = {
+            val pathWithoutExt = new Path(
+              inputDir,
+              if (domain.getAck().isEmpty)
+                File(path.toUri).nameWithoutExtension(true)
+              else path.getName.stripSuffix(domain.getAck())
+            )
 
-              File(Path.getPathWithoutSchemeAndAuthority(gz).toString)
-                .unGzipTo(File(tmpFile, File(prefixStr).name))
-              storageHandler.delete(gz)
-            } else if (storageHandler.exists(tgz)) {
-              logger.info(s"Found compressed file $tgz")
-              Unpacker
-                .unpack(File(Path.getPathWithoutSchemeAndAuthority(tgz).toString), File(tmpFile))
-              storageHandler.delete(tgz)
-            } else if (storageHandler.exists(zip)) {
-              logger.info(s"Found compressed file $zip")
-              File(Path.getPathWithoutSchemeAndAuthority(zip).toString)
-                .unzipTo(File(tmpFile))
-              storageHandler.delete(zip)
+            val existingRawFile =
+              if (domain.getAck().isEmpty) Some(path)
+              else
+                domain
+                  .getExtensions()
+                  .map(ext => pathWithoutExt.suffix(ext))
+                  .find(file => storageHandler.exists(file))
+            val foundZipExtension =
+              List(".gz", ".tgz", ".zip").find(ext => path.getName.endsWith(ext))
+
+            if (foundZipExtension.isEmpty && existingRawFile.isDefined) {
+              logger.info(s"Found raw file ${existingRawFile.get}")
+              (existingRawFile.toList, None)
+            } else if (foundZipExtension.isDefined && storageHandler.fs.getScheme == "file") {
+              val zipPath = pathWithoutExt.suffix(foundZipExtension.get)
+              if (storageHandler.exists(zipPath)) {
+                logger.info(s"Found compressed file $zipPath")
+                storageHandler.mkdirs(pathWithoutExt)
+
+                // File is a proxy to java.nio.Path / working with Uri
+                val tmpDir = File(pathWithoutExt.toUri)
+                val zipFile = File(zipPath.toUri)
+                foundZipExtension.get match {
+                  case ".tgz" => Unpacker.unpack(zipFile, tmpDir)
+                  case ".gz"  => zipFile.unGzipTo(tmpDir / pathWithoutExt.getName)
+                  case ".zip" => zipFile.unzipTo(tmpDir)
+                }
+                storageHandler.delete(zipPath)
+
+                (storageHandler.list(pathWithoutExt, recursive = false), Some(pathWithoutExt))
+              } else {
+                logger.error(s"No archive found for ack $path")
+                (List.empty, None)
+              }
             } else {
-              logger.error(s"No archive found for ack ${ackFile.toString}")
+              logger.error(s"No file found for ack $path")
+              (List.empty, None)
             }
-          } else {
-            logger.error(s"No file found for ack ${ackFile.toString}")
           }
-          if (storageHandler.exists(tmpDir)) {
-            val destFolder = DatasetArea.pending(domain.name)
-            storageHandler.list(tmpDir, recursive = false).foreach { file =>
-              val source = new Path(file.toString)
-              logger.info(s"Importing ${file.toString}")
-              val destFile = new Path(destFolder, file.getName)
-              storageHandler.moveFromLocal(source, destFile)
-            }
-            storageHandler.delete(tmpDir)
+
+          val destFolder = DatasetArea.pending(domain.name)
+          filesToLoad.foreach { file =>
+            logger.info(s"Importing $file")
+            val destFile = new Path(destFolder, file.getName)
+            storageHandler.moveFromLocal(file, destFile)
           }
+
+          if (tmpDir.isDefined)
+            storageHandler.delete(tmpDir.get)
         }
       } else {
         logger.error(s"Input path : $inputDir not found, ${domain.name} Domain is ignored")

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -106,6 +106,9 @@ class IngestionWorkflow(
               (findPathWithExt(domain.getExtensions()), findPathWithExt(zipExtensions))
             }
 
+            if (domain.getAck().nonEmpty)
+              storageHandler.delete(path)
+
             (existingArchiveFile, existingRawFile, storageHandler.fs.getScheme) match {
               case (Some(zipPath), _, "file") =>
                 logger.info(s"Found compressed file $zipPath")

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -90,7 +90,7 @@ class IngestionWorkflow(
             val pathWithoutExt = new Path(
               inputDir,
               if (domain.getAck().isEmpty)
-                File(path.toUri).nameWithoutExtension(true)
+                File(path.toUri).nameWithoutExtension(false)
               else path.getName.stripSuffix(domain.getAck())
             )
 

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -147,7 +147,7 @@ class IngestionWorkflow(
             storageHandler.moveFromLocal(file, destFile)
           }
 
-          tmpDir.map(storageHandler.delete)
+          tmpDir.foreach(storageHandler.delete)
         }
       } else {
         logger.error(s"Input path : $inputDir not found, ${domain.name} Domain is ignored")

--- a/src/test/resources/sample/DOMAIN-ACK.comet.yml
+++ b/src/test/resources/sample/DOMAIN-ACK.comet.yml
@@ -1,0 +1,132 @@
+---
+name: "DOMAIN"
+directory: "__COMET_TEST_ROOT__/DOMAIN"
+metadata:
+  mode: "FILE"
+  format: "DSV"
+  withHeader: false
+  separator: ";"
+  quote: "\""
+  escape: "\\"
+  write: "APPEND"
+  partition:
+    attributes:
+      - comet_year
+      - comet_month
+      - comet_day
+  sink:
+    type: ES
+ack: "ack"
+schemas:
+  - name: "User"
+    pattern: "SCHEMA-.*.dsv"
+    attributes:
+      - name: "first name"
+        rename: "firstname"
+        type: "string"
+        required: false
+        privacy: "NONE"
+      - name: "last name"
+        rename: "lastname"
+        type: "string"
+        required: false
+        privacy: "MD5"
+      - name: "age"
+        rename: "age"
+        type: "int"
+        metricType: "discrete"
+        required: false
+        privacy: "NONE"
+      - name: "ok"
+        type: "boolean"
+        required: false
+        privacy: "NONE"
+        default: true
+    metadata:
+      mode: "FILE"
+      format: "DSV"
+      withHeader: true
+      separator: ";"
+      quote: "\""
+      escape: "\\"
+      write: "APPEND"
+  - name: "Players"
+    pattern: "Players.*.csv"
+    attributes:
+      - name: "PK"
+        type: "string"
+        array: false
+        required: true
+        privacy: "NONE"
+        metricType: "NONE"
+      - name: "firstName"
+        type: "string"
+        array: false
+        required: true
+        privacy: "NONE"
+        metricType: "NONE"
+      - name: "lastName"
+        type: "string"
+        array: false
+        required: true
+        privacy: "NONE"
+        metricType: "NONE"
+      - name: "DOB"
+        type: "date"
+        array: false
+        required: true
+        privacy: "NONE"
+      - name: "YEAR"
+        type: "string"
+        array: false
+        required: false
+        privacy: "NONE"
+      - name: "MONTH"
+        type: "string"
+        array: false
+        required: false
+        privacy: "NONE"
+    metadata:
+      mode: "FILE"
+      format: "DSV"
+      encoding: "UTF-8"
+      multiline: false
+      withHeader: false
+      separator: ","
+      quote: "\""
+      escape: "\\"
+      write: "OVERWRITE"
+      partition:
+        attributes:
+          - "YEAR"
+          - "MONTH"
+    merge:
+      key:
+        - "PK"
+  - name: "employee"
+    pattern: "employee.*.csv"
+    attributes:
+      - name: "name"
+        type: "string"
+        privacy: "None"
+        required: false
+      - name: "age"
+        type: "int"
+        privacy: "None"
+        required: false
+      - name: "fileName"
+        type: "string"
+        script: "comet_input_file_name"
+        privacy: None
+        required: false
+    postsql:
+      - "Select name from COMET_TABLE"
+    metadata:
+      mode: "FILE"
+      format: "DSV"
+      withHeader: false
+      separator: ","
+      partition:
+        attributes: []
+      sink:
+        type: None

--- a/src/test/scala/com/ebiznext/comet/TestHelper.scala
+++ b/src/test/scala/com/ebiznext/comet/TestHelper.scala
@@ -158,7 +158,7 @@ trait TestHelper extends AnyFlatSpec with Matchers with BeforeAndAfterAll with S
   def readFileContent(path: Path): String = readFileContent(path.toUri.getPath)
 
   def applyTestFileSubstitutions(fileContent: String): String = {
-    fileContent.replaceAll("COMET_TEST_ROOT", cometTestRoot)
+    fileContent.replaceAll("__COMET_TEST_ROOT__", cometTestRoot)
   }
 
   def withSettings(configuration: Config)(op: Settings => Assertion): Assertion =

--- a/src/test/scala/com/ebiznext/comet/TestHelper.scala
+++ b/src/test/scala/com/ebiznext/comet/TestHelper.scala
@@ -351,7 +351,8 @@ trait TestHelper extends AnyFlatSpec with Matchers with BeforeAndAfterAll with S
       val targetPath = new Path(incomingDirectory.get, new Path(sourceDatasetPathName).getName)
       withSettings.deliverBinaryFile(sourceDatasetPathName, targetPath)
       storageHandler.touchz(
-        new Path(targetPath.toString.substring(0, targetPath.toString.lastIndexOf('.')) + ".ack")
+        new Path(targetPath.getParent, targetPath.getName.replaceFirst("\\.[^.]+$", ""))
+          .suffix(".ack")
       )
 
       // Load landing file

--- a/src/test/scala/com/ebiznext/comet/TestHelper.scala
+++ b/src/test/scala/com/ebiznext/comet/TestHelper.scala
@@ -336,7 +336,7 @@ trait TestHelper extends AnyFlatSpec with Matchers with BeforeAndAfterAll with S
         .map(_.directory)
         .getOrElse(throw new Exception("Incoming directory must be specified in domain descriptor"))
 
-    def loadLanding(implicit codec: Codec): Unit = {
+    def loadLanding(implicit codec: Codec, createAckFile: Boolean = true): Unit = {
 
       val schemaHandler = new SchemaHandler(settings.storageHandler)
 
@@ -350,10 +350,12 @@ trait TestHelper extends AnyFlatSpec with Matchers with BeforeAndAfterAll with S
       // Deliver file to incoming folder
       val targetPath = new Path(incomingDirectory.get, new Path(sourceDatasetPathName).getName)
       withSettings.deliverBinaryFile(sourceDatasetPathName, targetPath)
-      storageHandler.touchz(
-        new Path(targetPath.getParent, targetPath.getName.replaceFirst("\\.[^.]+$", ""))
-          .suffix(".ack")
-      )
+      if (createAckFile) {
+        storageHandler.touchz(
+          new Path(targetPath.getParent, targetPath.getName.replaceFirst("\\.[^.]+$", ""))
+            .suffix(".ack")
+        )
+      }
 
       // Load landing file
       val validator = new IngestionWorkflow(storageHandler, schemaHandler, new SimpleLauncher())

--- a/src/test/scala/com/ebiznext/comet/workflow/IngestionWorkflowSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/workflow/IngestionWorkflowSpec.scala
@@ -26,6 +26,11 @@ class IngestionWorkflowSpec extends TestHelper {
         assert(storageHandler.exists(targetFile))
       }
     }
+
+    "Loading files without extension in Landing area" should "produce file in pending area" in {
+      loadLandingFile("/sample/_SUCCESS", "_SUCCESS")
+    }
+
     "Loading files in Landing area" should "produce file in pending area" in {
       loadLandingFile("/sample/SCHEMA-VALID.dsv", "SCHEMA-VALID.dsv")
     }

--- a/src/test/scala/com/ebiznext/comet/workflow/IngestionWorkflowSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/workflow/IngestionWorkflowSpec.scala
@@ -22,7 +22,7 @@ class IngestionWorkflowSpec extends TestHelper {
 
         storageHandler.delete(new Path(landingPath))
         // Make sure unrelated files, even without extensions, are not imported
-        withSettings.deliverTestFile("/sample/_SUCCESS", new Path(landingPath, "_SUCCESS"))
+        storageHandler.touchz(new Path(landingPath, "_SUCCESS"))
 
         loadLanding(Codec.default, createAckFile = false)
         val destFolder: Path = DatasetArea.pending(datasetDomainName)

--- a/src/test/scala/com/ebiznext/comet/workflow/IngestionWorkflowSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/workflow/IngestionWorkflowSpec.scala
@@ -1,13 +1,16 @@
 package com.ebiznext.comet.workflow
 
+import better.files.File
 import com.ebiznext.comet.TestHelper
 import com.ebiznext.comet.config.DatasetArea
 import org.apache.hadoop.fs.Path
 
+import scala.io.Codec
+
 class IngestionWorkflowSpec extends TestHelper {
   new WithSettings() {
 
-    private def loadLandingFile(landingFile: String, pendingFile: String) = {
+    private def loadLandingFile(landingFile: String): TestHelper#SpecTrait = {
       new SpecTrait(
         domainOrJobFilename = "DOMAIN.comet.yml",
         sourceDomainOrJobPathname = "/sample/DOMAIN.comet.yml",
@@ -21,10 +24,16 @@ class IngestionWorkflowSpec extends TestHelper {
         // Make sure unrelated files, even without extensions, are not imported
         withSettings.deliverTestFile("/sample/_SUCCESS", new Path(landingPath, "_SUCCESS"))
 
-        loadLanding
+        loadLanding(Codec.default, createAckFile = false)
         val destFolder: Path = DatasetArea.pending(datasetDomainName)
-        assert(storageHandler.exists(new Path(destFolder, pendingFile)), "Landing file directly imported")
-        assert(!storageHandler.exists(new Path(destFolder, "_SUCCESS")), "Unrelated file ignored")
+        assert(
+          storageHandler.exists(new Path(destFolder, "SCHEMA-VALID.dsv")),
+          "Landing file directly imported"
+        )
+        assert(
+          !storageHandler.exists(new Path(destFolder, "_SUCCESS")),
+          "Unrelated file ignored"
+        )
       }
 
       // Test again, but with Domain.ack defined
@@ -41,24 +50,36 @@ class IngestionWorkflowSpec extends TestHelper {
 
         loadLanding
         val destFolder: Path = DatasetArea.pending(datasetDomainName)
-        assert(storageHandler.exists(new Path(destFolder, pendingFile)), "Landing file based on extension imported")
+        assert(
+          storageHandler.exists(new Path(destFolder, "SCHEMA-VALID.dsv")),
+          "Landing file based on extension imported"
+        )
+        val ackFilename: String = File(landingFile).nameWithoutExtension + ".ack"
+        assert(
+          !storageHandler.exists(new Path(destFolder, ackFilename)),
+          "Ack file not imported"
+        )
+        assert(
+          !storageHandler.exists(new Path(landingPath, ackFilename)),
+          "Ack file removed from landing zone"
+        )
       }
     }
 
     "Loading files in Landing area" should "produce file in pending area" in {
-      loadLandingFile("/sample/SCHEMA-VALID.dsv", "SCHEMA-VALID.dsv")
+      loadLandingFile("/sample/SCHEMA-VALID.dsv")
     }
 
     "Loading zip files in Landing area" should "produce file contained in Zip File in pending area" in {
-      loadLandingFile("/sample/SCHEMA-VALID.dsv.zip", "SCHEMA-VALID.dsv")
+      loadLandingFile("/sample/SCHEMA-VALID.dsv.zip")
     }
 
     "Loading gzip files in Landing area" should "produce file contained in GZ File in pending area" in {
-      loadLandingFile("/sample/SCHEMA-VALID.dsv.gz", "SCHEMA-VALID.dsv")
+      loadLandingFile("/sample/SCHEMA-VALID.dsv.gz")
     }
 
     "Loading tgz files in Landing area" should "produce file contained in tgz File in pending area" in {
-      loadLandingFile("/sample/SCHEMA-VALID.dsv.tgz", "SCHEMA-VALID.dsv")
+      loadLandingFile("/sample/SCHEMA-VALID.dsv.tgz")
     }
   }
 }

--- a/src/test/scala/com/ebiznext/comet/workflow/IngestionWorkflowSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/workflow/IngestionWorkflowSpec.scala
@@ -10,25 +10,39 @@ class IngestionWorkflowSpec extends TestHelper {
     private def loadLandingFile(landingFile: String, pendingFile: String) = {
       new SpecTrait(
         domainOrJobFilename = "DOMAIN.comet.yml",
-        sourceDomainOrJobPathname = s"/sample/DOMAIN.comet.yml",
+        sourceDomainOrJobPathname = "/sample/DOMAIN.comet.yml",
         datasetDomainName = "DOMAIN",
         sourceDatasetPathName = landingFile
       ) {
         cleanMetadata
         cleanDatasets
 
-        loadLanding
-        val destFolder = DatasetArea.pending(datasetDomainName)
-        val targetFile = new Path(
-          destFolder,
-          pendingFile
-        )
-        assert(storageHandler.exists(targetFile))
-      }
-    }
+        storageHandler.delete(new Path(landingPath))
+        // Make sure unrelated files, even without extensions, are not imported
+        withSettings.deliverTestFile("/sample/_SUCCESS", new Path(landingPath, "_SUCCESS"))
 
-    "Loading files without extension in Landing area" should "produce file in pending area" in {
-      loadLandingFile("/sample/_SUCCESS", "_SUCCESS")
+        loadLanding
+        val destFolder: Path = DatasetArea.pending(datasetDomainName)
+        assert(storageHandler.exists(new Path(destFolder, pendingFile)), "Landing file directly imported")
+        assert(!storageHandler.exists(new Path(destFolder, "_SUCCESS")), "Unrelated file ignored")
+      }
+
+      // Test again, but with Domain.ack defined
+      new SpecTrait(
+        domainOrJobFilename = "DOMAIN.comet.yml",
+        sourceDomainOrJobPathname = "/sample/DOMAIN-ACK.comet.yml",
+        datasetDomainName = "DOMAIN",
+        sourceDatasetPathName = landingFile
+      ) {
+        cleanMetadata
+        cleanDatasets
+
+        storageHandler.delete(new Path(landingPath))
+
+        loadLanding
+        val destFolder: Path = DatasetArea.pending(datasetDomainName)
+        assert(storageHandler.exists(new Path(destFolder, pendingFile)), "Landing file based on extension imported")
+      }
     }
 
     "Loading files in Landing area" should "produce file in pending area" in {


### PR DESCRIPTION
## Summary
Comet crashes when the landing zone contains a file without extension

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
Reworked the loadLanding method, using less String, more Path/Files API.

### How has this been tested?
New unit test

### Other changes
Found some errors with tests on Windows, linked to `TestHelper#applyTestFileSubstitutions`.
Fixed the pattern, but I may not have understood what was going on.

## Contributor checklist:
- [x] My code follows the code style of this project.
- [x] I have updated the Release notes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



