### PR TITLE
Merge two datasets with different schemas

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version=3.0.3
+version=3.0.2
 style = defaultWithAlign
 align.openParenCallSite = false
 align.openParenDefnSite = false

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release notes
 
+# 0.2.7
+__New feature__:
+- Support merging dataset with updated schema
+
 # 0.2.6
 __New feature__:
 - Support XML Schema inference

--- a/src/main/java/com/ebiznext/comet/utils/repackaged/BigQuerySchemaConverters.java
+++ b/src/main/java/com/ebiznext/comet/utils/repackaged/BigQuerySchemaConverters.java
@@ -23,6 +23,11 @@ import com.google.cloud.bigquery.Field;
 import com.google.cloud.bigquery.FieldList;
 import com.google.cloud.bigquery.LegacySQLTypeName;
 import com.google.cloud.bigquery.Schema;
+import com.google.cloud.bigquery.StandardTableDefinition;
+import com.google.cloud.bigquery.TableDefinition;
+import com.google.cloud.bigquery.TableInfo;
+import com.google.cloud.bigquery.TimePartitioning;
+import com.google.cloud.spark.bigquery.SupportedCustomDataType;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.avro.generic.GenericRecord;
@@ -30,42 +35,114 @@ import org.apache.avro.util.Utf8;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
-import org.apache.spark.sql.types.*;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.BinaryType;
+import org.apache.spark.sql.types.BooleanType;
+import org.apache.spark.sql.types.ByteType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.DateType;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.DecimalType;
+import org.apache.spark.sql.types.DoubleType;
+import org.apache.spark.sql.types.FloatType;
+import org.apache.spark.sql.types.IntegerType;
+import org.apache.spark.sql.types.LongType;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.ShortType;
+import org.apache.spark.sql.types.StringType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.TimestampType;
+import org.apache.spark.sql.types.UserDefinedType;
 import org.apache.spark.unsafe.types.UTF8String;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+// Copied from com.google.cloud.spark.bigquery.SchemaConverters
+// Last update : 0.22.0
+// Known differences : b3f1946f Fix timestamp conversion between parquet converted type and BigQuery data type (#427)
+
+@SuppressWarnings("all")
 public class BigQuerySchemaConverters {
     // Numeric is a fixed precision Decimal Type with 38 digits of precision and 9 digits of scale.
     // See https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#numeric-type
-    private static final int BQ_NUMERIC_PRECISION = 38;
-    private static final int BQ_NUMERIC_SCALE = 9;
+    static final int BQ_NUMERIC_PRECISION = 38;
+    static final int BQ_NUMERIC_SCALE = 9;
+    static final int BQ_BIG_NUMERIC_SCALE = 38;
     private static final DecimalType NUMERIC_SPARK_TYPE =
             DataTypes.createDecimalType(BQ_NUMERIC_PRECISION, BQ_NUMERIC_SCALE);
     // The maximum nesting depth of a BigQuery RECORD:
-    private static final int MAX_BIGQUERY_NESTED_DEPTH = 15;
-    private static final String MAPTYPE_ERROR_MESSAGE = "MapType is unsupported.";
+    static final int MAX_BIGQUERY_NESTED_DEPTH = 15;
+    static final String MAPTYPE_ERROR_MESSAGE = "MapType is unsupported.";
 
     /**
      * Convert a BigQuery schema to a Spark schema
      */
     public static StructType toSpark(Schema schema) {
-        return new StructType(schema.getFields()
-                .stream()
-                .map(BigQuerySchemaConverters::convert)
-                .toArray(StructField[]::new));
+        List<StructField> fieldList =
+                schema.getFields().stream().map(BigQuerySchemaConverters::convert).collect(Collectors.toList());
+        StructType structType = new StructType(fieldList.toArray(new StructField[0]));
+
+        return structType;
+    }
+
+    /**
+     * Retrieves and returns BigQuery Schema from TableInfo. If the table support pseudo columns, they
+     * are added to schema before schema is returned to the caller.
+     */
+    public static Schema getSchemaWithPseudoColumns(TableInfo tableInfo) {
+        TimePartitioning timePartitioning = null;
+        TableDefinition tableDefinition = tableInfo.getDefinition();
+        if (tableDefinition instanceof StandardTableDefinition) {
+            timePartitioning = ((StandardTableDefinition) tableDefinition).getTimePartitioning();
+        }
+        boolean tableSupportsPseudoColumns =
+                timePartitioning != null
+                        && timePartitioning.getField() == null
+                        && timePartitioning.getType() != null;
+
+        Schema schema = tableDefinition.getSchema();
+        if (tableSupportsPseudoColumns) {
+            ArrayList<Field> fields = new ArrayList<Field>(schema.getFields());
+            fields.add(
+                    createBigQueryFieldBuilder(
+                            "_PARTITIONTIME", LegacySQLTypeName.TIMESTAMP, Field.Mode.NULLABLE, null)
+                            .build());
+            fields.add(
+                    createBigQueryFieldBuilder(
+                            "_PARTITIONDATE", LegacySQLTypeName.DATE, Field.Mode.NULLABLE, null)
+                            .build());
+            schema = Schema.of(fields);
+        }
+        return schema;
     }
 
     public static InternalRow convertToInternalRow(
-            Schema schema, List<String> namesInOrder, GenericRecord record) {
-        return convertAll(schema.getFields(), record, namesInOrder);
+            Schema schema,
+            List<String> namesInOrder,
+            GenericRecord record,
+            Optional<StructType> userProvidedSchema) {
+        List<StructField> userProvidedFieldList =
+                Arrays.stream(userProvidedSchema.orElse(new StructType()).fields())
+                        .collect(Collectors.toList());
+
+        return convertAll(schema.getFields(), record, namesInOrder, userProvidedFieldList);
     }
 
-    static Object convert(Field field, Object value) {
+    static Object convert(Field field, Object value, StructField userProvidedField) {
         if (value == null) {
             return null;
         }
@@ -82,53 +159,88 @@ public class BigQuerySchemaConverters {
                             .setMode(Field.Mode.REQUIRED)
                             .build();
 
-            List<?> valueList = value instanceof List ? (List<?>) value : Collections.emptyList();
-
+            List<Object> valueList = (List<Object>) value;
             return new GenericArrayData(
-                    valueList.stream().map(v -> convert(nestedField, v)).collect(Collectors.toList()));
+                    valueList.stream()
+                            .map(v -> convert(nestedField, v, getStructFieldForRepeatedMode(userProvidedField)))
+                            .collect(Collectors.toList()));
         }
 
-        Object datum = convertByBigQueryType(field, value);
+        Object datum = convertByBigQueryType(field, value, userProvidedField);
         Optional<Object> customDatum =
-                getCustomDataType(field).map(dt -> ((UserDefinedType<?>) dt).deserialize(datum));
+                getCustomDataType(field).map(dt -> ((UserDefinedType) dt).deserialize(datum));
         return customDatum.orElse(datum);
     }
 
-    static Object convertByBigQueryType(Field field, Object value) {
-        if (LegacySQLTypeName.INTEGER.equals(field.getType())
-                || LegacySQLTypeName.FLOAT.equals(field.getType())
-                || LegacySQLTypeName.BOOLEAN.equals(field.getType())
-                || LegacySQLTypeName.DATE.equals(field.getType())
-                || LegacySQLTypeName.TIME.equals(field.getType())
-                || LegacySQLTypeName.TIMESTAMP.equals(field.getType())) {
+    private static StructField getStructFieldForRepeatedMode(StructField field) {
+        StructField nestedField = null;
+
+        if (field != null) {
+            ArrayType arrayType = ((ArrayType) field.dataType());
+            nestedField =
+                    new StructField(
+                            field.name(),
+                            arrayType.elementType(),
+                            arrayType.containsNull(),
+                            Metadata.empty()); // safe to pass empty metadata as it is not used anywhere
+        }
+        return nestedField;
+    }
+
+    static Object convertByBigQueryType(Field bqField, Object value, StructField userProvidedField) {
+        if (LegacySQLTypeName.INTEGER.equals(bqField.getType())
+                || LegacySQLTypeName.FLOAT.equals(bqField.getType())
+                || LegacySQLTypeName.BOOLEAN.equals(bqField.getType())
+                || LegacySQLTypeName.DATE.equals(bqField.getType())
+                || LegacySQLTypeName.TIME.equals(bqField.getType())
+                || LegacySQLTypeName.TIMESTAMP.equals(bqField.getType())) {
             return value;
         }
 
-        if (LegacySQLTypeName.STRING.equals(field.getType())
-                || LegacySQLTypeName.DATETIME.equals(field.getType())
-                || LegacySQLTypeName.GEOGRAPHY.equals(field.getType())) {
+        if (LegacySQLTypeName.STRING.equals(bqField.getType())
+                || LegacySQLTypeName.DATETIME.equals(bqField.getType())
+                || LegacySQLTypeName.GEOGRAPHY.equals(bqField.getType())) {
             return UTF8String.fromBytes(((Utf8) value).getBytes());
         }
 
-        if (LegacySQLTypeName.BYTES.equals(field.getType())) {
+        if (LegacySQLTypeName.BYTES.equals(bqField.getType())) {
             return getBytes((ByteBuffer) value);
         }
 
-        if (LegacySQLTypeName.NUMERIC.equals(field.getType())) {
+        if (LegacySQLTypeName.NUMERIC.equals(bqField.getType())) {
             byte[] bytes = getBytes((ByteBuffer) value);
             BigDecimal b = new BigDecimal(new BigInteger(bytes), BQ_NUMERIC_SCALE);
+            Decimal d = Decimal.apply(b, BQ_NUMERIC_PRECISION, BQ_NUMERIC_SCALE);
 
-            return Decimal.apply(b, BQ_NUMERIC_PRECISION, BQ_NUMERIC_SCALE);
+            return d;
         }
 
-        if (LegacySQLTypeName.RECORD.equals(field.getType())) {
-            return convertAll(
-                    field.getSubFields(),
-                    (GenericRecord) value,
-                    field.getSubFields().stream().map(Field::getName).collect(Collectors.toList()));
+        // TODO : uncomment after updating google-cloud-bigquery
+//        if (LegacySQLTypeName.BIGNUMERIC.equals(bqField.getType())) {
+//            byte[] bytes = getBytes((ByteBuffer) value);
+//            BigDecimal bigDecimal = new BigDecimal(new BigInteger(bytes), BQ_BIG_NUMERIC_SCALE);
+//            return UTF8String.fromString(bigDecimal.toString());
+//        }
+
+        if (LegacySQLTypeName.RECORD.equals(bqField.getType())) {
+            List<String> namesInOrder = null;
+            List<StructField> structList = null;
+
+            if (userProvidedField != null) {
+                structList =
+                        Arrays.stream(((StructType) userProvidedField.dataType()).fields())
+                                .collect(Collectors.toList());
+
+                namesInOrder = structList.stream().map(StructField::name).collect(Collectors.toList());
+            } else {
+                namesInOrder =
+                        bqField.getSubFields().stream().map(Field::getName).collect(Collectors.toList());
+            }
+
+            return convertAll(bqField.getSubFields(), (GenericRecord) value, namesInOrder, structList);
         }
 
-        throw new IllegalStateException("Unexpected type: " + field.getType());
+        throw new IllegalStateException("Unexpected type: " + bqField.getType());
     }
 
     private static byte[] getBytes(ByteBuffer buf) {
@@ -140,10 +252,27 @@ public class BigQuerySchemaConverters {
 
     // Schema is not recursive so add helper for sequence of fields
     static GenericInternalRow convertAll(
-            FieldList fieldList, GenericRecord record, List<String> namesInOrder) {
+            FieldList fieldList,
+            GenericRecord record,
+            List<String> namesInOrder,
+            List<StructField> userProvidedFieldList) {
+        Map<String, Object> fieldMap = new HashMap<>();
 
-        Map<String, Object> fieldMap = fieldList.stream()
-                .collect(Collectors.toMap(Field::getName, field -> convert(field, record.get(field.getName()))));
+        Map<String, StructField> userProvidedFieldMap =
+                userProvidedFieldList == null
+                        ? new HashMap<>()
+                        : userProvidedFieldList.stream()
+                        .collect(Collectors.toMap(StructField::name, Function.identity()));
+
+        fieldList.stream()
+                .forEach(
+                        field ->
+                                fieldMap.put(
+                                        field.getName(),
+                                        convert(
+                                                field,
+                                                record.get(field.getName()),
+                                                userProvidedFieldMap.get(field.getName()))));
 
         Object[] values = new Object[namesInOrder.size()];
         for (int i = 0; i < namesInOrder.size(); i++) {
@@ -173,6 +302,7 @@ public class BigQuerySchemaConverters {
 
         MetadataBuilder metadata = new MetadataBuilder();
         if (field.getDescription() != null) {
+            metadata.putString("description", field.getDescription());
             metadata.putString("comment", field.getDescription());
         }
 
@@ -191,7 +321,7 @@ public class BigQuerySchemaConverters {
             // All supported types are serialized to records
             if (LegacySQLTypeName.RECORD.equals(field.getType())) {
                 // we don't have many types, so we keep parsing to minimum
-                return SupportedCustomDataType.forDescription(description)
+                return com.google.cloud.spark.bigquery.SupportedCustomDataType.forDescription(description)
                         .map(SupportedCustomDataType::getSparkDataType);
             }
         }
@@ -205,6 +335,9 @@ public class BigQuerySchemaConverters {
             return DataTypes.DoubleType;
         } else if (LegacySQLTypeName.NUMERIC.equals(field.getType())) {
             return NUMERIC_SPARK_TYPE;
+            // TODO : uncomment after updating google-cloud-bigquery
+//        } else if (LegacySQLTypeName.BIGNUMERIC.equals(field.getType())) {
+//            return BigQueryDataTypes.BigNumericType;
         } else if (LegacySQLTypeName.STRING.equals(field.getType())) {
             return DataTypes.StringType;
         } else if (LegacySQLTypeName.BOOLEAN.equals(field.getType())) {
@@ -224,10 +357,9 @@ public class BigQuerySchemaConverters {
         } else if (LegacySQLTypeName.DATETIME.equals(field.getType())) {
             return DataTypes.StringType;
         } else if (LegacySQLTypeName.RECORD.equals(field.getType())) {
-            return new StructType(field.getSubFields()
-                    .stream()
-                    .map(BigQuerySchemaConverters::convert)
-                    .toArray(StructField[]::new));
+            List<StructField> structFields =
+                    field.getSubFields().stream().map(BigQuerySchemaConverters::convert).collect(Collectors.toList());
+            return new StructType(structFields.toArray(new StructField[0]));
         } else if (LegacySQLTypeName.GEOGRAPHY.equals(field.getType())) {
             return DataTypes.StringType;
         } else {
@@ -261,27 +393,46 @@ public class BigQuerySchemaConverters {
      */
     @VisibleForTesting
     protected static Field createBigQueryColumn(StructField sparkField, int depth) {
-        final Field.Builder builder = Field.newBuilder(sparkField.name(), LegacySQLTypeName.STRING);
-
-        builder.setMode((sparkField.nullable()) ? Field.Mode.NULLABLE : Field.Mode.REQUIRED);
-
         DataType sparkType = sparkField.dataType();
+        String fieldName = sparkField.name();
+        Field.Mode fieldMode = (sparkField.nullable()) ? Field.Mode.NULLABLE : Field.Mode.REQUIRED;
+        FieldList subFields = null;
+        LegacySQLTypeName fieldType;
+
         if (sparkType instanceof ArrayType) {
             ArrayType arrayType = (ArrayType) sparkType;
 
-            builder.setMode(Field.Mode.REPEATED);
+            fieldMode = Field.Mode.REPEATED;
             sparkType = arrayType.elementType();
         }
 
         if (sparkType instanceof StructType) {
-            builder.setType(LegacySQLTypeName.RECORD, sparkToBigQueryFields((StructType) sparkType, depth + 1));
+            subFields = sparkToBigQueryFields((StructType) sparkType, depth + 1);
+            fieldType = LegacySQLTypeName.RECORD;
         } else {
-            builder.setType(toBigQueryType(sparkType));
+            fieldType = toBigQueryType(sparkType);
         }
 
-        sparkField.getComment().foreach(builder::setDescription);
+        Field.Builder fieldBuilder =
+                createBigQueryFieldBuilder(fieldName, fieldType, fieldMode, subFields);
+        Optional<String> description = getDescriptionOrCommentOfField(sparkField);
 
-        return builder.build();
+        if (description.isPresent()) {
+            fieldBuilder.setDescription(description.get());
+        }
+
+        return fieldBuilder.build();
+    }
+
+    public static Optional<String> getDescriptionOrCommentOfField(StructField field) {
+        if (!field.getComment().isEmpty()) {
+            return Optional.of(field.getComment().get());
+        }
+        if (field.metadata().contains("description")
+                && field.metadata().getString("description") != null) {
+            return Optional.of(field.metadata().getString("description"));
+        }
+        return Optional.empty();
     }
 
     @VisibleForTesting
@@ -327,5 +478,10 @@ public class BigQuerySchemaConverters {
         } else {
             throw new IllegalArgumentException("Data type not expected: " + elementType.simpleString());
         }
+    }
+
+    private static Field.Builder createBigQueryFieldBuilder(
+            String name, LegacySQLTypeName type, Field.Mode mode, FieldList subFields) {
+        return Field.newBuilder(name, type, subFields).setMode(mode);
     }
 }

--- a/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
+++ b/src/main/scala/com/ebiznext/comet/job/ingest/IngestionJob.scala
@@ -896,7 +896,7 @@ trait IngestionJob extends SparkJob {
       settings.comet.mergeOptimizePartitionWrite
     ) match {
       // no need to apply optimization if existing dataset is empty
-      case ("dynamic", Some(timestamp), true) if !existingDF.isEmpty =>
+      case ("dynamic", Some(timestamp), true) if existingDF.limit(1).count == 1 =>
         logger.info(s"Computing partitions to update on date column $timestamp")
         val partitionsToUpdate =
           BigQueryUtils.computePartitionsToUpdateAfterMerge(mergedDF, toDeleteDF, timestamp)

--- a/src/main/scala/com/ebiznext/comet/utils/MergeUtils.scala
+++ b/src/main/scala/com/ebiznext/comet/utils/MergeUtils.scala
@@ -145,7 +145,6 @@ object MergeUtils extends StrictLogging {
         missingTypes.foldLeft(originalDF) {
           (dataframe: DataFrame, missingType: (List[String], DataType)) =>
             missingType match {
-              case (Nil, _) => dataframe
               case (colName :: Nil, dataType) =>
                 dataframe.withColumn(colName, lit(null).cast(dataType))
               case (colName :: tail, dataType) =>
@@ -153,6 +152,7 @@ object MergeUtils extends StrictLogging {
                   colName,
                   col(colName).withField(tail.mkString("."), lit(null).cast(dataType))
                 )
+              case (_, _) => dataframe
             }
         }
       }

--- a/src/main/scala/com/ebiznext/comet/utils/MergeUtils.scala
+++ b/src/main/scala/com/ebiznext/comet/utils/MergeUtils.scala
@@ -2,10 +2,10 @@ package com.ebiznext.comet.utils
 
 import com.ebiznext.comet.schema.model.MergeOptions
 import com.typesafe.scalalogging.StrictLogging
-import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.expressions.Window
-import org.apache.spark.sql.functions.{col, lit, row_number}
+import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{ArrayType, DataType, StructType}
+import org.apache.spark.sql.{Column, DataFrame}
 
 object MergeUtils extends StrictLogging {
 
@@ -101,60 +101,88 @@ object MergeUtils extends StrictLogging {
     (mergedDF, toDeleteDF)
   }
 
+  // return an optional list of column paths (ex "root.field" <=> ("root", "field"))
+  private def findMissingColumnsType(
+    schema: StructType,
+    reference: StructType,
+    stack: List[String] = List()
+  ): Option[Map[List[String], DataType]] = {
+    val fields = schema.fields.map(field => field.name -> field).toMap
+    reference.fields
+      .flatMap { referenceField =>
+        fields
+          .get(referenceField.name)
+          .fold(
+            // Without match, we have found a missing column
+            Option(Map((stack :+ referenceField.name) -> referenceField.dataType))
+          ) { field =>
+            (field.dataType, referenceField.dataType) match {
+              // In here, we known the reference column is matched in the original schema
+              // If the innerType is a StructType, we must do some recursion
+              // Otherwise, we can end the search, there is no missing column here.
+              case (fieldType: StructType, referenceType: StructType) =>
+                findMissingColumnsType(fieldType, referenceType, stack :+ referenceField.name)
+              case (
+                    ArrayType(fieldType: StructType, _),
+                    ArrayType(referenceType: StructType, _)
+                  ) =>
+                findMissingColumnsType(fieldType, referenceType, stack :+ referenceField.name)
+              case (_, _) => None
+            }
+          }
+      }
+      .reduceOption(_ ++ _)
+  }
+
+  private def supportsNestedFieldsOperations(dataFrame: DataFrame): Boolean =
+    Version(dataFrame.sparkSession.sparkContext.version).compareTo(Version("3.1.0")) >= 0
+
+  private def buildMissingType(
+    dataframe: DataFrame,
+    missingType: (List[String], DataType)
+  ): DataFrame = buildMissingType(dataframe, missingType, supportsNestedFieldsOperations(dataframe))
+
+  def buildMissingType(
+    dataframe: DataFrame,
+    missingType: (List[String], DataType),
+    useNestedFields: Boolean
+  ): DataFrame = {
+    // Inspired from https://medium.com/@fqaiser94/manipulating-nested-data-just-got-easier-in-apache-spark-3-1-1-f88bc9003827
+    def buildMissingColumn: (List[String], List[String], DataType, Boolean) => Column = {
+      case (_ :+ colName, Nil, missingType, _) => lit(null).cast(missingType).as(colName)
+      case (_ :+ colName, fields, missingType, true) =>
+        col(colName).withField(fields.mkString("."), lit(null).cast(missingType))
+      case (parents, colName :: fields, missingType, false) =>
+        val parentColName = parents.mkString(".")
+        when(
+          col(parentColName).isNotNull,
+          struct(
+            col(s"$parentColName.*"),
+            buildMissingColumn(parents ++ List(colName), fields, missingType, false)
+          )
+        )
+      case (_, _, _, _) => throw new Exception("should never happen")
+    }
+
+    missingType match {
+      case (colName :: tail, dataType) =>
+        dataframe.withColumn(
+          colName,
+          buildMissingColumn(List(colName), tail, dataType, useNestedFields)
+        )
+      case (_, _) => dataframe
+    }
+  }
+
   /** Perform an union between two dataframe. Fixes any missing column from the originalDF by add
     * null values where needed. Assumes toAddDF to at least contains all the columns from originalDF
     * (see {@link computeCompatibleSchema})
     */
   private def computeDataframeUnion(originalDF: DataFrame, toAddDF: DataFrame): DataFrame = {
-    // return an optional list of column paths (ex "root.field" <=> ("root", "field"))
-    def findMissingColumnsType(
-      schema: StructType,
-      reference: StructType,
-      stack: List[String] = List()
-    ): Option[Map[List[String], DataType]] = {
-      val fields = schema.fields.map(field => field.name -> field).toMap
-      reference.fields
-        .flatMap { referenceField =>
-          fields
-            .get(referenceField.name)
-            .fold(
-              // Without match, we have found a missing column
-              Option(Map((stack :+ referenceField.name) -> referenceField.dataType))
-            ) { field =>
-              (field.dataType, referenceField.dataType) match {
-                // In here, we known the reference column is matched in the original schema
-                // If the innerType is a StructType, we must do some recursion
-                // Otherwise, we can end the search, there is no missing column here.
-                case (fieldType: StructType, referenceType: StructType) =>
-                  findMissingColumnsType(fieldType, referenceType, stack :+ referenceField.name)
-                case (
-                      ArrayType(fieldType: StructType, _),
-                      ArrayType(referenceType: StructType, _)
-                    ) =>
-                  findMissingColumnsType(fieldType, referenceType, stack :+ referenceField.name)
-                case (_, _) => None
-              }
-            }
-        }
-        .reduceOption(_ ++ _)
-    }
-
     val missingTypes = findMissingColumnsType(originalDF.schema, toAddDF.schema)
     val patchedDF = missingTypes
       .fold(originalDF) { missingTypes =>
-        missingTypes.foldLeft(originalDF) {
-          (dataframe: DataFrame, missingType: (List[String], DataType)) =>
-            missingType match {
-              case (colName :: Nil, dataType) =>
-                dataframe.withColumn(colName, lit(null).cast(dataType))
-              case (colName :: tail, dataType) =>
-                dataframe.withColumn(
-                  colName,
-                  col(colName).withField(tail.mkString("."), lit(null).cast(dataType))
-                )
-              case (_, _) => dataframe
-            }
-        }
+        missingTypes.foldLeft(originalDF) { buildMissingType }
       }
       // Force ordering of columns to be the same
       .select(toAddDF.columns.map(col): _*)

--- a/src/main/scala/com/ebiznext/comet/utils/MergeUtils.scala
+++ b/src/main/scala/com/ebiznext/comet/utils/MergeUtils.scala
@@ -1,0 +1,181 @@
+package com.ebiznext.comet.utils
+
+import com.ebiznext.comet.schema.model.MergeOptions
+import com.typesafe.scalalogging.StrictLogging
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions.{col, date_format, lit, row_number}
+import org.apache.spark.sql.types.{ArrayType, DataType, StructType}
+
+object MergeUtils extends StrictLogging {
+
+  /** Compute a new schema that is compatible with merge operations. Built recursively from the
+    * incoming schema to retain the latest attributes, but without the columns that does not exist
+    * yet. Ensures that the incomingSchema contains all the columns from the existingSchema.
+    */
+  def computeCompatibleSchema(actualSchema: StructType, expectedSchema: StructType): StructType = {
+    val actualColumns = actualSchema.map(field => field.name -> field).toMap
+    val expectedColumns = expectedSchema.map(field => field.name -> field).toMap
+
+    val missingColumns = actualColumns.keySet.diff(expectedColumns.keySet)
+    if (missingColumns.nonEmpty)
+      throw new RuntimeException(
+        "Input Dataset should contain every column from the existing HDFS dataset. The following columns were not matched: " + missingColumns
+          .mkString(", ")
+      )
+
+    val newColumns = expectedColumns.keySet.diff(actualColumns.keySet)
+    val newColumnsNotNullable =
+      newColumns.flatMap(expectedColumns.get).filterNot(_.nullable).map(_.name)
+    if (newColumnsNotNullable.nonEmpty)
+      throw new RuntimeException(
+        "The new columns from Input Dataset should be nullable. The following columns were not: " + newColumnsNotNullable
+          .mkString(", ")
+      )
+
+    StructType(
+      expectedSchema
+        .flatMap(expectedField =>
+          actualColumns
+            .get(expectedField.name)
+            .map(existingField =>
+              (existingField.dataType, expectedField.dataType) match {
+                case (existingType: StructType, incomingType: StructType) =>
+                  expectedField.copy(dataType = computeCompatibleSchema(existingType, incomingType))
+                case (
+                      ArrayType(existingType: StructType, _),
+                      ArrayType(incomingType: StructType, nullable)
+                    ) =>
+                  expectedField
+                    .copy(dataType =
+                      ArrayType(computeCompatibleSchema(existingType, incomingType), nullable)
+                    )
+                case (_, _) => expectedField
+              }
+            )
+        )
+    )
+  }
+
+  def computeToMergeAndToDeleteDF(
+    existingDF: DataFrame,
+    incomingDF: DataFrame,
+    mergeOptions: MergeOptions
+  ): (DataFrame, DataFrame) = {
+    val finalIncomingDF = mergeOptions.delete
+      .map(condition => incomingDF.filter(s"not ($condition)"))
+      .getOrElse(incomingDF)
+
+    val orderingWindow = Window
+      .partitionBy(mergeOptions.key.head, mergeOptions.key.tail: _*)
+      .orderBy(mergeOptions.timestamp.fold(mergeOptions.key) { List(_) }.map(col(_).desc): _*)
+
+    val allRowsDF = computeDataframeUnion(existingDF, finalIncomingDF)
+
+    val allRowsWithRownum = allRowsDF
+      .withColumn("rownum", row_number.over(orderingWindow))
+
+    // Deduplicate
+    val mergedDF = allRowsWithRownum
+      .where(col("rownum") === 1)
+      .drop("rownum")
+
+    // Compute rows that will be deleted
+    val toDeleteDF = allRowsWithRownum
+      .where(col("rownum") =!= 1)
+      .drop("rownum")
+
+    logger.whenDebugEnabled {
+      logger.debug(s"Merge detected ${toDeleteDF.count()} items to update/delete")
+      logger.debug(s"Merge detected ${mergedDF.except(finalIncomingDF).count()} items to insert")
+      mergedDF.show(false)
+    }
+
+    (mergedDF, toDeleteDF)
+  }
+
+  /** Perform an union between two dataframe. Fixes any missing column from the originalDF by add
+    * null values where needed. Assumes toAddDF to at least contains all the columns from originalDF
+    * (see {@link computeCompatibleSchema})
+    */
+  private def computeDataframeUnion(originalDF: DataFrame, toAddDF: DataFrame): DataFrame = {
+    // return an optional list of column paths (ex "root.field" <=> ("root", "field"))
+    def findMissingColumnsType(
+      schema: StructType,
+      reference: StructType,
+      stack: List[String] = List()
+    ): Option[Map[List[String], DataType]] = {
+      val fields = schema.fields.map(field => field.name -> field).toMap
+      reference.fields
+        .flatMap { referenceField =>
+          fields
+            .get(referenceField.name)
+            .fold(
+              // Without match, we have found a missing column
+              Option(Map((stack :+ referenceField.name) -> referenceField.dataType))
+            ) { field =>
+              (field.dataType, referenceField.dataType) match {
+                // In here, we known the reference column is matched in the original schema
+                // If the innerType is a StructType, we must do some recursion
+                // Otherwise, we can end the search, there is no missing column here.
+                case (fieldType: StructType, referenceType: StructType) =>
+                  findMissingColumnsType(fieldType, referenceType, stack :+ referenceField.name)
+                case (
+                      ArrayType(fieldType: StructType, _),
+                      ArrayType(referenceType: StructType, _)
+                    ) =>
+                  findMissingColumnsType(fieldType, referenceType, stack :+ referenceField.name)
+                case (_, _) => None
+              }
+            }
+        }
+        .reduceOption(_ ++ _)
+    }
+
+    val missingTypes = findMissingColumnsType(originalDF.schema, toAddDF.schema)
+    val patchedDF = missingTypes
+      .fold(originalDF) { missingTypes =>
+        missingTypes.foldLeft(originalDF) {
+          (dataframe: DataFrame, missingType: (List[String], DataType)) =>
+            missingType match {
+              case (Nil, _) => dataframe
+              case (colName :: Nil, dataType) =>
+                dataframe.withColumn(colName, lit(null).cast(dataType))
+              case (colName :: tail, dataType) =>
+                dataframe.withColumn(
+                  colName,
+                  col(colName).withField(tail.mkString("."), lit(null).cast(dataType))
+                )
+            }
+        }
+      }
+      // Force ordering of columns to be the same
+      .select(toAddDF.columns.map(col): _*)
+
+    // place toAddDF first, so that if a new data takes precedence over the rest
+    toAddDF.union(patchedDF)
+  }
+
+  def computePartitionsToUpdateAfterMerge(
+    mergedDF: DataFrame,
+    toDeleteDF: DataFrame,
+    timestamp: String,
+    dateFormat: String
+  ): List[String] = {
+    logger.info(s"Computing partitions to update on date column $timestamp")
+    val partitionsToUpdate = mergedDF
+      .select(col(timestamp))
+      .union(toDeleteDF.select(col(timestamp)))
+      .select(date_format(col(timestamp), dateFormat).cast("string"))
+      .where(col(timestamp).isNotNull)
+      .distinct()
+      .collect()
+      .map(_.getString(0))
+      .toList
+    logger.info(
+      s"The following partitions will be updated ${partitionsToUpdate.mkString(",")}"
+    )
+    partitionsToUpdate
+  }
+
+}

--- a/src/main/scala/com/ebiznext/comet/utils/conversion/BigQueryUtils.scala
+++ b/src/main/scala/com/ebiznext/comet/utils/conversion/BigQueryUtils.scala
@@ -21,4 +21,30 @@ object BigQueryUtils {
   def bqSchema(schema: DataType): BQSchema = {
     BigQuerySchemaConverters.toBigQuerySchema(schema.asInstanceOf[StructType])
   }
+
+  /** Spark BigQuery driver consider integer in BQ as Long. We need to convert the Int DataType to
+    * LongType before loading the data. As a good practice, always use long when dealing with big
+    * query in your YAML Schema.
+    * @param schema
+    * @return
+    */
+  def normalizeSchema(schema: StructType): StructType = {
+    val fields = schema.fields.map { field =>
+      field.dataType match {
+        case dataType: StructType =>
+          field.copy(dataType = normalizeSchema(dataType))
+        case ArrayType(elementType: StructType, nullable) =>
+          field.copy(dataType = ArrayType(normalizeSchema(elementType), nullable))
+        case ArrayType(_: IntegerType, nullable) =>
+          field.copy(dataType = ArrayType(LongType, nullable))
+        case IntegerType => field.copy(dataType = LongType)
+        case _           => field
+      }
+    }
+    schema.copy(fields = fields)
+  }
+  ///////////////////////////////////////////////////////////////////////////
+  // Merge From BigQuery Data Source
+  ///////////////////////////////////////////////////////////////////////////
+
 }

--- a/src/test/resources/expected/datasets/accepted/DOMAIN/Players-merged-entitled.csv
+++ b/src/test/resources/expected/datasets/accepted/DOMAIN/Players-merged-entitled.csv
@@ -1,0 +1,6 @@
+1,john,doe,2018-07-21,,2018,07
+2,micheal,jordan,2019-07-21,,2019,07
+5,xavi,hernandez,2018-07-21,player,2018,06
+6,leo,messi,1987-07-24,god,1987,07
+3,mohamad,salah,1999-05-02,leader,1999,05
+4,kilian,mbappe,2010-07-03,player,2010,07

--- a/src/test/resources/expected/merge/merge-new-schema.jsonl
+++ b/src/test/resources/expected/merge/merge-new-schema.jsonl
@@ -1,0 +1,3 @@
+{"id":1,"data":{"version":0}}
+{"id":2,"data":{"version":0,"new":"value"}}
+{"id":3,"data":{"version":1,"new":"value"},"field":"new"}

--- a/src/test/resources/expected/merge/merge-simple.jsonl
+++ b/src/test/resources/expected/merge/merge-simple.jsonl
@@ -1,0 +1,3 @@
+{"id":1,"data":{"version":0}}
+{"id":2,"data":{"version":0}}
+{"id":3,"data":{"version":1}}

--- a/src/test/resources/expected/merge/merge-with-timestamp.jsonl
+++ b/src/test/resources/expected/merge/merge-with-timestamp.jsonl
@@ -1,0 +1,3 @@
+{"id":1,"data":{"version":1}}
+{"id":2,"data":{"version":3}}
+{"id":3,"data":{"version":1}}

--- a/src/test/resources/sample/merge/Players-Entitled.csv
+++ b/src/test/resources/sample/merge/Players-Entitled.csv
@@ -1,0 +1,4 @@
+3,mohamad,salah,1999-05-02,1999,05,leader
+4,kilian,mbappe,2010-07-03,2010,07,player
+5,xavi,hernandez,2018-07-21,2018,06,player
+6,leo,messi,1987-07-24,1987,07,god

--- a/src/test/resources/sample/merge/existing.jsonl
+++ b/src/test/resources/sample/merge/existing.jsonl
@@ -1,0 +1,3 @@
+{"id":1,"data":{"version":0}}
+{"id":1,"data":{"version":1}}
+{"id":2,"data":{"version":3}}

--- a/src/test/resources/sample/merge/incoming-new-schema.jsonl
+++ b/src/test/resources/sample/merge/incoming-new-schema.jsonl
@@ -1,0 +1,2 @@
+{"id":2,"data":{"version":0,"new":"value"}}
+{"id":3,"data":{"version":1,"new":"value"},"field":"new"}

--- a/src/test/resources/sample/merge/incoming.jsonl
+++ b/src/test/resources/sample/merge/incoming.jsonl
@@ -1,0 +1,3 @@
+{"id":2,"data":{"version":0}}
+{"id":3,"data":{"version":1}}
+{"id":3,"data":{"version":0}}

--- a/src/test/resources/sample/merge/merge-with-new-schema.comet.yml
+++ b/src/test/resources/sample/merge/merge-with-new-schema.comet.yml
@@ -1,0 +1,78 @@
+---
+name: "DOMAIN"
+directory: "__COMET_TEST_ROOT__/DOMAIN"
+metadata:
+  mode: "FILE"
+  format: "DSV"
+  withHeader: false
+  separator: ";"
+  quote: "\""
+  escape: "\\"
+  write: "APPEND"
+  partition:
+    attributes:
+      - comet_year
+      - comet_month
+      - comet_day
+  sink:
+    type: ES
+schemas:
+  - name: "Players"
+    pattern: "Players.*.csv"
+    attributes:
+      - name: "PK"
+        type: "string"
+        array: false
+        required: true
+        privacy: "NONE"
+        metricType: "NONE"
+      - name: "firstName"
+        type: "string"
+        array: false
+        required: true
+        privacy: "NONE"
+        metricType: "NONE"
+      - name: "lastName"
+        type: "string"
+        array: false
+        required: true
+        privacy: "NONE"
+        metricType: "NONE"
+      - name: "DOB"
+        type: "date"
+        array: false
+        required: true
+        privacy: "NONE"
+      - name: "YEAR"
+        type: "string"
+        array: false
+        required: false
+        privacy: "NONE"
+      - name: "MONTH"
+        type: "string"
+        array: false
+        required: false
+        privacy: "NONE"
+      - name: "title"
+        type: "string"
+        array: false
+        required: true
+        privacy: "NONE"
+        metricType: "NONE"
+    metadata:
+      mode: "FILE"
+      format: "DSV"
+      encoding: "UTF-8"
+      multiline: false
+      withHeader: false
+      separator: ","
+      quote: "\""
+      escape: "\\"
+      write: "OVERWRITE"
+      partition:
+        attributes:
+          - "YEAR"
+          - "MONTH"
+    merge:
+      key:
+        - "PK"

--- a/src/test/resources/sample/merge/merge-with-new-schema.comet.yml
+++ b/src/test/resources/sample/merge/merge-with-new-schema.comet.yml
@@ -56,7 +56,7 @@ schemas:
       - name: "title"
         type: "string"
         array: false
-        required: true
+        required: false
         privacy: "NONE"
         metricType: "NONE"
     metadata:

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/SchemaHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/SchemaHandlerSpec.scala
@@ -210,7 +210,6 @@ class SchemaHandlerSpec extends TestHelper {
         datasetDomainName = "DOMAIN",
         sourceDatasetPathName = "/sample/Players-merge.csv"
       ) {
-
         cleanMetadata
         deliverSourceDomain()
         loadPending
@@ -239,7 +238,6 @@ class SchemaHandlerSpec extends TestHelper {
         datasetDomainName = "DOMAIN",
         sourceDatasetPathName = "/sample/Players-merge.csv"
       ) {
-
         cleanMetadata
         deliverSourceDomain()
         loadPending
@@ -257,6 +255,45 @@ class SchemaHandlerSpec extends TestHelper {
             .option("encoding", "UTF-8")
             .schema(playerSchema)
             .csv(getResPath("/expected/datasets/accepted/DOMAIN/Players-always-override.csv"))
+            .collect()
+
+        accepted should contain theSameElementsAs expected
+      }
+    }
+    "Ingest updated schema with merge" should "work" in {
+      new SpecTrait(
+        domainOrJobFilename = "simple-merge.comet.yml",
+        sourceDomainOrJobPathname = s"/sample/merge/simple-merge.comet.yml",
+        datasetDomainName = "DOMAIN",
+        sourceDatasetPathName = "/sample/Players.csv"
+      ) {
+        cleanMetadata
+        cleanDatasets
+        loadPending
+      }
+
+      new SpecTrait(
+        domainOrJobFilename = "merge-with-new-schema.comet.yml",
+        sourceDomainOrJobPathname = s"/sample/merge/merge-with-new-schema.comet.yml",
+        datasetDomainName = "DOMAIN",
+        sourceDatasetPathName = "/sample/merge/Players-Entitled.csv"
+      ) {
+        cleanMetadata
+        deliverSourceDomain()
+        loadPending
+
+        val accepted: Array[Row] = sparkSession.read
+          .parquet(cometDatasetsPath + s"/accepted/$datasetDomainName/Players")
+          .collect()
+
+        // Input contains a row with an older timestamp
+        // With MergeOptions.timestamp set, that row should be ignored (the rest should be updated)
+
+        val expected: Array[Row] =
+          sparkSession.read
+            .option("encoding", "UTF-8")
+            .schema("`PK` STRING,`firstName` STRING,`lastName` STRING,`DOB` DATE,`title` STRING,`YEAR` INT,`MONTH` INT")
+            .csv(getResPath("/expected/datasets/accepted/DOMAIN/Players-merged-entitled.csv"))
             .collect()
 
         accepted should contain theSameElementsAs expected

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/SchemaHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/SchemaHandlerSpec.scala
@@ -260,7 +260,7 @@ class SchemaHandlerSpec extends TestHelper {
         accepted should contain theSameElementsAs expected
       }
     }
-    "Ingest updated schema with merge" should "work" in {
+    "Ingest updated schema with merge" should "produce merged results accepted" in {
       new SpecTrait(
         domainOrJobFilename = "simple-merge.comet.yml",
         sourceDomainOrJobPathname = s"/sample/merge/simple-merge.comet.yml",

--- a/src/test/scala/com/ebiznext/comet/schema/handlers/SchemaHandlerSpec.scala
+++ b/src/test/scala/com/ebiznext/comet/schema/handlers/SchemaHandlerSpec.scala
@@ -292,7 +292,9 @@ class SchemaHandlerSpec extends TestHelper {
         val expected: Array[Row] =
           sparkSession.read
             .option("encoding", "UTF-8")
-            .schema("`PK` STRING,`firstName` STRING,`lastName` STRING,`DOB` DATE,`title` STRING,`YEAR` INT,`MONTH` INT")
+            .schema(
+              "`PK` STRING,`firstName` STRING,`lastName` STRING,`DOB` DATE,`title` STRING,`YEAR` INT,`MONTH` INT"
+            )
             .csv(getResPath("/expected/datasets/accepted/DOMAIN/Players-merged-entitled.csv"))
             .collect()
 

--- a/src/test/scala/com/ebiznext/comet/utils/MergeUtilsTest.scala
+++ b/src/test/scala/com/ebiznext/comet/utils/MergeUtilsTest.scala
@@ -1,0 +1,97 @@
+package com.ebiznext.comet.utils
+
+import com.ebiznext.comet.TestHelper
+import com.ebiznext.comet.schema.model.MergeOptions
+import org.apache.spark.sql.types.{StringType, StructType}
+
+import scala.io.Source
+
+class MergeUtilsTest extends TestHelper {
+
+  "merging simple schema" should "succeed" in {
+    val schema = StructType.fromDDL("`root` STRUCT<`field`: BIGINT>,`note` STRING")
+    val result = MergeUtils.computeCompatibleSchema(schema, schema)
+    result shouldBe schema
+  }
+
+  "merging compatible schemas" should "succeed" in {
+    val actualSchema = StructType.fromDDL("`root` STRUCT<`field`: BIGINT>,`note` STRING")
+    val compatibleSchema = StructType.fromDDL(
+      "`root` STRUCT<`field`: BIGINT, `other`: STRING>,`note` STRING, `same` STRUCT<`value`: BIGINT>"
+    )
+    val result = MergeUtils.computeCompatibleSchema(actualSchema, compatibleSchema)
+    result shouldBe actualSchema
+  }
+
+  "merging schemas with missing columns" should "fail" in {
+    val actualSchema = StructType.fromDDL("`root` STRUCT<`field`: BIGINT>,`note` STRING")
+    val invalidSchema = StructType.fromDDL("`root` STRUCT<`other`: BIGINT>,`note` STRING")
+
+    assertThrows[RuntimeException] {
+      MergeUtils.computeCompatibleSchema(actualSchema, invalidSchema)
+    }
+  }
+
+  "merging schemas new columns not nullable" should "fail" in {
+    val actualSchema = StructType.fromDDL("`root` STRUCT<`field`: BIGINT>,`note` STRING")
+    val invalidSchema = StructType
+      .fromDDL("`root` STRUCT<`field`: BIGINT>,`note` STRING")
+      .add("other", StringType, nullable = false)
+
+    assertThrows[RuntimeException] {
+      MergeUtils.computeCompatibleSchema(actualSchema, invalidSchema)
+    }
+  }
+
+  "merging two dataset with duplicated lines" should "deduplicate the lines" in {
+    val schema = StructType.fromDDL("`id` INT,`data` STRUCT<`version`: INT>")
+    val existingDF =
+      sparkSession.read.schema(schema).json(getResPath("/sample/merge/existing.jsonl"))
+    val incomingDF =
+      sparkSession.read.schema(schema).json(getResPath("/sample/merge/incoming.jsonl"))
+
+    val (mergedDF, _) =
+      MergeUtils.computeToMergeAndToDeleteDF(existingDF, incomingDF, MergeOptions(key = List("id")))
+    val actual = mergedDF.toJSON.collect()
+
+    val expected = Source.fromResource("expected/merge/merge-simple.jsonl").getLines().toList
+    actual should contain theSameElementsAs expected
+  }
+
+  "merging two dataset with duplicated lines using timestamp" should "keep the latest line of each" in {
+    val schema = StructType.fromDDL("`id` INT,`data` STRUCT<`version`: INT>")
+    val existingDF =
+      sparkSession.read.schema(schema).json(getResPath("/sample/merge/existing.jsonl"))
+    val incomingDF =
+      sparkSession.read.schema(schema).json(getResPath("/sample/merge/incoming.jsonl"))
+
+    val (mergedDF, _) = MergeUtils.computeToMergeAndToDeleteDF(
+      existingDF,
+      incomingDF,
+      MergeOptions(key = List("id"), timestamp = Some("data.version"))
+    )
+    val actual = mergedDF.toJSON.collect()
+
+    val expected =
+      Source.fromResource("expected/merge/merge-with-timestamp.jsonl").getLines().toList
+    actual should contain theSameElementsAs expected
+  }
+
+  "merging two dataset with duplicated lines and different schemas" should "deduplicate the lines" in {
+    val existingSchema = StructType.fromDDL("`id` INT,`data` STRUCT<`version`: INT>")
+    val incomingSchema =
+      StructType.fromDDL("`id` INT,`data` STRUCT<`version`: INT,`new`: STRING>,`field` STRING")
+    val existingDF =
+      sparkSession.read.schema(existingSchema).json(getResPath("/sample/merge/existing.jsonl"))
+    val incomingDF = sparkSession.read
+      .schema(incomingSchema)
+      .json(getResPath("/sample/merge/incoming-new-schema.jsonl"))
+
+    val (mergedDF, _) =
+      MergeUtils.computeToMergeAndToDeleteDF(existingDF, incomingDF, MergeOptions(key = List("id")))
+    val actual = mergedDF.toJSON.collect()
+
+    val expected = Source.fromResource("expected/merge/merge-new-schema.jsonl").getLines().toList
+    actual should contain theSameElementsAs expected
+  }
+}


### PR DESCRIPTION
**Related Issue: #582**

**PR Type: Feature**

**Status: Ready to review**

**Breaking change? No**


## Description
### Solution
- check if schemas are compatible for merge (new schema contains at least all the columns from existing one, and new columns are nullable)
- produce a schema that is built from the new schema, but compatible with the existing one, in order to load the existing data without errors
- expand the existing data with new columns without any value
- do the union with the incoming data
- remove duplicated lines


### How has this been tested?
New Integration test, new unit tests

### Other changes
- rework common algorithm, split into Util class (out of IngestionJob), to simplify testing
- small refactor in BigQuerySchemaConverters (fix warnings) + bugfix for metadata description


## Contributor checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] I have updated the Release notes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.