### PR TITLE
Fix FileSystem exception with landing raw files

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -97,7 +97,7 @@ object Dependencies {
     "com.google.cloud" % "google-cloud-bigquery" % Versions.bq exclude ("javax.jms", "jms") exclude ("com.sun.jdmk", "jmxtools") exclude ("com.sun.jmx", "jmxri") excludeAll (jacksonExclusions: _*),
     // see https://github.com/GoogleCloudDataproc/spark-bigquery-connector/issues/36
     // Add the jar file to spark dependencies
-    "com.google.cloud.spark" %% "spark-bigquery-with-dependencies" % "0.22.0" % "provided" excludeAll (jacksonExclusions: _*),
+    "com.google.cloud.spark" %% "spark-bigquery-with-dependencies" % "0.22.0" % "provided" excludeAll (jacksonExclusions: _*)
   )
 
   val esSpark211 = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -98,7 +98,6 @@ object Dependencies {
     // see https://github.com/GoogleCloudDataproc/spark-bigquery-connector/issues/36
     // Add the jar file to spark dependencies
     "com.google.cloud.spark" %% "spark-bigquery-with-dependencies" % "0.22.0" % "provided" excludeAll (jacksonExclusions: _*),
-    "com.google.cloud" % "google-cloud-nio" % "0.123.9" exclude ("javax.jms", "jms") exclude ("com.sun.jdmk", "jmxtools") exclude ("com.sun.jmx", "jmxri") excludeAll (jacksonExclusions: _*) classifier "shaded"
   )
 
   val esSpark211 = Seq(


### PR DESCRIPTION
**Related Issue: #587**

**PR Type: Bug Fix**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
Back to original feature: we only use Java nio for when we deal with archives.
We also keep the new method that can recover from a FileSystem not yet installed.
This will work as long as the user provides a Java nio FileSystem implementation.

## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] I have updated the Release notes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.



