### PR TITLE
Feature/custom extensions

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,7 +12,7 @@ __New feature__:
 - Added env var to control BigQuery read data format COMET_SPARK_BIGQUERY_READ_DATA_FORMAT (default to AVRO)
 - When COMET_MERGE_OPTIMIZE_PARTITION_WRITE is set and dynamic partition is active, only write partition containing new records or records to be deleted or updated for BQ (handled by Spark by default for FS).
 - Add VALIDATE_ON_LOAD (comet-validate-on-load) property to raise an exception if one of the domain/job YML file is invalid. default to false
-
+- Add custom file extensions property in Domain import ```default-file-extensions``` and env var ```COMET_DEFAULT_FILE_EXTENSIONS```
 __Bug Fix__:
 - Loading empty files when the schema contains script fields
 - Applying default value for an attribute when value in the input data is null

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -41,7 +41,7 @@ tmpdir = ${?COMET_TMPDIR}
 archive = true
 archive = ${?COMET_ARCHIVE}
 
-default-file-extensions = ["json", "csv", "dsv", "psv", "dat", "txt", "xml"]
+default-file-extensions = "json,csv,dsv,psv,dat,txt,xml"
 default-file-extensions = ${?COMET_DEFAULT_FILE_EXTENSIONS}
 
 default-write-format = parquet

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -41,6 +41,9 @@ tmpdir = ${?COMET_TMPDIR}
 archive = true
 archive = ${?COMET_ARCHIVE}
 
+default-file-extensions = ["json", "csv", "dsv", "psv", "dat", "txt"]
+default-file-extensions = ${?COMET_DEFAULT_FILE_EXTENSIONS}
+
 default-write-format = parquet
 default-write-format = ${?COMET_DEFAULT_WRITE_FORMAT}
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -44,6 +44,9 @@ archive = ${?COMET_ARCHIVE}
 default-file-extensions = "json,csv,dsv,psv,dat,txt,xml"
 default-file-extensions = ${?COMET_DEFAULT_FILE_EXTENSIONS}
 
+force-file-extensions =  "json,csv,dsv,psv,dat,txt,xml,plt"
+force-file-extensions = ${?COMET_FORCE_FILE_EXTENSIONS}
+
 default-write-format = parquet
 default-write-format = ${?COMET_DEFAULT_WRITE_FORMAT}
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -41,7 +41,7 @@ tmpdir = ${?COMET_TMPDIR}
 archive = true
 archive = ${?COMET_ARCHIVE}
 
-default-file-extensions = ["json", "csv", "dsv", "psv", "dat", "txt"]
+default-file-extensions = ["json", "csv", "dsv", "psv", "dat", "txt", "xml"]
 default-file-extensions = ${?COMET_DEFAULT_FILE_EXTENSIONS}
 
 default-write-format = parquet

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -280,7 +280,8 @@ object Settings extends StrictLogging {
     assertions: Assertions,
     kafka: KafkaConfig,
     sqlParameterPattern: String,
-    rejectAllOnError: Boolean
+    rejectAllOnError: Boolean,
+    defaultFileExtensions: List[String]
   ) extends Serializable {
 
     @JsonIgnore

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -281,7 +281,7 @@ object Settings extends StrictLogging {
     kafka: KafkaConfig,
     sqlParameterPattern: String,
     rejectAllOnError: Boolean,
-    defaultFileExtensions: List[String]
+    defaultFileExtensions: String
   ) extends Serializable {
 
     @JsonIgnore

--- a/src/main/scala/com/ebiznext/comet/config/Settings.scala
+++ b/src/main/scala/com/ebiznext/comet/config/Settings.scala
@@ -281,7 +281,8 @@ object Settings extends StrictLogging {
     kafka: KafkaConfig,
     sqlParameterPattern: String,
     rejectAllOnError: Boolean,
-    defaultFileExtensions: String
+    defaultFileExtensions: String,
+    forceFileExtensions: String
   ) extends Serializable {
 
     @JsonIgnore

--- a/src/main/scala/com/ebiznext/comet/schema/model/Domain.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Domain.scala
@@ -20,12 +20,12 @@
 
 package com.ebiznext.comet.schema.model
 
-import java.util.regex.Pattern
 import com.ebiznext.comet.config.{DatasetArea, Settings}
 import com.ebiznext.comet.schema.handlers.SchemaHandler
 import com.ebiznext.comet.utils.Utils
 import org.apache.hadoop.fs.Path
 
+import java.util.regex.Pattern
 import scala.collection.mutable
 
 /** Let's say you are willing to import customers and orders from your Sales system. Sales is
@@ -109,9 +109,13 @@ case class Domain(
     * @return
     *   the list of extensions of teh default ones : ".json", ".csv", ".dsv", ".psv"
     */
-  def getExtensions(): List[String] = {
-    extensions.getOrElse(List("json", "csv", "dsv", "psv")).map("." + _)
-  }
+  def getExtensions(default: List[String]): List[String] =
+    extensions.getOrElse(default).map { extension =>
+      if (extension.startsWith(".") || extension.isEmpty)
+        extension
+      else
+        "." + extension
+    }
 
   /** Ack file should be present for each file to ingest.
     *

--- a/src/main/scala/com/ebiznext/comet/schema/model/Domain.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Domain.scala
@@ -106,11 +106,13 @@ case class Domain(
 
   /** List of file extensions to scan for in the domain directory
     *
+    * @param defaultFileExtensions
+    *   List of comma separated accepted file extensions
     * @return
     *   the list of extensions of teh default ones : ".json", ".csv", ".dsv", ".psv"
     */
-  def getExtensions(default: List[String]): List[String] =
-    extensions.getOrElse(default).map { extension =>
+  def getExtensions(defaultFileExtensions: String): List[String] =
+    extensions.getOrElse(defaultFileExtensions.split(',').map(_.trim).toList).map { extension =>
       if (extension.startsWith(".") || extension.isEmpty)
         extension
       else

--- a/src/main/scala/com/ebiznext/comet/schema/model/Domain.scala
+++ b/src/main/scala/com/ebiznext/comet/schema/model/Domain.scala
@@ -111,13 +111,17 @@ case class Domain(
     * @return
     *   the list of extensions of teh default ones : ".json", ".csv", ".dsv", ".psv"
     */
-  def getExtensions(defaultFileExtensions: String): List[String] =
-    extensions.getOrElse(defaultFileExtensions.split(',').map(_.trim).toList).map { extension =>
+  def getExtensions(defaultFileExtensions: String, forceFileExtensions: String): List[String] = {
+    def toList(extensions: String) = extensions.split(',').map(_.trim).toList
+    val allExtensions =
+      extensions.getOrElse(toList(defaultFileExtensions)) ++ toList(forceFileExtensions)
+    allExtensions.distinct.map { extension =>
       if (extension.startsWith(".") || extension.isEmpty)
         extension
       else
         "." + extension
     }
+  }
 
   /** Ack file should be present for each file to ingest.
     *

--- a/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
+++ b/src/main/scala/com/ebiznext/comet/workflow/IngestionWorkflow.scala
@@ -109,7 +109,12 @@ class IngestionWorkflow(
                   extensions.map(pathWithoutLastExt.suffix).find(storageHandler.exists)
               }
               (
-                findPathWithExt(domain.getExtensions(settings.comet.defaultFileExtensions)),
+                findPathWithExt(
+                  domain.getExtensions(
+                    settings.comet.defaultFileExtensions,
+                    settings.comet.forceFileExtensions
+                  )
+                ),
                 findPathWithExt(zipExtensions)
               )
             }
@@ -159,7 +164,10 @@ class IngestionWorkflow(
                     .list(pathWithoutLastExt, recursive = false)
                     .filter(path =>
                       domain
-                        .getExtensions(settings.comet.defaultFileExtensions)
+                        .getExtensions(
+                          settings.comet.defaultFileExtensions,
+                          settings.comet.forceFileExtensions
+                        )
                         .exists(path.getName.endsWith)
                     ),
                   Some(pathWithoutLastExt)

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
@@ -106,9 +106,9 @@ class StorageHandlerSpec extends TestHelper {
       resultDomain.metadata.get equals domain.metadata.get
       resultDomain.ack shouldBe None
       resultDomain.comment shouldBe domain.comment
-      resultDomain.extensions shouldBe Some(
-        domain.getExtensions(settings.comet.defaultFileExtensions)
-      )
+      resultDomain.getExtensions(
+        settings.comet.defaultFileExtensions
+      ) should contain theSameElementsAs domain.getExtensions(settings.comet.defaultFileExtensions)
     }
 
     "Types Case Class" should "be written as yaml and read correctly" in {

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
@@ -107,8 +107,12 @@ class StorageHandlerSpec extends TestHelper {
       resultDomain.ack shouldBe None
       resultDomain.comment shouldBe domain.comment
       resultDomain.getExtensions(
-        settings.comet.defaultFileExtensions
-      ) should contain theSameElementsAs domain.getExtensions(settings.comet.defaultFileExtensions)
+        settings.comet.defaultFileExtensions,
+        settings.comet.forceFileExtensions
+      ) should contain theSameElementsAs domain.getExtensions(
+        settings.comet.defaultFileExtensions,
+        settings.comet.forceFileExtensions
+      )
     }
 
     "Types Case Class" should "be written as yaml and read correctly" in {

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/StorageHandlerSpec.scala
@@ -106,7 +106,9 @@ class StorageHandlerSpec extends TestHelper {
       resultDomain.metadata.get equals domain.metadata.get
       resultDomain.ack shouldBe None
       resultDomain.comment shouldBe domain.comment
-      resultDomain.extensions shouldBe Some(domain.getExtensions())
+      resultDomain.extensions shouldBe Some(
+        domain.getExtensions(settings.comet.defaultFileExtensions)
+      )
     }
 
     "Types Case Class" should "be written as yaml and read correctly" in {


### PR DESCRIPTION
## Summary
Support custom extensions through the property COMET_DEFAULT_FILE_EXTENSIONS (default-file-extensions)

Alow the use of COMET_FORCE_FILE_EXTENSIONS to force extensions to be recognized
Temporary env var until users correctly set the extensions in their YML file. This feature will stay undocumented and will be removed in a future version

**PR Type: Feature**

**Status: WIP**

**Breaking change? No**

